### PR TITLE
Tip Router: Fix stack frame `initialize_weight_table`

### DIFF
--- a/core/src/weight_table.rs
+++ b/core/src/weight_table.rs
@@ -50,6 +50,10 @@ impl WeightTable {
         }
     }
 
+    pub fn initialize(&mut self, ncn: Pubkey, ncn_epoch: u64, slot_created: u64, bump: u8) {
+        *self = WeightTable::new(ncn, ncn_epoch, slot_created, bump);
+    }
+
     pub fn seeds(ncn: &Pubkey, ncn_epoch: u64) -> Vec<Vec<u8>> {
         Vec::from_iter(
             [

--- a/integration_tests/tests/tip_router/initialize_weight_table.rs
+++ b/integration_tests/tests/tip_router/initialize_weight_table.rs
@@ -1,23 +1,34 @@
 #[cfg(test)]
 mod tests {
 
-    use crate::fixtures::{test_builder::TestBuilder, TestResult};
+    use crate::fixtures::test_builder::TestBuilder;
 
     #[tokio::test]
-    async fn test_initialize_weight_table_ok() -> TestResult<()> {
+    async fn test_initialize_weight_table_ok() {
         let mut fixture = TestBuilder::new().await;
         let mut tip_router_client = fixture.tip_router_client();
+        let mut restaking_client = fixture.restaking_program_client();
 
-        let test_ncn = fixture.create_initial_test_ncn(1, 1).await?;
+        let test_ncn = fixture.create_initial_test_ncn(1, 1).await.unwrap();
 
-        fixture.warp_slot_incremental(1000).await?;
+        fixture.warp_slot_incremental(1000).await.unwrap();
 
         let slot = fixture.clock().await.slot;
 
         tip_router_client
             .do_initialize_weight_table(test_ncn.ncn_root.ncn_pubkey, slot)
-            .await?;
+            .await
+            .unwrap();
 
-        Ok(())
+        let ncn_epoch = restaking_client.get_ncn_epoch(slot).await.unwrap();
+        let weight_table = tip_router_client
+            .get_weight_table(test_ncn.ncn_root.ncn_pubkey, ncn_epoch)
+            .await
+            .unwrap();
+
+        assert!(weight_table.initialized());
+        assert_eq!(weight_table.ncn(), test_ncn.ncn_root.ncn_pubkey);
+        assert_eq!(weight_table.ncn_epoch(), ncn_epoch);
+        assert_eq!(weight_table.slot_created(), slot);
     }
 }

--- a/program/src/initialize_weight_table.rs
+++ b/program/src/initialize_weight_table.rs
@@ -89,7 +89,7 @@ pub fn process_initialize_weight_table(
     weight_table_data[0] = WeightTable::DISCRIMINATOR;
     let weight_table_account = WeightTable::try_from_slice_unchecked_mut(&mut weight_table_data)?;
 
-    *weight_table_account = WeightTable::new(*ncn.key, ncn_epoch, current_slot, weight_table_bump);
+    weight_table_account.initialize(*ncn.key, ncn_epoch, current_slot, weight_table_bump);
 
     weight_table_account.initalize_weight_table(&unique_mints)?;
 


### PR DESCRIPTION
We currently have issue with `initialize_weight_table`:
```bash
cargo-build-sbf --dump

Error: Function _ZN23jito_tip_router_program23initialize_weight_table31process_initialize_weight_table17h6eb3696e2ef38ac9E Stack offset of 6688 exceeded max offset of 4096 by 2592 bytes, please minimize large stack variables. Estimated function frame size: 6880 bytes. Exceeding the maximum stack offset may cause undefined behavior during execution.
```

By shifting the logic out of the main function, stack size usage in the main function is reduced, which helps to prevent stack overflow errors, i think. 

At least after fixing, i dont see the error and test still passes.