### PR TITLE
BUG: Fixed interruption in route_base_rewards

### DIFF
--- a/clients/js/jito_tip_router/accounts/baseRewardRouter.ts
+++ b/clients/js/jito_tip_router/accounts/baseRewardRouter.ts
@@ -59,6 +59,7 @@ export type BaseRewardRouter = {
   reserved: Array<number>;
   lastNcnGroupIndex: number;
   lastVoteIndex: number;
+  lastRewardsToProcess: bigint;
   baseFeeGroupRewards: Array<BaseRewardRouterRewards>;
   ncnFeeGroupRewards: Array<BaseRewardRouterRewards>;
   ncnFeeGroupRewardRoutes: Array<NcnRewardRoute>;
@@ -76,6 +77,7 @@ export type BaseRewardRouterArgs = {
   reserved: Array<number>;
   lastNcnGroupIndex: number;
   lastVoteIndex: number;
+  lastRewardsToProcess: number | bigint;
   baseFeeGroupRewards: Array<BaseRewardRouterRewardsArgs>;
   ncnFeeGroupRewards: Array<BaseRewardRouterRewardsArgs>;
   ncnFeeGroupRewardRoutes: Array<NcnRewardRouteArgs>;
@@ -94,6 +96,7 @@ export function getBaseRewardRouterEncoder(): Encoder<BaseRewardRouterArgs> {
     ['reserved', getArrayEncoder(getU8Encoder(), { size: 128 })],
     ['lastNcnGroupIndex', getU8Encoder()],
     ['lastVoteIndex', getU16Encoder()],
+    ['lastRewardsToProcess', getU64Encoder()],
     [
       'baseFeeGroupRewards',
       getArrayEncoder(getBaseRewardRouterRewardsEncoder(), { size: 8 }),
@@ -122,6 +125,7 @@ export function getBaseRewardRouterDecoder(): Decoder<BaseRewardRouter> {
     ['reserved', getArrayDecoder(getU8Decoder(), { size: 128 })],
     ['lastNcnGroupIndex', getU8Decoder()],
     ['lastVoteIndex', getU16Decoder()],
+    ['lastRewardsToProcess', getU64Decoder()],
     [
       'baseFeeGroupRewards',
       getArrayDecoder(getBaseRewardRouterRewardsDecoder(), { size: 8 }),

--- a/clients/rust/jito_tip_router/src/generated/accounts/base_reward_router.rs
+++ b/clients/rust/jito_tip_router/src/generated/accounts/base_reward_router.rs
@@ -28,6 +28,7 @@ pub struct BaseRewardRouter {
     pub reserved: [u8; 128],
     pub last_ncn_group_index: u8,
     pub last_vote_index: u16,
+    pub last_rewards_to_process: u64,
     pub base_fee_group_rewards: [BaseRewardRouterRewards; 8],
     pub ncn_fee_group_rewards: [BaseRewardRouterRewards; 8],
     #[cfg_attr(feature = "serde", serde(with = "serde_big_array::BigArray"))]

--- a/core/src/base_reward_router.rs
+++ b/core/src/base_reward_router.rs
@@ -102,7 +102,7 @@ impl BaseRewardRouter {
             [BaseRewardRouterRewards::default(); NcnFeeGroup::FEE_GROUP_COUNT];
         self.ncn_fee_group_reward_routes = [NcnRewardRoute::default(); MAX_OPERATORS];
 
-        self.finish_routing_state();
+        self.reset_routing_state();
     }
 
     pub fn seeds(ncn: &Pubkey, ncn_epoch: u64) -> Vec<Vec<u8>> {
@@ -197,7 +197,7 @@ impl BaseRewardRouter {
         self.last_rewards_to_process = PodU64::from(rewards_to_process);
     }
 
-    pub fn finish_routing_state(&mut self) {
+    pub fn reset_routing_state(&mut self) {
         self.last_ncn_group_index = Self::NO_LAST_NCN_GROUP_INDEX;
         self.last_vote_index = PodU16::from(Self::NO_LAST_VOTE_INDEX);
         self.last_rewards_to_process = PodU64::from(Self::NO_LAST_REWARDS_TO_PROCESS);
@@ -340,7 +340,7 @@ impl BaseRewardRouter {
         }
 
         msg!("Finished routing NCN fee group rewards");
-        self.finish_routing_state();
+        self.reset_routing_state();
 
         Ok(())
     }

--- a/core/src/base_reward_router.rs
+++ b/core/src/base_reward_router.rs
@@ -42,6 +42,8 @@ pub struct BaseRewardRouter {
     last_ncn_group_index: u8,
     /// Last vote index
     last_vote_index: PodU16,
+    /// Last rewards to process
+    last_rewards_to_process: PodU64,
 
     /// Base Fee Group Rewards
     base_fee_group_rewards: [BaseRewardRouterRewards; 8],
@@ -60,6 +62,7 @@ impl BaseRewardRouter {
 
     pub const NO_LAST_NCN_GROUP_INDEX: u8 = u8::MAX;
     pub const NO_LAST_VOTE_INDEX: u16 = u16::MAX;
+    pub const NO_LAST_REWARDS_TO_PROCESS: u64 = u64::MAX;
     pub const MAX_ROUTE_BASE_ITERATIONS: u16 = 30;
 
     pub fn new(ncn: &Pubkey, ncn_epoch: u64, bump: u8, slot_created: u64) -> Self {
@@ -74,6 +77,7 @@ impl BaseRewardRouter {
             reserved: [0; 128],
             last_ncn_group_index: Self::NO_LAST_NCN_GROUP_INDEX,
             last_vote_index: PodU16::from(Self::NO_LAST_VOTE_INDEX),
+            last_rewards_to_process: PodU64::from(Self::NO_LAST_REWARDS_TO_PROCESS),
             base_fee_group_rewards: [BaseRewardRouterRewards::default();
                 NcnFeeGroup::FEE_GROUP_COUNT],
             ncn_fee_group_rewards: [BaseRewardRouterRewards::default();
@@ -166,30 +170,43 @@ impl BaseRewardRouter {
         self.last_vote_index.into()
     }
 
-    pub fn resume_routing_state(&mut self) -> (usize, usize) {
+    pub fn last_rewards_to_process(&self) -> u64 {
+        self.last_rewards_to_process.into()
+    }
+
+    pub fn resume_routing_state(&mut self) -> (usize, usize, u64) {
         if !self.still_routing() {
-            return (0, 0);
+            return (0, 0, 0);
         }
 
         (
             self.last_ncn_group_index() as usize,
             self.last_vote_index() as usize,
+            self.last_rewards_to_process(),
         )
     }
 
-    pub fn save_routing_state(&mut self, ncn_group_index: usize, vote_index: usize) {
+    pub fn save_routing_state(
+        &mut self,
+        ncn_group_index: usize,
+        vote_index: usize,
+        rewards_to_process: u64,
+    ) {
         self.last_ncn_group_index = ncn_group_index as u8;
         self.last_vote_index = PodU16::from(vote_index as u16);
+        self.last_rewards_to_process = PodU64::from(rewards_to_process);
     }
 
     pub fn finish_routing_state(&mut self) {
         self.last_ncn_group_index = Self::NO_LAST_NCN_GROUP_INDEX;
         self.last_vote_index = PodU16::from(Self::NO_LAST_VOTE_INDEX);
+        self.last_rewards_to_process = PodU64::from(Self::NO_LAST_REWARDS_TO_PROCESS);
     }
 
     pub fn still_routing(&self) -> bool {
         self.last_ncn_group_index() != Self::NO_LAST_NCN_GROUP_INDEX
             || self.last_vote_index() != Self::NO_LAST_VOTE_INDEX
+            || self.last_rewards_to_process() != Self::NO_LAST_REWARDS_TO_PROCESS
     }
 
     // ----------------- ROUTE REWARDS ---------------------
@@ -259,12 +276,20 @@ impl BaseRewardRouter {
         let winning_ballot = ballot_box.get_winning_ballot_tally()?;
         let winning_stake_weight = winning_ballot.stake_weights();
 
-        let (starting_group_index, starting_vote_index) = self.resume_routing_state();
+        let (starting_group_index, starting_vote_index, mut starting_rewards_to_process) =
+            self.resume_routing_state();
         let mut iterations: u16 = 0;
 
         for group_index in starting_group_index..NcnFeeGroup::FEE_GROUP_COUNT {
             let group = NcnFeeGroup::all_groups()[group_index];
-            let rewards_to_process = self.ncn_fee_group_rewards(group)?;
+            let rewards_to_process = if starting_rewards_to_process > 0 {
+                starting_rewards_to_process
+            } else {
+                self.ncn_fee_group_rewards(group)?
+            };
+
+            // Reset starting rewards to process
+            starting_rewards_to_process = 0;
 
             if rewards_to_process == 0 {
                 continue;
@@ -286,7 +311,7 @@ impl BaseRewardRouter {
                                 group_index,
                                 vote_index
                             );
-                            self.save_routing_state(group_index, vote_index);
+                            self.save_routing_state(group_index, vote_index, rewards_to_process);
                             return Ok(());
                         }
                     }
@@ -835,6 +860,62 @@ mod tests {
     use solana_program::pubkey::Pubkey;
 
     use super::*;
+    use crate::{ballot_box::Ballot, stake_weight::StakeWeights, utils::assert_tip_router_error};
+
+    const TEST_EPOCH: u64 = 1;
+    const TEST_CURRENT_SLOT: u64 = 100;
+    const TEST_VALID_SLOTS_AFTER_CONSENSUS: u64 = 1000;
+
+    pub fn get_test_ballot_box() -> BallotBox {
+        let ncn = Pubkey::new_unique();
+        let epoch = TEST_EPOCH;
+        let current_slot = TEST_CURRENT_SLOT;
+        let bump = 1;
+
+        BallotBox::new(&ncn, epoch, bump, current_slot)
+    }
+
+    pub fn cast_test_vote(
+        ballot_box: &mut BallotBox,
+        group: NcnFeeGroup,
+        stake_weight: u128,
+        reward_multiplier: u64,
+        merkle_root_prefix: u8,
+    ) {
+        let operator = Pubkey::new_unique();
+        let merkle_root = [merkle_root_prefix; 32];
+        let ballot = Ballot::new(&merkle_root);
+        let stake_weights = StakeWeights::snapshot(group, stake_weight, reward_multiplier).unwrap();
+
+        ballot_box
+            .cast_vote(
+                &operator,
+                &ballot,
+                &stake_weights,
+                TEST_CURRENT_SLOT,
+                TEST_VALID_SLOTS_AFTER_CONSENSUS,
+            )
+            .unwrap();
+    }
+
+    pub fn get_test_operators(ballot_box: &BallotBox) -> Vec<Pubkey> {
+        ballot_box
+            .operator_votes()
+            .iter()
+            .filter(|vote| !vote.is_empty())
+            .map(|votes| *votes.operator())
+            .collect()
+    }
+
+    pub fn get_test_total_stake_weights(ballot_box: &BallotBox) -> StakeWeights {
+        let mut total_stake_weights = StakeWeights::default();
+        for vote in ballot_box.operator_votes() {
+            total_stake_weights.increment(vote.stake_weights()).unwrap();
+        }
+
+        total_stake_weights
+    }
+
     #[test]
     fn test_len() {
         use std::mem::size_of;
@@ -849,6 +930,7 @@ mod tests {
             + 128 // reserved
             + 1 // last_ncn_group_index
             + size_of::<PodU16>() // last_vote_index
+            + size_of::<PodU64>() // last_rewards_to_process
             + size_of::<BaseRewardRouterRewards>() * NcnFeeGroup::FEE_GROUP_COUNT // base_fee_group_rewards
             + size_of::<BaseRewardRouterRewards>() * NcnFeeGroup::FEE_GROUP_COUNT // ncn_fee_group_rewards
             + size_of::<NcnRewardRoute>() * MAX_OPERATORS; // ncn_fee_group_reward_routes
@@ -969,6 +1051,393 @@ mod tests {
 
         for group in NcnFeeGroup::all_groups().iter() {
             assert_eq!(router.ncn_fee_group_rewards(*group).unwrap(), 100);
+        }
+    }
+
+    #[test]
+    fn test_rounding() {
+        const INCOMING_REWARDS: u64 = 101;
+
+        let mut router = BaseRewardRouter::new(
+            &Pubkey::new_unique(), // ncn
+            1,                     // ncn_epoch
+            1,                     // bump
+            100,                   // slot_created
+        );
+
+        // Fees - all base groups and ncn groups
+        let fees = Fees::new(99, 1, 1).unwrap();
+
+        // Route incoming rewards
+        router.route_incoming_rewards(0, INCOMING_REWARDS).unwrap();
+
+        assert_eq!(router.total_rewards(), INCOMING_REWARDS);
+        assert_eq!(router.reward_pool(), INCOMING_REWARDS);
+
+        router.route_reward_pool(&fees).unwrap();
+
+        assert_eq!(router.total_rewards(), INCOMING_REWARDS);
+        assert_eq!(router.reward_pool(), 0);
+
+        assert_eq!(
+            router
+                .base_fee_group_reward(BaseFeeGroup::default())
+                .unwrap(),
+            100
+        );
+        assert_eq!(
+            router
+                .ncn_fee_group_rewards(NcnFeeGroup::default())
+                .unwrap(),
+            1
+        );
+    }
+
+    #[test]
+    fn test_route_to_operators_consensus_not_reached() {
+        const INCOMING_REWARDS: u64 = 1600;
+
+        let mut router = BaseRewardRouter::new(
+            &Pubkey::new_unique(), // ncn
+            1,                     // ncn_epoch
+            1,                     // bump
+            100,                   // slot_created
+        );
+
+        // Fees
+        let mut fees = Fees::new(100, 100, 1).unwrap();
+
+        for group in BaseFeeGroup::all_groups().iter() {
+            fees.set_base_fee_bps(*group, 100).unwrap();
+        }
+
+        for group in NcnFeeGroup::all_groups().iter() {
+            fees.set_ncn_fee_bps(*group, 100).unwrap();
+        }
+
+        // Route incoming rewards
+        router.route_incoming_rewards(0, INCOMING_REWARDS).unwrap();
+
+        assert_eq!(router.total_rewards(), INCOMING_REWARDS);
+        assert_eq!(router.reward_pool(), INCOMING_REWARDS);
+
+        router.route_reward_pool(&fees).unwrap();
+
+        assert_eq!(router.total_rewards(), INCOMING_REWARDS);
+        assert_eq!(router.reward_pool(), 0);
+
+        for group in BaseFeeGroup::all_groups().iter() {
+            assert_eq!(router.base_fee_group_reward(*group).unwrap(), 100);
+        }
+
+        for group in NcnFeeGroup::all_groups().iter() {
+            assert_eq!(router.ncn_fee_group_rewards(*group).unwrap(), 100);
+        }
+
+        let (ballot_box, _) = {
+            let mut ballot_box = get_test_ballot_box();
+
+            for group in NcnFeeGroup::all_groups().iter() {
+                cast_test_vote(&mut ballot_box, *group, 200, 1, 1);
+            }
+
+            (ballot_box, get_test_operators(&ballot_box))
+        };
+
+        let result = router.route_ncn_fee_group_rewards(&ballot_box, 100);
+
+        assert_tip_router_error(result, TipRouterError::ConsensusNotReached);
+    }
+
+    #[test]
+    fn test_route_to_operators() {
+        const INCOMING_REWARDS: u64 = 1600;
+
+        let mut router = BaseRewardRouter::new(
+            &Pubkey::new_unique(), // ncn
+            1,                     // ncn_epoch
+            1,                     // bump
+            100,                   // slot_created
+        );
+
+        // Fees
+        let mut fees = Fees::new(100, 100, 1).unwrap();
+
+        for group in BaseFeeGroup::all_groups().iter() {
+            fees.set_base_fee_bps(*group, 100).unwrap();
+        }
+
+        for group in NcnFeeGroup::all_groups().iter() {
+            fees.set_ncn_fee_bps(*group, 100).unwrap();
+        }
+
+        // Route incoming rewards
+        router.route_incoming_rewards(0, INCOMING_REWARDS).unwrap();
+
+        assert_eq!(router.total_rewards(), INCOMING_REWARDS);
+        assert_eq!(router.reward_pool(), INCOMING_REWARDS);
+
+        router.route_reward_pool(&fees).unwrap();
+
+        assert_eq!(router.total_rewards(), INCOMING_REWARDS);
+        assert_eq!(router.reward_pool(), 0);
+
+        for group in BaseFeeGroup::all_groups().iter() {
+            assert_eq!(router.base_fee_group_reward(*group).unwrap(), 100);
+        }
+
+        for group in NcnFeeGroup::all_groups().iter() {
+            assert_eq!(router.ncn_fee_group_rewards(*group).unwrap(), 100);
+        }
+
+        let (ballot_box, operators) = {
+            let mut ballot_box = get_test_ballot_box();
+
+            for group in NcnFeeGroup::all_groups().iter() {
+                cast_test_vote(&mut ballot_box, *group, 200, 1, 1);
+            }
+
+            let total_stake_weights = get_test_total_stake_weights(&ballot_box);
+
+            ballot_box
+                .tally_votes(total_stake_weights.stake_weight(), TEST_CURRENT_SLOT)
+                .unwrap();
+
+            (ballot_box, get_test_operators(&ballot_box))
+        };
+
+        router
+            .route_ncn_fee_group_rewards(&ballot_box, 100)
+            .unwrap();
+
+        for operator in operators.iter() {
+            let route = router.ncn_fee_group_reward_route(operator).unwrap();
+
+            let mut rewards = 0;
+            for group in NcnFeeGroup::all_groups().iter() {
+                rewards += route.rewards(*group).unwrap();
+            }
+
+            assert_eq!(rewards, 100);
+        }
+    }
+
+    #[test]
+    fn test_route_to_operators_with_wrong_vote() {
+        const INCOMING_REWARDS: u64 = 1600;
+
+        let mut router = BaseRewardRouter::new(
+            &Pubkey::new_unique(), // ncn
+            1,                     // ncn_epoch
+            1,                     // bump
+            100,                   // slot_created
+        );
+
+        // Fees
+        let mut fees = Fees::new(100, 100, 1).unwrap();
+
+        for group in BaseFeeGroup::all_groups().iter() {
+            fees.set_base_fee_bps(*group, 100).unwrap();
+        }
+
+        for group in NcnFeeGroup::all_groups().iter() {
+            fees.set_ncn_fee_bps(*group, 100).unwrap();
+        }
+
+        // Route incoming rewards
+        router.route_incoming_rewards(0, INCOMING_REWARDS).unwrap();
+
+        assert_eq!(router.total_rewards(), INCOMING_REWARDS);
+        assert_eq!(router.reward_pool(), INCOMING_REWARDS);
+
+        router.route_reward_pool(&fees).unwrap();
+
+        assert_eq!(router.total_rewards(), INCOMING_REWARDS);
+        assert_eq!(router.reward_pool(), 0);
+
+        for group in BaseFeeGroup::all_groups().iter() {
+            assert_eq!(router.base_fee_group_reward(*group).unwrap(), 100);
+        }
+
+        for group in NcnFeeGroup::all_groups().iter() {
+            assert_eq!(router.ncn_fee_group_rewards(*group).unwrap(), 100);
+        }
+
+        let (ballot_box, _) = {
+            let mut ballot_box = get_test_ballot_box();
+
+            for group in NcnFeeGroup::all_groups().iter() {
+                if group == &NcnFeeGroup::default() {
+                    cast_test_vote(&mut ballot_box, *group, 200, 1, 1);
+                } else {
+                    cast_test_vote(&mut ballot_box, *group, 200, 1, 2);
+                }
+            }
+
+            let total_stake_weights = get_test_total_stake_weights(&ballot_box);
+
+            ballot_box
+                .tally_votes(total_stake_weights.stake_weight(), TEST_CURRENT_SLOT)
+                .unwrap();
+
+            (ballot_box, get_test_operators(&ballot_box))
+        };
+
+        router
+            .route_ncn_fee_group_rewards(&ballot_box, 100)
+            .unwrap();
+
+        // Operator 1, did not vote with consensus, so it should not have a route
+        let route_count = router
+            .ncn_fee_group_reward_routes()
+            .iter()
+            .filter(|route| !route.is_empty())
+            .count();
+
+        assert_eq!(route_count, 7);
+    }
+
+    #[test]
+    fn test_route_to_max_operators() {
+        const INCOMING_REWARDS: u64 = 256_000;
+
+        let mut router = BaseRewardRouter::new(
+            &Pubkey::new_unique(), // ncn
+            1,                     // ncn_epoch
+            1,                     // bump
+            100,                   // slot_created
+        );
+
+        // Fees
+        let fees = Fees::new(0, 100, 1).unwrap();
+
+        // Route incoming rewards
+        router.route_incoming_rewards(0, INCOMING_REWARDS).unwrap();
+
+        assert_eq!(router.total_rewards(), INCOMING_REWARDS);
+        assert_eq!(router.reward_pool(), INCOMING_REWARDS);
+
+        router.route_reward_pool(&fees).unwrap();
+
+        assert_eq!(router.total_rewards(), INCOMING_REWARDS);
+        assert_eq!(router.reward_pool(), 0);
+
+        for group in BaseFeeGroup::all_groups().iter() {
+            assert_eq!(router.base_fee_group_reward(*group).unwrap(), 0);
+        }
+
+        assert_eq!(
+            router
+                .ncn_fee_group_rewards(NcnFeeGroup::default())
+                .unwrap(),
+            INCOMING_REWARDS
+        );
+
+        let (ballot_box, operators) = {
+            let mut ballot_box = get_test_ballot_box();
+
+            for _ in 0..256 {
+                cast_test_vote(&mut ballot_box, NcnFeeGroup::default(), 200, 1, 1);
+            }
+
+            let total_stake_weights = get_test_total_stake_weights(&ballot_box);
+
+            ballot_box
+                .tally_votes(total_stake_weights.stake_weight(), TEST_CURRENT_SLOT)
+                .unwrap();
+
+            (ballot_box, get_test_operators(&ballot_box))
+        };
+
+        router
+            .route_ncn_fee_group_rewards(&ballot_box, 1000)
+            .unwrap();
+
+        assert!(!router.still_routing());
+
+        for operator in operators.iter() {
+            let route = router.ncn_fee_group_reward_route(operator).unwrap();
+
+            let mut rewards = 0;
+            for group in NcnFeeGroup::all_groups().iter() {
+                rewards += route.rewards(*group).unwrap();
+            }
+
+            assert_eq!(rewards, 1000);
+        }
+    }
+
+    #[test]
+    fn test_route_with_interruption() {
+        const INCOMING_REWARDS: u64 = 256_000;
+
+        let mut router = BaseRewardRouter::new(
+            &Pubkey::new_unique(), // ncn
+            1,                     // ncn_epoch
+            1,                     // bump
+            100,                   // slot_created
+        );
+
+        // Fees
+        let fees = Fees::new(0, 100, 1).unwrap();
+
+        // Route incoming rewards
+        router.route_incoming_rewards(0, INCOMING_REWARDS).unwrap();
+
+        assert_eq!(router.total_rewards(), INCOMING_REWARDS);
+        assert_eq!(router.reward_pool(), INCOMING_REWARDS);
+
+        router.route_reward_pool(&fees).unwrap();
+
+        assert_eq!(router.total_rewards(), INCOMING_REWARDS);
+        assert_eq!(router.reward_pool(), 0);
+
+        for group in BaseFeeGroup::all_groups().iter() {
+            assert_eq!(router.base_fee_group_reward(*group).unwrap(), 0);
+        }
+
+        assert_eq!(
+            router
+                .ncn_fee_group_rewards(NcnFeeGroup::default())
+                .unwrap(),
+            INCOMING_REWARDS
+        );
+
+        let (ballot_box, operators) = {
+            let mut ballot_box = get_test_ballot_box();
+
+            for _ in 0..256 {
+                cast_test_vote(&mut ballot_box, NcnFeeGroup::default(), 200, 1, 1);
+            }
+
+            let total_stake_weights = get_test_total_stake_weights(&ballot_box);
+
+            ballot_box
+                .tally_votes(total_stake_weights.stake_weight(), TEST_CURRENT_SLOT)
+                .unwrap();
+
+            (ballot_box, get_test_operators(&ballot_box))
+        };
+
+        router.route_ncn_fee_group_rewards(&ballot_box, 5).unwrap();
+
+        assert!(router.still_routing());
+
+        router
+            .route_ncn_fee_group_rewards(&ballot_box, 1000)
+            .unwrap();
+
+        assert!(!router.still_routing());
+
+        for operator in operators.iter() {
+            let route = router.ncn_fee_group_reward_route(operator).unwrap();
+
+            let mut rewards = 0;
+            for group in NcnFeeGroup::all_groups().iter() {
+                rewards += route.rewards(*group).unwrap();
+            }
+
+            assert_eq!(rewards, 1000);
         }
     }
 }

--- a/core/src/utils.rs
+++ b/core/src/utils.rs
@@ -1,6 +1,6 @@
 use solana_program::program_error::ProgramError;
 
-use crate::constants::MAX_REALLOC_BYTES;
+use crate::{constants::MAX_REALLOC_BYTES, error::TipRouterError};
 
 /// Calculate new size for reallocation, capped at target size
 /// Returns the minimum of (current_size + MAX_REALLOC_BYTES) and target_size
@@ -9,4 +9,14 @@ pub fn get_new_size(current_size: usize, target_size: usize) -> Result<usize, Pr
         .checked_add(MAX_REALLOC_BYTES as usize)
         .ok_or(ProgramError::ArithmeticOverflow)?
         .min(target_size))
+}
+
+#[inline(always)]
+#[track_caller]
+pub fn assert_tip_router_error<T>(
+    test_error: Result<T, TipRouterError>,
+    tip_router_error: TipRouterError,
+) {
+    assert!(test_error.is_err());
+    assert_eq!(test_error.err().unwrap(), tip_router_error);
 }

--- a/idl/jito_tip_router.json
+++ b/idl/jito_tip_router.json
@@ -1978,6 +1978,12 @@
             }
           },
           {
+            "name": "lastRewardsToProcess",
+            "type": {
+              "defined": "PodU64"
+            }
+          },
+          {
             "name": "baseFeeGroupRewards",
             "type": {
               "array": [


### PR DESCRIPTION
There was an issue in the BaseRewardRouter where if max_iterations was hit, it would not carry over the `rewards_to_process` meaning when the instruction ran again, it would go off of the new pre-routed value.

Say we had 10 operators and 5 max_iterations with 10_000 rewards to split:

```
op0: 1000
op1: 1000
op2: 1000
op3: 1000
- Iterations Hit -
op4: 600
op5: 600
op6: 600
op7: 600
op8: 600
op9: 600
```

The fix was to save the `last_rewards_to_process` like we do in route_ncn_rewards;