### PR TITLE
AUDIT: H-01 Stakes might be credited twice during snapshotting

### DIFF
--- a/core/src/epoch_snapshot.rs
+++ b/core/src/epoch_snapshot.rs
@@ -498,9 +498,10 @@ impl OperatorSnapshot {
         weight_table: &WeightTable,
         st_mint: &Pubkey,
     ) -> Result<u128, ProgramError> {
-        let total_security = vault_operator_delegation
-            .delegation_state
-            .total_security()?;
+        // With using `delegation_state.total_security()` there is a thin margin
+        // where stake can be double counted. For this reason, we'll use the
+        // delegation_state.staked_amount() instead.
+        let total_security = vault_operator_delegation.delegation_state.staked_amount();
 
         let precise_total_security = PreciseNumber::new(total_security as u128)
             .ok_or(TipRouterError::NewPreciseNumberError)?;


### PR DESCRIPTION
Moved from `total_security()` to `staked_amount()`