### PR TITLE
AdminSetParameters instruction

### DIFF
--- a/clients/js/jito_tip_router/errors/jitoTipRouter.ts
+++ b/clients/js/jito_tip_router/errors/jitoTipRouter.ts
@@ -154,6 +154,10 @@ export const JITO_TIP_ROUTER_ERROR__BAD_SWITCHBOARD_VALUE = 0x223a; // 8762
 export const JITO_TIP_ROUTER_ERROR__STALE_SWITCHBOARD_FEED = 0x223b; // 8763
 /** NoFeedWeightOrSwitchboardFeed: Weight entry needs either a feed or a no feed weight */
 export const JITO_TIP_ROUTER_ERROR__NO_FEED_WEIGHT_OR_SWITCHBOARD_FEED = 0x223c; // 8764
+/** InvalidEpochsBeforeStall: Invalid epochs before stall */
+export const JITO_TIP_ROUTER_ERROR__INVALID_EPOCHS_BEFORE_STALL = 0x223d; // 8765
+/** InvalidSlotsAfterConsensus: Invalid slots after consensus */
+export const JITO_TIP_ROUTER_ERROR__INVALID_SLOTS_AFTER_CONSENSUS = 0x223e; // 8766
 
 export type JitoTipRouterError =
   | typeof JITO_TIP_ROUTER_ERROR__ARITHMETIC_FLOOR_ERROR
@@ -185,9 +189,11 @@ export type JitoTipRouterError =
   | typeof JITO_TIP_ROUTER_ERROR__INCORRECT_NCN_ADMIN
   | typeof JITO_TIP_ROUTER_ERROR__INCORRECT_WEIGHT_TABLE_ADMIN
   | typeof JITO_TIP_ROUTER_ERROR__INVALID_BASE_FEE_GROUP
+  | typeof JITO_TIP_ROUTER_ERROR__INVALID_EPOCHS_BEFORE_STALL
   | typeof JITO_TIP_ROUTER_ERROR__INVALID_MERKLE_PROOF
   | typeof JITO_TIP_ROUTER_ERROR__INVALID_MINT_FOR_WEIGHT_TABLE
   | typeof JITO_TIP_ROUTER_ERROR__INVALID_NCN_FEE_GROUP
+  | typeof JITO_TIP_ROUTER_ERROR__INVALID_SLOTS_AFTER_CONSENSUS
   | typeof JITO_TIP_ROUTER_ERROR__MINT_ENTRY_NOT_FOUND
   | typeof JITO_TIP_ROUTER_ERROR__MINT_IN_TABLE
   | typeof JITO_TIP_ROUTER_ERROR__MODULO_OVERFLOW
@@ -259,9 +265,11 @@ if (process.env.NODE_ENV !== 'production') {
     [JITO_TIP_ROUTER_ERROR__INCORRECT_NCN_ADMIN]: `Incorrect NCN Admin`,
     [JITO_TIP_ROUTER_ERROR__INCORRECT_WEIGHT_TABLE_ADMIN]: `Incorrect weight table admin`,
     [JITO_TIP_ROUTER_ERROR__INVALID_BASE_FEE_GROUP]: `Not a valid base fee group`,
+    [JITO_TIP_ROUTER_ERROR__INVALID_EPOCHS_BEFORE_STALL]: `Invalid epochs before stall`,
     [JITO_TIP_ROUTER_ERROR__INVALID_MERKLE_PROOF]: `Invalid merkle proof`,
     [JITO_TIP_ROUTER_ERROR__INVALID_MINT_FOR_WEIGHT_TABLE]: `Invalid mint for weight table`,
     [JITO_TIP_ROUTER_ERROR__INVALID_NCN_FEE_GROUP]: `Not a valid NCN fee group`,
+    [JITO_TIP_ROUTER_ERROR__INVALID_SLOTS_AFTER_CONSENSUS]: `Invalid slots after consensus`,
     [JITO_TIP_ROUTER_ERROR__MINT_ENTRY_NOT_FOUND]: `Mint Entry not found`,
     [JITO_TIP_ROUTER_ERROR__MINT_IN_TABLE]: `Mint is already in the table`,
     [JITO_TIP_ROUTER_ERROR__MODULO_OVERFLOW]: `Modulo Overflow`,

--- a/clients/js/jito_tip_router/instructions/adminSetParameters.ts
+++ b/clients/js/jito_tip_router/instructions/adminSetParameters.ts
@@ -8,10 +8,10 @@
 
 import {
   combineCodec,
+  getOptionDecoder,
+  getOptionEncoder,
   getStructDecoder,
   getStructEncoder,
-  getU16Decoder,
-  getU16Encoder,
   getU64Decoder,
   getU64Encoder,
   getU8Decoder,
@@ -26,6 +26,8 @@ import {
   type IInstruction,
   type IInstructionWithAccounts,
   type IInstructionWithData,
+  type Option,
+  type OptionOrNullable,
   type ReadonlyAccount,
   type ReadonlySignerAccount,
   type TransactionSigner,
@@ -34,24 +36,19 @@ import {
 import { JITO_TIP_ROUTER_PROGRAM_ADDRESS } from '../programs';
 import { getAccountMetaFactory, type ResolvedAccount } from '../shared';
 
-export const INITIALIZE_CONFIG_DISCRIMINATOR = 0;
+export const ADMIN_SET_PARAMETERS_DISCRIMINATOR = 31;
 
-export function getInitializeConfigDiscriminatorBytes() {
-  return getU8Encoder().encode(INITIALIZE_CONFIG_DISCRIMINATOR);
+export function getAdminSetParametersDiscriminatorBytes() {
+  return getU8Encoder().encode(ADMIN_SET_PARAMETERS_DISCRIMINATOR);
 }
 
-export type InitializeConfigInstruction<
+export type AdminSetParametersInstruction<
   TProgram extends string = typeof JITO_TIP_ROUTER_PROGRAM_ADDRESS,
   TAccountRestakingConfig extends string | IAccountMeta<string> = string,
   TAccountConfig extends string | IAccountMeta<string> = string,
   TAccountNcn extends string | IAccountMeta<string> = string,
-  TAccountFeeWallet extends string | IAccountMeta<string> = string,
   TAccountNcnAdmin extends string | IAccountMeta<string> = string,
-  TAccountTieBreakerAdmin extends string | IAccountMeta<string> = string,
   TAccountRestakingProgram extends string | IAccountMeta<string> = string,
-  TAccountSystemProgram extends
-    | string
-    | IAccountMeta<string> = '11111111111111111111111111111111',
   TRemainingAccounts extends readonly IAccountMeta<string>[] = [],
 > = IInstruction<TProgram> &
   IInstructionWithData<Uint8Array> &
@@ -64,135 +61,96 @@ export type InitializeConfigInstruction<
         ? WritableAccount<TAccountConfig>
         : TAccountConfig,
       TAccountNcn extends string ? ReadonlyAccount<TAccountNcn> : TAccountNcn,
-      TAccountFeeWallet extends string
-        ? ReadonlyAccount<TAccountFeeWallet>
-        : TAccountFeeWallet,
       TAccountNcnAdmin extends string
         ? ReadonlySignerAccount<TAccountNcnAdmin> &
             IAccountSignerMeta<TAccountNcnAdmin>
         : TAccountNcnAdmin,
-      TAccountTieBreakerAdmin extends string
-        ? ReadonlyAccount<TAccountTieBreakerAdmin>
-        : TAccountTieBreakerAdmin,
       TAccountRestakingProgram extends string
         ? ReadonlyAccount<TAccountRestakingProgram>
         : TAccountRestakingProgram,
-      TAccountSystemProgram extends string
-        ? ReadonlyAccount<TAccountSystemProgram>
-        : TAccountSystemProgram,
       ...TRemainingAccounts,
     ]
   >;
 
-export type InitializeConfigInstructionData = {
+export type AdminSetParametersInstructionData = {
   discriminator: number;
-  blockEngineFeeBps: number;
-  daoFeeBps: number;
-  defaultNcnFeeBps: number;
-  epochsBeforeStall: bigint;
-  validSlotsAfterConsensus: bigint;
+  epochsBeforeStall: Option<bigint>;
+  validSlotsAfterConsensus: Option<bigint>;
 };
 
-export type InitializeConfigInstructionDataArgs = {
-  blockEngineFeeBps: number;
-  daoFeeBps: number;
-  defaultNcnFeeBps: number;
-  epochsBeforeStall: number | bigint;
-  validSlotsAfterConsensus: number | bigint;
+export type AdminSetParametersInstructionDataArgs = {
+  epochsBeforeStall: OptionOrNullable<number | bigint>;
+  validSlotsAfterConsensus: OptionOrNullable<number | bigint>;
 };
 
-export function getInitializeConfigInstructionDataEncoder(): Encoder<InitializeConfigInstructionDataArgs> {
+export function getAdminSetParametersInstructionDataEncoder(): Encoder<AdminSetParametersInstructionDataArgs> {
   return transformEncoder(
     getStructEncoder([
       ['discriminator', getU8Encoder()],
-      ['blockEngineFeeBps', getU16Encoder()],
-      ['daoFeeBps', getU16Encoder()],
-      ['defaultNcnFeeBps', getU16Encoder()],
-      ['epochsBeforeStall', getU64Encoder()],
-      ['validSlotsAfterConsensus', getU64Encoder()],
+      ['epochsBeforeStall', getOptionEncoder(getU64Encoder())],
+      ['validSlotsAfterConsensus', getOptionEncoder(getU64Encoder())],
     ]),
-    (value) => ({ ...value, discriminator: INITIALIZE_CONFIG_DISCRIMINATOR })
+    (value) => ({ ...value, discriminator: ADMIN_SET_PARAMETERS_DISCRIMINATOR })
   );
 }
 
-export function getInitializeConfigInstructionDataDecoder(): Decoder<InitializeConfigInstructionData> {
+export function getAdminSetParametersInstructionDataDecoder(): Decoder<AdminSetParametersInstructionData> {
   return getStructDecoder([
     ['discriminator', getU8Decoder()],
-    ['blockEngineFeeBps', getU16Decoder()],
-    ['daoFeeBps', getU16Decoder()],
-    ['defaultNcnFeeBps', getU16Decoder()],
-    ['epochsBeforeStall', getU64Decoder()],
-    ['validSlotsAfterConsensus', getU64Decoder()],
+    ['epochsBeforeStall', getOptionDecoder(getU64Decoder())],
+    ['validSlotsAfterConsensus', getOptionDecoder(getU64Decoder())],
   ]);
 }
 
-export function getInitializeConfigInstructionDataCodec(): Codec<
-  InitializeConfigInstructionDataArgs,
-  InitializeConfigInstructionData
+export function getAdminSetParametersInstructionDataCodec(): Codec<
+  AdminSetParametersInstructionDataArgs,
+  AdminSetParametersInstructionData
 > {
   return combineCodec(
-    getInitializeConfigInstructionDataEncoder(),
-    getInitializeConfigInstructionDataDecoder()
+    getAdminSetParametersInstructionDataEncoder(),
+    getAdminSetParametersInstructionDataDecoder()
   );
 }
 
-export type InitializeConfigInput<
+export type AdminSetParametersInput<
   TAccountRestakingConfig extends string = string,
   TAccountConfig extends string = string,
   TAccountNcn extends string = string,
-  TAccountFeeWallet extends string = string,
   TAccountNcnAdmin extends string = string,
-  TAccountTieBreakerAdmin extends string = string,
   TAccountRestakingProgram extends string = string,
-  TAccountSystemProgram extends string = string,
 > = {
   restakingConfig: Address<TAccountRestakingConfig>;
   config: Address<TAccountConfig>;
   ncn: Address<TAccountNcn>;
-  feeWallet: Address<TAccountFeeWallet>;
   ncnAdmin: TransactionSigner<TAccountNcnAdmin>;
-  tieBreakerAdmin: Address<TAccountTieBreakerAdmin>;
   restakingProgram: Address<TAccountRestakingProgram>;
-  systemProgram?: Address<TAccountSystemProgram>;
-  blockEngineFeeBps: InitializeConfigInstructionDataArgs['blockEngineFeeBps'];
-  daoFeeBps: InitializeConfigInstructionDataArgs['daoFeeBps'];
-  defaultNcnFeeBps: InitializeConfigInstructionDataArgs['defaultNcnFeeBps'];
-  epochsBeforeStall: InitializeConfigInstructionDataArgs['epochsBeforeStall'];
-  validSlotsAfterConsensus: InitializeConfigInstructionDataArgs['validSlotsAfterConsensus'];
+  epochsBeforeStall: AdminSetParametersInstructionDataArgs['epochsBeforeStall'];
+  validSlotsAfterConsensus: AdminSetParametersInstructionDataArgs['validSlotsAfterConsensus'];
 };
 
-export function getInitializeConfigInstruction<
+export function getAdminSetParametersInstruction<
   TAccountRestakingConfig extends string,
   TAccountConfig extends string,
   TAccountNcn extends string,
-  TAccountFeeWallet extends string,
   TAccountNcnAdmin extends string,
-  TAccountTieBreakerAdmin extends string,
   TAccountRestakingProgram extends string,
-  TAccountSystemProgram extends string,
   TProgramAddress extends Address = typeof JITO_TIP_ROUTER_PROGRAM_ADDRESS,
 >(
-  input: InitializeConfigInput<
+  input: AdminSetParametersInput<
     TAccountRestakingConfig,
     TAccountConfig,
     TAccountNcn,
-    TAccountFeeWallet,
     TAccountNcnAdmin,
-    TAccountTieBreakerAdmin,
-    TAccountRestakingProgram,
-    TAccountSystemProgram
+    TAccountRestakingProgram
   >,
   config?: { programAddress?: TProgramAddress }
-): InitializeConfigInstruction<
+): AdminSetParametersInstruction<
   TProgramAddress,
   TAccountRestakingConfig,
   TAccountConfig,
   TAccountNcn,
-  TAccountFeeWallet,
   TAccountNcnAdmin,
-  TAccountTieBreakerAdmin,
-  TAccountRestakingProgram,
-  TAccountSystemProgram
+  TAccountRestakingProgram
 > {
   // Program address.
   const programAddress =
@@ -206,17 +164,11 @@ export function getInitializeConfigInstruction<
     },
     config: { value: input.config ?? null, isWritable: true },
     ncn: { value: input.ncn ?? null, isWritable: false },
-    feeWallet: { value: input.feeWallet ?? null, isWritable: false },
     ncnAdmin: { value: input.ncnAdmin ?? null, isWritable: false },
-    tieBreakerAdmin: {
-      value: input.tieBreakerAdmin ?? null,
-      isWritable: false,
-    },
     restakingProgram: {
       value: input.restakingProgram ?? null,
       isWritable: false,
     },
-    systemProgram: { value: input.systemProgram ?? null, isWritable: false },
   };
   const accounts = originalAccounts as Record<
     keyof typeof originalAccounts,
@@ -226,44 +178,32 @@ export function getInitializeConfigInstruction<
   // Original args.
   const args = { ...input };
 
-  // Resolve default values.
-  if (!accounts.systemProgram.value) {
-    accounts.systemProgram.value =
-      '11111111111111111111111111111111' as Address<'11111111111111111111111111111111'>;
-  }
-
   const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
   const instruction = {
     accounts: [
       getAccountMeta(accounts.restakingConfig),
       getAccountMeta(accounts.config),
       getAccountMeta(accounts.ncn),
-      getAccountMeta(accounts.feeWallet),
       getAccountMeta(accounts.ncnAdmin),
-      getAccountMeta(accounts.tieBreakerAdmin),
       getAccountMeta(accounts.restakingProgram),
-      getAccountMeta(accounts.systemProgram),
     ],
     programAddress,
-    data: getInitializeConfigInstructionDataEncoder().encode(
-      args as InitializeConfigInstructionDataArgs
+    data: getAdminSetParametersInstructionDataEncoder().encode(
+      args as AdminSetParametersInstructionDataArgs
     ),
-  } as InitializeConfigInstruction<
+  } as AdminSetParametersInstruction<
     TProgramAddress,
     TAccountRestakingConfig,
     TAccountConfig,
     TAccountNcn,
-    TAccountFeeWallet,
     TAccountNcnAdmin,
-    TAccountTieBreakerAdmin,
-    TAccountRestakingProgram,
-    TAccountSystemProgram
+    TAccountRestakingProgram
   >;
 
   return instruction;
 }
 
-export type ParsedInitializeConfigInstruction<
+export type ParsedAdminSetParametersInstruction<
   TProgram extends string = typeof JITO_TIP_ROUTER_PROGRAM_ADDRESS,
   TAccountMetas extends readonly IAccountMeta[] = readonly IAccountMeta[],
 > = {
@@ -272,24 +212,21 @@ export type ParsedInitializeConfigInstruction<
     restakingConfig: TAccountMetas[0];
     config: TAccountMetas[1];
     ncn: TAccountMetas[2];
-    feeWallet: TAccountMetas[3];
-    ncnAdmin: TAccountMetas[4];
-    tieBreakerAdmin: TAccountMetas[5];
-    restakingProgram: TAccountMetas[6];
-    systemProgram: TAccountMetas[7];
+    ncnAdmin: TAccountMetas[3];
+    restakingProgram: TAccountMetas[4];
   };
-  data: InitializeConfigInstructionData;
+  data: AdminSetParametersInstructionData;
 };
 
-export function parseInitializeConfigInstruction<
+export function parseAdminSetParametersInstruction<
   TProgram extends string,
   TAccountMetas extends readonly IAccountMeta[],
 >(
   instruction: IInstruction<TProgram> &
     IInstructionWithAccounts<TAccountMetas> &
     IInstructionWithData<Uint8Array>
-): ParsedInitializeConfigInstruction<TProgram, TAccountMetas> {
-  if (instruction.accounts.length < 8) {
+): ParsedAdminSetParametersInstruction<TProgram, TAccountMetas> {
+  if (instruction.accounts.length < 5) {
     // TODO: Coded error.
     throw new Error('Not enough accounts');
   }
@@ -305,12 +242,11 @@ export function parseInitializeConfigInstruction<
       restakingConfig: getNextAccount(),
       config: getNextAccount(),
       ncn: getNextAccount(),
-      feeWallet: getNextAccount(),
       ncnAdmin: getNextAccount(),
-      tieBreakerAdmin: getNextAccount(),
       restakingProgram: getNextAccount(),
-      systemProgram: getNextAccount(),
     },
-    data: getInitializeConfigInstructionDataDecoder().decode(instruction.data),
+    data: getAdminSetParametersInstructionDataDecoder().decode(
+      instruction.data
+    ),
   };
 }

--- a/clients/js/jito_tip_router/instructions/index.ts
+++ b/clients/js/jito_tip_router/instructions/index.ts
@@ -9,6 +9,7 @@
 export * from './adminRegisterStMint';
 export * from './adminSetConfigFees';
 export * from './adminSetNewAdmin';
+export * from './adminSetParameters';
 export * from './adminSetStMint';
 export * from './adminSetTieBreaker';
 export * from './adminSetWeight';

--- a/clients/js/jito_tip_router/programs/jitoTipRouter.ts
+++ b/clients/js/jito_tip_router/programs/jitoTipRouter.ts
@@ -16,6 +16,7 @@ import {
   type ParsedAdminRegisterStMintInstruction,
   type ParsedAdminSetConfigFeesInstruction,
   type ParsedAdminSetNewAdminInstruction,
+  type ParsedAdminSetParametersInstruction,
   type ParsedAdminSetStMintInstruction,
   type ParsedAdminSetTieBreakerInstruction,
   type ParsedAdminSetWeightInstruction,
@@ -92,6 +93,7 @@ export enum JitoTipRouterInstruction {
   ReallocBaseRewardRouter,
   ReallocWeightTable,
   ReallocVaultRegistry,
+  AdminSetParameters,
 }
 
 export function identifyJitoTipRouterInstruction(
@@ -190,6 +192,9 @@ export function identifyJitoTipRouterInstruction(
   }
   if (containsBytes(data, getU8Encoder().encode(30), 0)) {
     return JitoTipRouterInstruction.ReallocVaultRegistry;
+  }
+  if (containsBytes(data, getU8Encoder().encode(31), 0)) {
+    return JitoTipRouterInstruction.AdminSetParameters;
   }
   throw new Error(
     'The provided instruction could not be identified as a jitoTipRouter instruction.'
@@ -291,4 +296,7 @@ export type ParsedJitoTipRouterInstruction<
     } & ParsedReallocWeightTableInstruction<TProgram>)
   | ({
       instructionType: JitoTipRouterInstruction.ReallocVaultRegistry;
-    } & ParsedReallocVaultRegistryInstruction<TProgram>);
+    } & ParsedReallocVaultRegistryInstruction<TProgram>)
+  | ({
+      instructionType: JitoTipRouterInstruction.AdminSetParameters;
+    } & ParsedAdminSetParametersInstruction<TProgram>);

--- a/clients/rust/jito_tip_router/src/generated/errors/jito_tip_router.rs
+++ b/clients/rust/jito_tip_router/src/generated/errors/jito_tip_router.rs
@@ -219,6 +219,12 @@ pub enum JitoTipRouterError {
     /// 8764 - Weight entry needs either a feed or a no feed weight
     #[error("Weight entry needs either a feed or a no feed weight")]
     NoFeedWeightOrSwitchboardFeed = 0x223C,
+    /// 8765 - Invalid epochs before stall
+    #[error("Invalid epochs before stall")]
+    InvalidEpochsBeforeStall = 0x223D,
+    /// 8766 - Invalid slots after consensus
+    #[error("Invalid slots after consensus")]
+    InvalidSlotsAfterConsensus = 0x223E,
 }
 
 impl solana_program::program_error::PrintProgramError for JitoTipRouterError {

--- a/clients/rust/jito_tip_router/src/generated/instructions/admin_set_parameters.rs
+++ b/clients/rust/jito_tip_router/src/generated/instructions/admin_set_parameters.rs
@@ -7,38 +7,32 @@
 use borsh::{BorshDeserialize, BorshSerialize};
 
 /// Accounts.
-pub struct InitializeConfig {
+pub struct AdminSetParameters {
     pub restaking_config: solana_program::pubkey::Pubkey,
 
     pub config: solana_program::pubkey::Pubkey,
 
     pub ncn: solana_program::pubkey::Pubkey,
 
-    pub fee_wallet: solana_program::pubkey::Pubkey,
-
     pub ncn_admin: solana_program::pubkey::Pubkey,
 
-    pub tie_breaker_admin: solana_program::pubkey::Pubkey,
-
     pub restaking_program: solana_program::pubkey::Pubkey,
-
-    pub system_program: solana_program::pubkey::Pubkey,
 }
 
-impl InitializeConfig {
+impl AdminSetParameters {
     pub fn instruction(
         &self,
-        args: InitializeConfigInstructionArgs,
+        args: AdminSetParametersInstructionArgs,
     ) -> solana_program::instruction::Instruction {
         self.instruction_with_remaining_accounts(args, &[])
     }
     #[allow(clippy::vec_init_then_push)]
     pub fn instruction_with_remaining_accounts(
         &self,
-        args: InitializeConfigInstructionArgs,
+        args: AdminSetParametersInstructionArgs,
         remaining_accounts: &[solana_program::instruction::AccountMeta],
     ) -> solana_program::instruction::Instruction {
-        let mut accounts = Vec::with_capacity(8 + remaining_accounts.len());
+        let mut accounts = Vec::with_capacity(5 + remaining_accounts.len());
         accounts.push(solana_program::instruction::AccountMeta::new_readonly(
             self.restaking_config,
             false,
@@ -51,27 +45,17 @@ impl InitializeConfig {
             self.ncn, false,
         ));
         accounts.push(solana_program::instruction::AccountMeta::new_readonly(
-            self.fee_wallet,
-            false,
-        ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
             self.ncn_admin,
             true,
-        ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
-            self.tie_breaker_admin,
-            false,
         ));
         accounts.push(solana_program::instruction::AccountMeta::new_readonly(
             self.restaking_program,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
-            self.system_program,
-            false,
-        ));
         accounts.extend_from_slice(remaining_accounts);
-        let mut data = InitializeConfigInstructionData::new().try_to_vec().unwrap();
+        let mut data = AdminSetParametersInstructionData::new()
+            .try_to_vec()
+            .unwrap();
         let mut args = args.try_to_vec().unwrap();
         data.append(&mut args);
 
@@ -84,17 +68,17 @@ impl InitializeConfig {
 }
 
 #[derive(BorshDeserialize, BorshSerialize)]
-pub struct InitializeConfigInstructionData {
+pub struct AdminSetParametersInstructionData {
     discriminator: u8,
 }
 
-impl InitializeConfigInstructionData {
+impl AdminSetParametersInstructionData {
     pub fn new() -> Self {
-        Self { discriminator: 0 }
+        Self { discriminator: 31 }
     }
 }
 
-impl Default for InitializeConfigInstructionData {
+impl Default for AdminSetParametersInstructionData {
     fn default() -> Self {
         Self::new()
     }
@@ -102,45 +86,33 @@ impl Default for InitializeConfigInstructionData {
 
 #[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct InitializeConfigInstructionArgs {
-    pub block_engine_fee_bps: u16,
-    pub dao_fee_bps: u16,
-    pub default_ncn_fee_bps: u16,
-    pub epochs_before_stall: u64,
-    pub valid_slots_after_consensus: u64,
+pub struct AdminSetParametersInstructionArgs {
+    pub epochs_before_stall: Option<u64>,
+    pub valid_slots_after_consensus: Option<u64>,
 }
 
-/// Instruction builder for `InitializeConfig`.
+/// Instruction builder for `AdminSetParameters`.
 ///
 /// ### Accounts:
 ///
 ///   0. `[]` restaking_config
 ///   1. `[writable]` config
 ///   2. `[]` ncn
-///   3. `[]` fee_wallet
-///   4. `[signer]` ncn_admin
-///   5. `[]` tie_breaker_admin
-///   6. `[]` restaking_program
-///   7. `[optional]` system_program (default to `11111111111111111111111111111111`)
+///   3. `[signer]` ncn_admin
+///   4. `[]` restaking_program
 #[derive(Clone, Debug, Default)]
-pub struct InitializeConfigBuilder {
+pub struct AdminSetParametersBuilder {
     restaking_config: Option<solana_program::pubkey::Pubkey>,
     config: Option<solana_program::pubkey::Pubkey>,
     ncn: Option<solana_program::pubkey::Pubkey>,
-    fee_wallet: Option<solana_program::pubkey::Pubkey>,
     ncn_admin: Option<solana_program::pubkey::Pubkey>,
-    tie_breaker_admin: Option<solana_program::pubkey::Pubkey>,
     restaking_program: Option<solana_program::pubkey::Pubkey>,
-    system_program: Option<solana_program::pubkey::Pubkey>,
-    block_engine_fee_bps: Option<u16>,
-    dao_fee_bps: Option<u16>,
-    default_ncn_fee_bps: Option<u16>,
     epochs_before_stall: Option<u64>,
     valid_slots_after_consensus: Option<u64>,
     __remaining_accounts: Vec<solana_program::instruction::AccountMeta>,
 }
 
-impl InitializeConfigBuilder {
+impl AdminSetParametersBuilder {
     pub fn new() -> Self {
         Self::default()
     }
@@ -163,21 +135,8 @@ impl InitializeConfigBuilder {
         self
     }
     #[inline(always)]
-    pub fn fee_wallet(&mut self, fee_wallet: solana_program::pubkey::Pubkey) -> &mut Self {
-        self.fee_wallet = Some(fee_wallet);
-        self
-    }
-    #[inline(always)]
     pub fn ncn_admin(&mut self, ncn_admin: solana_program::pubkey::Pubkey) -> &mut Self {
         self.ncn_admin = Some(ncn_admin);
-        self
-    }
-    #[inline(always)]
-    pub fn tie_breaker_admin(
-        &mut self,
-        tie_breaker_admin: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
-        self.tie_breaker_admin = Some(tie_breaker_admin);
         self
     }
     #[inline(always)]
@@ -188,32 +147,13 @@ impl InitializeConfigBuilder {
         self.restaking_program = Some(restaking_program);
         self
     }
-    /// `[optional account, default to '11111111111111111111111111111111']`
-    #[inline(always)]
-    pub fn system_program(&mut self, system_program: solana_program::pubkey::Pubkey) -> &mut Self {
-        self.system_program = Some(system_program);
-        self
-    }
-    #[inline(always)]
-    pub fn block_engine_fee_bps(&mut self, block_engine_fee_bps: u16) -> &mut Self {
-        self.block_engine_fee_bps = Some(block_engine_fee_bps);
-        self
-    }
-    #[inline(always)]
-    pub fn dao_fee_bps(&mut self, dao_fee_bps: u16) -> &mut Self {
-        self.dao_fee_bps = Some(dao_fee_bps);
-        self
-    }
-    #[inline(always)]
-    pub fn default_ncn_fee_bps(&mut self, default_ncn_fee_bps: u16) -> &mut Self {
-        self.default_ncn_fee_bps = Some(default_ncn_fee_bps);
-        self
-    }
+    /// `[optional argument]`
     #[inline(always)]
     pub fn epochs_before_stall(&mut self, epochs_before_stall: u64) -> &mut Self {
         self.epochs_before_stall = Some(epochs_before_stall);
         self
     }
+    /// `[optional argument]`
     #[inline(always)]
     pub fn valid_slots_after_consensus(&mut self, valid_slots_after_consensus: u64) -> &mut Self {
         self.valid_slots_after_consensus = Some(valid_slots_after_consensus);
@@ -239,67 +179,39 @@ impl InitializeConfigBuilder {
     }
     #[allow(clippy::clone_on_copy)]
     pub fn instruction(&self) -> solana_program::instruction::Instruction {
-        let accounts = InitializeConfig {
+        let accounts = AdminSetParameters {
             restaking_config: self.restaking_config.expect("restaking_config is not set"),
             config: self.config.expect("config is not set"),
             ncn: self.ncn.expect("ncn is not set"),
-            fee_wallet: self.fee_wallet.expect("fee_wallet is not set"),
             ncn_admin: self.ncn_admin.expect("ncn_admin is not set"),
-            tie_breaker_admin: self
-                .tie_breaker_admin
-                .expect("tie_breaker_admin is not set"),
             restaking_program: self
                 .restaking_program
                 .expect("restaking_program is not set"),
-            system_program: self
-                .system_program
-                .unwrap_or(solana_program::pubkey!("11111111111111111111111111111111")),
         };
-        let args = InitializeConfigInstructionArgs {
-            block_engine_fee_bps: self
-                .block_engine_fee_bps
-                .clone()
-                .expect("block_engine_fee_bps is not set"),
-            dao_fee_bps: self.dao_fee_bps.clone().expect("dao_fee_bps is not set"),
-            default_ncn_fee_bps: self
-                .default_ncn_fee_bps
-                .clone()
-                .expect("default_ncn_fee_bps is not set"),
-            epochs_before_stall: self
-                .epochs_before_stall
-                .clone()
-                .expect("epochs_before_stall is not set"),
-            valid_slots_after_consensus: self
-                .valid_slots_after_consensus
-                .clone()
-                .expect("valid_slots_after_consensus is not set"),
+        let args = AdminSetParametersInstructionArgs {
+            epochs_before_stall: self.epochs_before_stall.clone(),
+            valid_slots_after_consensus: self.valid_slots_after_consensus.clone(),
         };
 
         accounts.instruction_with_remaining_accounts(args, &self.__remaining_accounts)
     }
 }
 
-/// `initialize_config` CPI accounts.
-pub struct InitializeConfigCpiAccounts<'a, 'b> {
+/// `admin_set_parameters` CPI accounts.
+pub struct AdminSetParametersCpiAccounts<'a, 'b> {
     pub restaking_config: &'b solana_program::account_info::AccountInfo<'a>,
 
     pub config: &'b solana_program::account_info::AccountInfo<'a>,
 
     pub ncn: &'b solana_program::account_info::AccountInfo<'a>,
 
-    pub fee_wallet: &'b solana_program::account_info::AccountInfo<'a>,
-
     pub ncn_admin: &'b solana_program::account_info::AccountInfo<'a>,
 
-    pub tie_breaker_admin: &'b solana_program::account_info::AccountInfo<'a>,
-
     pub restaking_program: &'b solana_program::account_info::AccountInfo<'a>,
-
-    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
 }
 
-/// `initialize_config` CPI instruction.
-pub struct InitializeConfigCpi<'a, 'b> {
+/// `admin_set_parameters` CPI instruction.
+pub struct AdminSetParametersCpi<'a, 'b> {
     /// The program to invoke.
     pub __program: &'b solana_program::account_info::AccountInfo<'a>,
 
@@ -309,35 +221,26 @@ pub struct InitializeConfigCpi<'a, 'b> {
 
     pub ncn: &'b solana_program::account_info::AccountInfo<'a>,
 
-    pub fee_wallet: &'b solana_program::account_info::AccountInfo<'a>,
-
     pub ncn_admin: &'b solana_program::account_info::AccountInfo<'a>,
 
-    pub tie_breaker_admin: &'b solana_program::account_info::AccountInfo<'a>,
-
     pub restaking_program: &'b solana_program::account_info::AccountInfo<'a>,
-
-    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// The arguments for the instruction.
-    pub __args: InitializeConfigInstructionArgs,
+    pub __args: AdminSetParametersInstructionArgs,
 }
 
-impl<'a, 'b> InitializeConfigCpi<'a, 'b> {
+impl<'a, 'b> AdminSetParametersCpi<'a, 'b> {
     pub fn new(
         program: &'b solana_program::account_info::AccountInfo<'a>,
-        accounts: InitializeConfigCpiAccounts<'a, 'b>,
-        args: InitializeConfigInstructionArgs,
+        accounts: AdminSetParametersCpiAccounts<'a, 'b>,
+        args: AdminSetParametersInstructionArgs,
     ) -> Self {
         Self {
             __program: program,
             restaking_config: accounts.restaking_config,
             config: accounts.config,
             ncn: accounts.ncn,
-            fee_wallet: accounts.fee_wallet,
             ncn_admin: accounts.ncn_admin,
-            tie_breaker_admin: accounts.tie_breaker_admin,
             restaking_program: accounts.restaking_program,
-            system_program: accounts.system_program,
             __args: args,
         }
     }
@@ -374,7 +277,7 @@ impl<'a, 'b> InitializeConfigCpi<'a, 'b> {
             bool,
         )],
     ) -> solana_program::entrypoint::ProgramResult {
-        let mut accounts = Vec::with_capacity(8 + remaining_accounts.len());
+        let mut accounts = Vec::with_capacity(5 + remaining_accounts.len());
         accounts.push(solana_program::instruction::AccountMeta::new_readonly(
             *self.restaking_config.key,
             false,
@@ -388,23 +291,11 @@ impl<'a, 'b> InitializeConfigCpi<'a, 'b> {
             false,
         ));
         accounts.push(solana_program::instruction::AccountMeta::new_readonly(
-            *self.fee_wallet.key,
-            false,
-        ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
             *self.ncn_admin.key,
             true,
         ));
         accounts.push(solana_program::instruction::AccountMeta::new_readonly(
-            *self.tie_breaker_admin.key,
-            false,
-        ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
             *self.restaking_program.key,
-            false,
-        ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
-            *self.system_program.key,
             false,
         ));
         remaining_accounts.iter().for_each(|remaining_account| {
@@ -414,7 +305,9 @@ impl<'a, 'b> InitializeConfigCpi<'a, 'b> {
                 is_writable: remaining_account.2,
             })
         });
-        let mut data = InitializeConfigInstructionData::new().try_to_vec().unwrap();
+        let mut data = AdminSetParametersInstructionData::new()
+            .try_to_vec()
+            .unwrap();
         let mut args = self.__args.try_to_vec().unwrap();
         data.append(&mut args);
 
@@ -423,16 +316,13 @@ impl<'a, 'b> InitializeConfigCpi<'a, 'b> {
             accounts,
             data,
         };
-        let mut account_infos = Vec::with_capacity(8 + 1 + remaining_accounts.len());
+        let mut account_infos = Vec::with_capacity(5 + 1 + remaining_accounts.len());
         account_infos.push(self.__program.clone());
         account_infos.push(self.restaking_config.clone());
         account_infos.push(self.config.clone());
         account_infos.push(self.ncn.clone());
-        account_infos.push(self.fee_wallet.clone());
         account_infos.push(self.ncn_admin.clone());
-        account_infos.push(self.tie_breaker_admin.clone());
         account_infos.push(self.restaking_program.clone());
-        account_infos.push(self.system_program.clone());
         remaining_accounts
             .iter()
             .for_each(|remaining_account| account_infos.push(remaining_account.0.clone()));
@@ -445,38 +335,29 @@ impl<'a, 'b> InitializeConfigCpi<'a, 'b> {
     }
 }
 
-/// Instruction builder for `InitializeConfig` via CPI.
+/// Instruction builder for `AdminSetParameters` via CPI.
 ///
 /// ### Accounts:
 ///
 ///   0. `[]` restaking_config
 ///   1. `[writable]` config
 ///   2. `[]` ncn
-///   3. `[]` fee_wallet
-///   4. `[signer]` ncn_admin
-///   5. `[]` tie_breaker_admin
-///   6. `[]` restaking_program
-///   7. `[]` system_program
+///   3. `[signer]` ncn_admin
+///   4. `[]` restaking_program
 #[derive(Clone, Debug)]
-pub struct InitializeConfigCpiBuilder<'a, 'b> {
-    instruction: Box<InitializeConfigCpiBuilderInstruction<'a, 'b>>,
+pub struct AdminSetParametersCpiBuilder<'a, 'b> {
+    instruction: Box<AdminSetParametersCpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a, 'b> InitializeConfigCpiBuilder<'a, 'b> {
+impl<'a, 'b> AdminSetParametersCpiBuilder<'a, 'b> {
     pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
-        let instruction = Box::new(InitializeConfigCpiBuilderInstruction {
+        let instruction = Box::new(AdminSetParametersCpiBuilderInstruction {
             __program: program,
             restaking_config: None,
             config: None,
             ncn: None,
-            fee_wallet: None,
             ncn_admin: None,
-            tie_breaker_admin: None,
             restaking_program: None,
-            system_program: None,
-            block_engine_fee_bps: None,
-            dao_fee_bps: None,
-            default_ncn_fee_bps: None,
             epochs_before_stall: None,
             valid_slots_after_consensus: None,
             __remaining_accounts: Vec::new(),
@@ -505,27 +386,11 @@ impl<'a, 'b> InitializeConfigCpiBuilder<'a, 'b> {
         self
     }
     #[inline(always)]
-    pub fn fee_wallet(
-        &mut self,
-        fee_wallet: &'b solana_program::account_info::AccountInfo<'a>,
-    ) -> &mut Self {
-        self.instruction.fee_wallet = Some(fee_wallet);
-        self
-    }
-    #[inline(always)]
     pub fn ncn_admin(
         &mut self,
         ncn_admin: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.ncn_admin = Some(ncn_admin);
-        self
-    }
-    #[inline(always)]
-    pub fn tie_breaker_admin(
-        &mut self,
-        tie_breaker_admin: &'b solana_program::account_info::AccountInfo<'a>,
-    ) -> &mut Self {
-        self.instruction.tie_breaker_admin = Some(tie_breaker_admin);
         self
     }
     #[inline(always)]
@@ -536,34 +401,13 @@ impl<'a, 'b> InitializeConfigCpiBuilder<'a, 'b> {
         self.instruction.restaking_program = Some(restaking_program);
         self
     }
-    #[inline(always)]
-    pub fn system_program(
-        &mut self,
-        system_program: &'b solana_program::account_info::AccountInfo<'a>,
-    ) -> &mut Self {
-        self.instruction.system_program = Some(system_program);
-        self
-    }
-    #[inline(always)]
-    pub fn block_engine_fee_bps(&mut self, block_engine_fee_bps: u16) -> &mut Self {
-        self.instruction.block_engine_fee_bps = Some(block_engine_fee_bps);
-        self
-    }
-    #[inline(always)]
-    pub fn dao_fee_bps(&mut self, dao_fee_bps: u16) -> &mut Self {
-        self.instruction.dao_fee_bps = Some(dao_fee_bps);
-        self
-    }
-    #[inline(always)]
-    pub fn default_ncn_fee_bps(&mut self, default_ncn_fee_bps: u16) -> &mut Self {
-        self.instruction.default_ncn_fee_bps = Some(default_ncn_fee_bps);
-        self
-    }
+    /// `[optional argument]`
     #[inline(always)]
     pub fn epochs_before_stall(&mut self, epochs_before_stall: u64) -> &mut Self {
         self.instruction.epochs_before_stall = Some(epochs_before_stall);
         self
     }
+    /// `[optional argument]`
     #[inline(always)]
     pub fn valid_slots_after_consensus(&mut self, valid_slots_after_consensus: u64) -> &mut Self {
         self.instruction.valid_slots_after_consensus = Some(valid_slots_after_consensus);
@@ -610,34 +454,11 @@ impl<'a, 'b> InitializeConfigCpiBuilder<'a, 'b> {
         &self,
         signers_seeds: &[&[&[u8]]],
     ) -> solana_program::entrypoint::ProgramResult {
-        let args = InitializeConfigInstructionArgs {
-            block_engine_fee_bps: self
-                .instruction
-                .block_engine_fee_bps
-                .clone()
-                .expect("block_engine_fee_bps is not set"),
-            dao_fee_bps: self
-                .instruction
-                .dao_fee_bps
-                .clone()
-                .expect("dao_fee_bps is not set"),
-            default_ncn_fee_bps: self
-                .instruction
-                .default_ncn_fee_bps
-                .clone()
-                .expect("default_ncn_fee_bps is not set"),
-            epochs_before_stall: self
-                .instruction
-                .epochs_before_stall
-                .clone()
-                .expect("epochs_before_stall is not set"),
-            valid_slots_after_consensus: self
-                .instruction
-                .valid_slots_after_consensus
-                .clone()
-                .expect("valid_slots_after_consensus is not set"),
+        let args = AdminSetParametersInstructionArgs {
+            epochs_before_stall: self.instruction.epochs_before_stall.clone(),
+            valid_slots_after_consensus: self.instruction.valid_slots_after_consensus.clone(),
         };
-        let instruction = InitializeConfigCpi {
+        let instruction = AdminSetParametersCpi {
             __program: self.instruction.__program,
 
             restaking_config: self
@@ -649,24 +470,12 @@ impl<'a, 'b> InitializeConfigCpiBuilder<'a, 'b> {
 
             ncn: self.instruction.ncn.expect("ncn is not set"),
 
-            fee_wallet: self.instruction.fee_wallet.expect("fee_wallet is not set"),
-
             ncn_admin: self.instruction.ncn_admin.expect("ncn_admin is not set"),
-
-            tie_breaker_admin: self
-                .instruction
-                .tie_breaker_admin
-                .expect("tie_breaker_admin is not set"),
 
             restaking_program: self
                 .instruction
                 .restaking_program
                 .expect("restaking_program is not set"),
-
-            system_program: self
-                .instruction
-                .system_program
-                .expect("system_program is not set"),
             __args: args,
         };
         instruction.invoke_signed_with_remaining_accounts(
@@ -677,19 +486,13 @@ impl<'a, 'b> InitializeConfigCpiBuilder<'a, 'b> {
 }
 
 #[derive(Clone, Debug)]
-struct InitializeConfigCpiBuilderInstruction<'a, 'b> {
+struct AdminSetParametersCpiBuilderInstruction<'a, 'b> {
     __program: &'b solana_program::account_info::AccountInfo<'a>,
     restaking_config: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     config: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ncn: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    fee_wallet: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ncn_admin: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    tie_breaker_admin: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     restaking_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    system_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    block_engine_fee_bps: Option<u16>,
-    dao_fee_bps: Option<u16>,
-    default_ncn_fee_bps: Option<u16>,
     epochs_before_stall: Option<u64>,
     valid_slots_after_consensus: Option<u64>,
     /// Additional instruction accounts `(AccountInfo, is_writable, is_signer)`.

--- a/clients/rust/jito_tip_router/src/generated/instructions/mod.rs
+++ b/clients/rust/jito_tip_router/src/generated/instructions/mod.rs
@@ -7,6 +7,7 @@
 pub(crate) mod r#admin_register_st_mint;
 pub(crate) mod r#admin_set_config_fees;
 pub(crate) mod r#admin_set_new_admin;
+pub(crate) mod r#admin_set_parameters;
 pub(crate) mod r#admin_set_st_mint;
 pub(crate) mod r#admin_set_tie_breaker;
 pub(crate) mod r#admin_set_weight;
@@ -38,8 +39,9 @@ pub(crate) mod r#switchboard_set_weight;
 
 pub use self::{
     r#admin_register_st_mint::*, r#admin_set_config_fees::*, r#admin_set_new_admin::*,
-    r#admin_set_st_mint::*, r#admin_set_tie_breaker::*, r#admin_set_weight::*, r#cast_vote::*,
-    r#claim_with_payer::*, r#distribute_base_ncn_reward_route::*, r#distribute_base_rewards::*,
+    r#admin_set_parameters::*, r#admin_set_st_mint::*, r#admin_set_tie_breaker::*,
+    r#admin_set_weight::*, r#cast_vote::*, r#claim_with_payer::*,
+    r#distribute_base_ncn_reward_route::*, r#distribute_base_rewards::*,
     r#distribute_ncn_operator_rewards::*, r#distribute_ncn_vault_rewards::*,
     r#initialize_ballot_box::*, r#initialize_base_reward_router::*, r#initialize_config::*,
     r#initialize_epoch_snapshot::*, r#initialize_ncn_reward_router::*,

--- a/core/src/constants.rs
+++ b/core/src/constants.rs
@@ -1,4 +1,6 @@
-use solana_program::{entrypoint::MAX_PERMITTED_DATA_INCREASE, pubkey, pubkey::Pubkey};
+use solana_program::{
+    clock::DEFAULT_SLOTS_PER_EPOCH, entrypoint::MAX_PERMITTED_DATA_INCREASE, pubkey, pubkey::Pubkey,
+};
 use spl_math::precise_number::PreciseNumber;
 
 use crate::error::TipRouterError;
@@ -7,6 +9,10 @@ pub const MAX_FEE_BPS: u64 = 10_000;
 pub const MAX_ST_MINTS: usize = 64;
 pub const MAX_VAULTS: usize = 64;
 pub const MAX_OPERATORS: usize = 256;
+pub const MIN_EPOCHS_BEFORE_STALL: u64 = 1;
+pub const MAX_EPOCHS_BEFORE_STALL: u64 = 10;
+pub const MIN_SLOTS_AFTER_CONSENSUS: u64 = 1000;
+pub const MAX_SLOTS_AFTER_CONSENSUS: u64 = 10 * DEFAULT_SLOTS_PER_EPOCH;
 const PRECISE_CONSENSUS_NUMERATOR: u128 = 2;
 const PRECISE_CONSENSUS_DENOMINATOR: u128 = 3;
 pub fn precise_consensus() -> Result<PreciseNumber, TipRouterError> {

--- a/core/src/constants.rs
+++ b/core/src/constants.rs
@@ -10,9 +10,9 @@ pub const MAX_ST_MINTS: usize = 64;
 pub const MAX_VAULTS: usize = 64;
 pub const MAX_OPERATORS: usize = 256;
 pub const MIN_EPOCHS_BEFORE_STALL: u64 = 1;
-pub const MAX_EPOCHS_BEFORE_STALL: u64 = 10;
+pub const MAX_EPOCHS_BEFORE_STALL: u64 = 50;
 pub const MIN_SLOTS_AFTER_CONSENSUS: u64 = 1000;
-pub const MAX_SLOTS_AFTER_CONSENSUS: u64 = 10 * DEFAULT_SLOTS_PER_EPOCH;
+pub const MAX_SLOTS_AFTER_CONSENSUS: u64 = 50 * DEFAULT_SLOTS_PER_EPOCH;
 const PRECISE_CONSENSUS_NUMERATOR: u128 = 2;
 const PRECISE_CONSENSUS_DENOMINATOR: u128 = 3;
 pub fn precise_consensus() -> Result<PreciseNumber, TipRouterError> {

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -145,6 +145,12 @@ pub enum TipRouterError {
     StaleSwitchboardFeed,
     #[error("Weight entry needs either a feed or a no feed weight")]
     NoFeedWeightOrSwitchboardFeed,
+
+    #[error("Invalid epochs before stall")]
+    InvalidEpochsBeforeStall,
+
+    #[error("Invalid slots after consensus")]
+    InvalidSlotsAfterConsensus,
 }
 
 impl<T> DecodeError<T> for TipRouterError {

--- a/core/src/instruction.rs
+++ b/core/src/instruction.rs
@@ -17,8 +17,8 @@ pub enum TipRouterInstruction {
     #[account(0, name = "restaking_config")]
     #[account(1, writable, name = "config")]
     #[account(2, name = "ncn")]
-    #[account(3, signer, name = "ncn_admin")]
-    #[account(4, name = "fee_wallet")]
+    #[account(3, name = "fee_wallet")]
+    #[account(4, signer, name = "ncn_admin")]
     #[account(5, name = "tie_breaker_admin")]
     #[account(6, name = "restaking_program")]
     #[account(7, name = "system_program")]
@@ -26,6 +26,8 @@ pub enum TipRouterInstruction {
         block_engine_fee_bps: u16,
         dao_fee_bps: u16,
         default_ncn_fee_bps: u16,
+        epochs_before_stall: u64,
+        valid_slots_after_consensus: u64,
     },
 
     /// Initializes the tracked mints account for an NCN
@@ -438,4 +440,15 @@ pub enum TipRouterInstruction {
     #[account(3, writable, signer, name = "payer")]
     #[account(4, name = "system_program")]
     ReallocVaultRegistry,
+
+    /// Updates NCN parameters
+    #[account(0, name = "restaking_config")]
+    #[account(1, writable, name = "config")]
+    #[account(2, name = "ncn")]
+    #[account(3, signer, name = "ncn_admin")]
+    #[account(4, name = "restaking_program")]
+    AdminSetParameters {
+        epochs_before_stall: Option<u64>,
+        valid_slots_after_consensus: Option<u64>,
+    },
 }

--- a/core/src/ncn_config.rs
+++ b/core/src/ncn_config.rs
@@ -27,7 +27,8 @@ pub struct NcnConfig {
 
     /// Bump seed for the PDA
     pub bump: u8,
-    // /// Reserved space
+
+    /// Reserved space
     reserved: [u8; 127],
 }
 
@@ -43,15 +44,18 @@ impl NcnConfig {
         tie_breaker_admin: Pubkey,
         fee_admin: Pubkey,
         fee_config: &FeeConfig,
+        valid_slots_after_consensus: u64,
+        epochs_before_stall: u64,
+        bump: u8,
     ) -> Self {
         Self {
             ncn,
             tie_breaker_admin,
             fee_admin,
-            valid_slots_after_consensus: PodU64::from(0), // TODO set this
-            epochs_before_stall: PodU64::from(0),         // TODO set this
+            valid_slots_after_consensus: PodU64::from(valid_slots_after_consensus),
+            epochs_before_stall: PodU64::from(epochs_before_stall),
             fee_config: *fee_config,
-            bump: 0,
+            bump,
             reserved: [0; 127],
         }
     }

--- a/idl/jito_tip_router.json
+++ b/idl/jito_tip_router.json
@@ -21,14 +21,14 @@
           "isSigner": false
         },
         {
-          "name": "ncnAdmin",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
           "name": "feeWallet",
           "isMut": false,
           "isSigner": false
+        },
+        {
+          "name": "ncnAdmin",
+          "isMut": false,
+          "isSigner": true
         },
         {
           "name": "tieBreakerAdmin",
@@ -58,6 +58,14 @@
         {
           "name": "defaultNcnFeeBps",
           "type": "u16"
+        },
+        {
+          "name": "epochsBeforeStall",
+          "type": "u64"
+        },
+        {
+          "name": "validSlotsAfterConsensus",
+          "type": "u64"
         }
       ],
       "discriminant": {
@@ -1845,6 +1853,54 @@
         "type": "u8",
         "value": 30
       }
+    },
+    {
+      "name": "AdminSetParameters",
+      "accounts": [
+        {
+          "name": "restakingConfig",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "config",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "ncn",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "ncnAdmin",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "restakingProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "epochsBeforeStall",
+          "type": {
+            "option": "u64"
+          }
+        },
+        {
+          "name": "validSlotsAfterConsensus",
+          "type": {
+            "option": "u64"
+          }
+        }
+      ],
+      "discriminant": {
+        "type": "u8",
+        "value": 31
+      }
     }
   ],
   "accounts": [
@@ -3300,6 +3356,16 @@
       "code": 8764,
       "name": "NoFeedWeightOrSwitchboardFeed",
       "msg": "Weight entry needs either a feed or a no feed weight"
+    },
+    {
+      "code": 8765,
+      "name": "InvalidEpochsBeforeStall",
+      "msg": "Invalid epochs before stall"
+    },
+    {
+      "code": 8766,
+      "name": "InvalidSlotsAfterConsensus",
+      "msg": "Invalid slots after consensus"
     }
   ],
   "metadata": {

--- a/integration_tests/tests/tip_router/admin_set_parameters.rs
+++ b/integration_tests/tests/tip_router/admin_set_parameters.rs
@@ -1,0 +1,56 @@
+#[cfg(test)]
+mod tests {
+    use jito_tip_router_core::error::TipRouterError;
+
+    use crate::fixtures::{
+        test_builder::TestBuilder, tip_router_client::assert_tip_router_error, TestResult,
+    };
+
+    #[tokio::test]
+    async fn test_admin_set_parameters() -> TestResult<()> {
+        let mut fixture = TestBuilder::new().await;
+        let mut tip_router_client = fixture.tip_router_client();
+        let ncn_root = fixture.setup_ncn().await?;
+        tip_router_client
+            .do_initialize_config(ncn_root.ncn_pubkey, &ncn_root.ncn_admin)
+            .await?;
+
+        // Test setting valid parameters
+        tip_router_client
+            .do_set_parameters(
+                Some(5),    // epochs_before_stall
+                Some(1000), // valid_slots_after_consensus
+                &ncn_root,
+            )
+            .await?;
+
+        // Verify parameters were set
+        let config = tip_router_client
+            .get_ncn_config(ncn_root.ncn_pubkey)
+            .await?;
+        assert_eq!(config.epochs_before_stall(), 5);
+        assert_eq!(config.valid_slots_after_consensus(), 1000);
+
+        // Test invalid epochs_before_stall
+        let result = tip_router_client
+            .do_set_parameters(
+                Some(0), // Invalid - too low
+                None,
+                &ncn_root,
+            )
+            .await;
+        assert_tip_router_error(result, TipRouterError::InvalidEpochsBeforeStall);
+
+        // Test invalid valid_slots_after_consensus
+        let result = tip_router_client
+            .do_set_parameters(
+                None,
+                Some(99), // Invalid - too low
+                &ncn_root,
+            )
+            .await;
+        assert_tip_router_error(result, TipRouterError::InvalidSlotsAfterConsensus);
+
+        Ok(())
+    }
+}

--- a/integration_tests/tests/tip_router/initialize_ncn_config.rs
+++ b/integration_tests/tests/tip_router/initialize_ncn_config.rs
@@ -69,12 +69,55 @@ mod tests {
                 &ncn_root.ncn_admin,
                 &ncn_admin_pubkey,
                 &ncn_admin_pubkey,
+                0,
+                0,
                 10_001,
                 0,
                 0,
             )
             .await;
         assert_tip_router_error(transaction_error, TipRouterError::FeeCapExceeded);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_initialize_ncn_config_invalid_parameters() -> TestResult<()> {
+        let mut fixture = TestBuilder::new().await;
+        let mut tip_router_client = fixture.tip_router_client();
+        let ncn_root = fixture.setup_ncn().await?;
+
+        // Test invalid epochs_before_stall
+        let result = tip_router_client
+            .initialize_config(
+                ncn_root.ncn_pubkey,
+                &ncn_root.ncn_admin,
+                &ncn_root.ncn_admin.pubkey(),
+                &ncn_root.ncn_admin.pubkey(),
+                0,
+                0,
+                0,
+                0, // Invalid - too low
+                10001,
+            )
+            .await;
+        assert_tip_router_error(result, TipRouterError::InvalidEpochsBeforeStall);
+
+        // Test invalid valid_slots_after_consensus
+        let result = tip_router_client
+            .initialize_config(
+                ncn_root.ncn_pubkey,
+                &ncn_root.ncn_admin,
+                &ncn_root.ncn_admin.pubkey(),
+                &ncn_root.ncn_admin.pubkey(),
+                0,
+                0,
+                0,
+                5,
+                50, // Invalid - too low
+            )
+            .await;
+        assert_tip_router_error(result, TipRouterError::InvalidSlotsAfterConsensus);
+
         Ok(())
     }
 }

--- a/integration_tests/tests/tip_router/mod.rs
+++ b/integration_tests/tests/tip_router/mod.rs
@@ -1,3 +1,4 @@
+mod admin_set_parameters;
 mod admin_set_st_mint;
 mod admin_update_weight_table;
 mod bpf;

--- a/program/src/admin_set_parameters.rs
+++ b/program/src/admin_set_parameters.rs
@@ -1,0 +1,67 @@
+use jito_bytemuck::{types::PodU64, AccountDeserialize, Discriminator};
+use jito_jsm_core::loader::load_signer;
+use jito_restaking_core::{config::Config, ncn::Ncn};
+use jito_tip_router_core::{
+    constants::{
+        MAX_EPOCHS_BEFORE_STALL, MAX_SLOTS_AFTER_CONSENSUS, MIN_EPOCHS_BEFORE_STALL,
+        MIN_SLOTS_AFTER_CONSENSUS,
+    },
+    error::TipRouterError,
+    ncn_config::NcnConfig,
+};
+use solana_program::{
+    account_info::AccountInfo, entrypoint::ProgramResult, msg, program_error::ProgramError,
+    pubkey::Pubkey,
+};
+
+pub fn process_admin_set_parameters(
+    program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    epochs_before_stall: Option<u64>,
+    valid_slots_after_consensus: Option<u64>,
+) -> ProgramResult {
+    let [restaking_config, config, ncn_account, ncn_admin, restaking_program] = accounts else {
+        return Err(ProgramError::NotEnoughAccountKeys);
+    };
+
+    load_signer(ncn_admin, true)?;
+
+    // Load and verify accounts
+    NcnConfig::load(program_id, ncn_account.key, config, true)?;
+    Ncn::load(restaking_program.key, ncn_account, false)?;
+    Config::load(restaking_program.key, restaking_config, false)?;
+
+    let ncn_data = ncn_account.data.borrow();
+    let ncn = Ncn::try_from_slice_unchecked(&ncn_data)?;
+    if ncn.admin != *ncn_admin.key {
+        return Err(TipRouterError::IncorrectNcnAdmin.into());
+    }
+
+    let mut config_data = config.try_borrow_mut_data()?;
+    if config_data[0] != NcnConfig::DISCRIMINATOR {
+        return Err(ProgramError::InvalidAccountData);
+    }
+    let config = NcnConfig::try_from_slice_unchecked_mut(&mut config_data)?;
+
+    if config.ncn != *ncn_account.key {
+        return Err(TipRouterError::IncorrectNcn.into());
+    }
+
+    if let Some(epochs) = epochs_before_stall {
+        if !(MIN_EPOCHS_BEFORE_STALL..=MAX_EPOCHS_BEFORE_STALL).contains(&epochs) {
+            return Err(TipRouterError::InvalidEpochsBeforeStall.into());
+        }
+        config.epochs_before_stall = PodU64::from(epochs);
+        msg!("Updated epochs_before_stall to {}", epochs);
+    }
+
+    if let Some(slots) = valid_slots_after_consensus {
+        if !(MIN_SLOTS_AFTER_CONSENSUS..=MAX_SLOTS_AFTER_CONSENSUS).contains(&slots) {
+            return Err(TipRouterError::InvalidSlotsAfterConsensus.into());
+        }
+        config.valid_slots_after_consensus = PodU64::from(slots);
+        msg!("Updated valid_slots_after_consensus to {}", slots);
+    }
+
+    Ok(())
+}

--- a/program/src/lib.rs
+++ b/program/src/lib.rs
@@ -1,6 +1,7 @@
 mod admin_register_st_mint;
 mod admin_set_config_fees;
 mod admin_set_new_admin;
+mod admin_set_parameters;
 mod admin_set_st_mint;
 mod admin_set_tie_breaker;
 mod admin_set_weight;
@@ -44,6 +45,7 @@ use solana_security_txt::security_txt;
 use crate::{
     admin_register_st_mint::process_admin_register_st_mint,
     admin_set_config_fees::process_admin_set_config_fees,
+    admin_set_parameters::process_admin_set_parameters,
     admin_set_st_mint::process_admin_set_st_mint,
     admin_set_tie_breaker::process_admin_set_tie_breaker,
     admin_set_weight::process_admin_set_weight, cast_vote::process_cast_vote,
@@ -107,6 +109,8 @@ pub fn process_instruction(
             block_engine_fee_bps,
             dao_fee_bps,
             default_ncn_fee_bps,
+            epochs_before_stall,
+            valid_slots_after_consensus,
         } => {
             msg!("Instruction: InitializeConfig");
             process_initialize_ncn_config(
@@ -115,6 +119,8 @@ pub fn process_instruction(
                 block_engine_fee_bps,
                 dao_fee_bps,
                 default_ncn_fee_bps,
+                epochs_before_stall,
+                valid_slots_after_consensus,
             )
         }
         TipRouterInstruction::InitializeVaultRegistry => {
@@ -332,6 +338,18 @@ pub fn process_instruction(
         TipRouterInstruction::ReallocVaultRegistry => {
             msg!("Instruction: ReallocVaultRegistry");
             process_realloc_vault_registry(program_id, accounts)
+        }
+        TipRouterInstruction::AdminSetParameters {
+            epochs_before_stall,
+            valid_slots_after_consensus,
+        } => {
+            msg!("Instruction: AdminSetParameters");
+            process_admin_set_parameters(
+                program_id,
+                accounts,
+                epochs_before_stall,
+                valid_slots_after_consensus,
+            )
         }
     }
 }


### PR DESCRIPTION
New instruction to set parameters epochs_before_stall, which indicates how long we wait for consensus to be reached before tie breaking, and valid_slots_after_consensus which is how many slots operators can still vote after consensus has been reached.
Also ensures these parameters are set upon NcnConfig initialization.
Creates valid bounds for these parameters -- double check these are reasonable.
