### PR TITLE
AUDIT: Inconsistent NCN Vault Count

### DIFF
--- a/cli/src/instructions.rs
+++ b/cli/src/instructions.rs
@@ -278,23 +278,15 @@ pub async fn register_vault(handler: &CliHandler, vault: &Pubkey) -> Result<()> 
     let (vault_registry, _, _) =
         VaultRegistry::find_program_address(&handler.tip_router_program_id, &ncn);
 
-    let (restaking_config, _, _) =
-        RestakingConfig::find_program_address(&handler.restaking_program_id);
-
     let (ncn_vault_ticket, _, _) =
         NcnVaultTicket::find_program_address(&handler.restaking_program_id, &ncn, &vault);
-
-    let (vault_ncn_ticket, _, _) =
-        VaultNcnTicket::find_program_address(&handler.vault_program_id, &vault, &ncn);
 
     let register_vault_ix = RegisterVaultBuilder::new()
         .vault_registry(vault_registry)
         .vault(vault)
         .ncn(ncn)
         .ncn_vault_ticket(ncn_vault_ticket)
-        .restaking_config(restaking_config)
         .restaking_program_id(handler.restaking_program_id)
-        .vault_ncn_ticket(vault_ncn_ticket)
         .vault_program_id(handler.vault_program_id)
         .vault_registry(vault_registry)
         .instruction();

--- a/clients/js/jito_tip_router/instructions/registerVault.ts
+++ b/clients/js/jito_tip_router/instructions/registerVault.ts
@@ -35,11 +35,9 @@ export function getRegisterVaultDiscriminatorBytes() {
 
 export type RegisterVaultInstruction<
   TProgram extends string = typeof JITO_TIP_ROUTER_PROGRAM_ADDRESS,
-  TAccountRestakingConfig extends string | IAccountMeta<string> = string,
   TAccountVaultRegistry extends string | IAccountMeta<string> = string,
   TAccountNcn extends string | IAccountMeta<string> = string,
   TAccountVault extends string | IAccountMeta<string> = string,
-  TAccountVaultNcnTicket extends string | IAccountMeta<string> = string,
   TAccountNcnVaultTicket extends string | IAccountMeta<string> = string,
   TAccountRestakingProgramId extends string | IAccountMeta<string> = string,
   TAccountVaultProgramId extends string | IAccountMeta<string> = string,
@@ -48,9 +46,6 @@ export type RegisterVaultInstruction<
   IInstructionWithData<Uint8Array> &
   IInstructionWithAccounts<
     [
-      TAccountRestakingConfig extends string
-        ? ReadonlyAccount<TAccountRestakingConfig>
-        : TAccountRestakingConfig,
       TAccountVaultRegistry extends string
         ? WritableAccount<TAccountVaultRegistry>
         : TAccountVaultRegistry,
@@ -58,9 +53,6 @@ export type RegisterVaultInstruction<
       TAccountVault extends string
         ? ReadonlyAccount<TAccountVault>
         : TAccountVault,
-      TAccountVaultNcnTicket extends string
-        ? ReadonlyAccount<TAccountVaultNcnTicket>
-        : TAccountVaultNcnTicket,
       TAccountNcnVaultTicket extends string
         ? ReadonlyAccount<TAccountNcnVaultTicket>
         : TAccountNcnVaultTicket,
@@ -100,42 +92,34 @@ export function getRegisterVaultInstructionDataCodec(): Codec<
 }
 
 export type RegisterVaultInput<
-  TAccountRestakingConfig extends string = string,
   TAccountVaultRegistry extends string = string,
   TAccountNcn extends string = string,
   TAccountVault extends string = string,
-  TAccountVaultNcnTicket extends string = string,
   TAccountNcnVaultTicket extends string = string,
   TAccountRestakingProgramId extends string = string,
   TAccountVaultProgramId extends string = string,
 > = {
-  restakingConfig: Address<TAccountRestakingConfig>;
   vaultRegistry: Address<TAccountVaultRegistry>;
   ncn: Address<TAccountNcn>;
   vault: Address<TAccountVault>;
-  vaultNcnTicket: Address<TAccountVaultNcnTicket>;
   ncnVaultTicket: Address<TAccountNcnVaultTicket>;
   restakingProgramId: Address<TAccountRestakingProgramId>;
   vaultProgramId: Address<TAccountVaultProgramId>;
 };
 
 export function getRegisterVaultInstruction<
-  TAccountRestakingConfig extends string,
   TAccountVaultRegistry extends string,
   TAccountNcn extends string,
   TAccountVault extends string,
-  TAccountVaultNcnTicket extends string,
   TAccountNcnVaultTicket extends string,
   TAccountRestakingProgramId extends string,
   TAccountVaultProgramId extends string,
   TProgramAddress extends Address = typeof JITO_TIP_ROUTER_PROGRAM_ADDRESS,
 >(
   input: RegisterVaultInput<
-    TAccountRestakingConfig,
     TAccountVaultRegistry,
     TAccountNcn,
     TAccountVault,
-    TAccountVaultNcnTicket,
     TAccountNcnVaultTicket,
     TAccountRestakingProgramId,
     TAccountVaultProgramId
@@ -143,11 +127,9 @@ export function getRegisterVaultInstruction<
   config?: { programAddress?: TProgramAddress }
 ): RegisterVaultInstruction<
   TProgramAddress,
-  TAccountRestakingConfig,
   TAccountVaultRegistry,
   TAccountNcn,
   TAccountVault,
-  TAccountVaultNcnTicket,
   TAccountNcnVaultTicket,
   TAccountRestakingProgramId,
   TAccountVaultProgramId
@@ -158,14 +140,9 @@ export function getRegisterVaultInstruction<
 
   // Original accounts.
   const originalAccounts = {
-    restakingConfig: {
-      value: input.restakingConfig ?? null,
-      isWritable: false,
-    },
     vaultRegistry: { value: input.vaultRegistry ?? null, isWritable: true },
     ncn: { value: input.ncn ?? null, isWritable: false },
     vault: { value: input.vault ?? null, isWritable: false },
-    vaultNcnTicket: { value: input.vaultNcnTicket ?? null, isWritable: false },
     ncnVaultTicket: { value: input.ncnVaultTicket ?? null, isWritable: false },
     restakingProgramId: {
       value: input.restakingProgramId ?? null,
@@ -181,11 +158,9 @@ export function getRegisterVaultInstruction<
   const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
   const instruction = {
     accounts: [
-      getAccountMeta(accounts.restakingConfig),
       getAccountMeta(accounts.vaultRegistry),
       getAccountMeta(accounts.ncn),
       getAccountMeta(accounts.vault),
-      getAccountMeta(accounts.vaultNcnTicket),
       getAccountMeta(accounts.ncnVaultTicket),
       getAccountMeta(accounts.restakingProgramId),
       getAccountMeta(accounts.vaultProgramId),
@@ -194,11 +169,9 @@ export function getRegisterVaultInstruction<
     data: getRegisterVaultInstructionDataEncoder().encode({}),
   } as RegisterVaultInstruction<
     TProgramAddress,
-    TAccountRestakingConfig,
     TAccountVaultRegistry,
     TAccountNcn,
     TAccountVault,
-    TAccountVaultNcnTicket,
     TAccountNcnVaultTicket,
     TAccountRestakingProgramId,
     TAccountVaultProgramId
@@ -213,14 +186,12 @@ export type ParsedRegisterVaultInstruction<
 > = {
   programAddress: Address<TProgram>;
   accounts: {
-    restakingConfig: TAccountMetas[0];
-    vaultRegistry: TAccountMetas[1];
-    ncn: TAccountMetas[2];
-    vault: TAccountMetas[3];
-    vaultNcnTicket: TAccountMetas[4];
-    ncnVaultTicket: TAccountMetas[5];
-    restakingProgramId: TAccountMetas[6];
-    vaultProgramId: TAccountMetas[7];
+    vaultRegistry: TAccountMetas[0];
+    ncn: TAccountMetas[1];
+    vault: TAccountMetas[2];
+    ncnVaultTicket: TAccountMetas[3];
+    restakingProgramId: TAccountMetas[4];
+    vaultProgramId: TAccountMetas[5];
   };
   data: RegisterVaultInstructionData;
 };
@@ -233,7 +204,7 @@ export function parseRegisterVaultInstruction<
     IInstructionWithAccounts<TAccountMetas> &
     IInstructionWithData<Uint8Array>
 ): ParsedRegisterVaultInstruction<TProgram, TAccountMetas> {
-  if (instruction.accounts.length < 8) {
+  if (instruction.accounts.length < 6) {
     // TODO: Coded error.
     throw new Error('Not enough accounts');
   }
@@ -246,11 +217,9 @@ export function parseRegisterVaultInstruction<
   return {
     programAddress: instruction.programAddress,
     accounts: {
-      restakingConfig: getNextAccount(),
       vaultRegistry: getNextAccount(),
       ncn: getNextAccount(),
       vault: getNextAccount(),
-      vaultNcnTicket: getNextAccount(),
       ncnVaultTicket: getNextAccount(),
       restakingProgramId: getNextAccount(),
       vaultProgramId: getNextAccount(),

--- a/clients/rust/jito_tip_router/src/generated/instructions/register_vault.rs
+++ b/clients/rust/jito_tip_router/src/generated/instructions/register_vault.rs
@@ -10,15 +10,11 @@ use borsh::BorshSerialize;
 
 /// Accounts.
 pub struct RegisterVault {
-    pub restaking_config: solana_program::pubkey::Pubkey,
-
     pub vault_registry: solana_program::pubkey::Pubkey,
 
     pub ncn: solana_program::pubkey::Pubkey,
 
     pub vault: solana_program::pubkey::Pubkey,
-
-    pub vault_ncn_ticket: solana_program::pubkey::Pubkey,
 
     pub ncn_vault_ticket: solana_program::pubkey::Pubkey,
 
@@ -36,11 +32,7 @@ impl RegisterVault {
         &self,
         remaining_accounts: &[solana_program::instruction::AccountMeta],
     ) -> solana_program::instruction::Instruction {
-        let mut accounts = Vec::with_capacity(8 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
-            self.restaking_config,
-            false,
-        ));
+        let mut accounts = Vec::with_capacity(6 + remaining_accounts.len());
         accounts.push(solana_program::instruction::AccountMeta::new(
             self.vault_registry,
             false,
@@ -50,10 +42,6 @@ impl RegisterVault {
         ));
         accounts.push(solana_program::instruction::AccountMeta::new_readonly(
             self.vault, false,
-        ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
-            self.vault_ncn_ticket,
-            false,
         ));
         accounts.push(solana_program::instruction::AccountMeta::new_readonly(
             self.ncn_vault_ticket,
@@ -99,21 +87,17 @@ impl Default for RegisterVaultInstructionData {
 ///
 /// ### Accounts:
 ///
-///   0. `[]` restaking_config
-///   1. `[writable]` vault_registry
-///   2. `[]` ncn
-///   3. `[]` vault
-///   4. `[]` vault_ncn_ticket
-///   5. `[]` ncn_vault_ticket
-///   6. `[]` restaking_program_id
-///   7. `[]` vault_program_id
+///   0. `[writable]` vault_registry
+///   1. `[]` ncn
+///   2. `[]` vault
+///   3. `[]` ncn_vault_ticket
+///   4. `[]` restaking_program_id
+///   5. `[]` vault_program_id
 #[derive(Clone, Debug, Default)]
 pub struct RegisterVaultBuilder {
-    restaking_config: Option<solana_program::pubkey::Pubkey>,
     vault_registry: Option<solana_program::pubkey::Pubkey>,
     ncn: Option<solana_program::pubkey::Pubkey>,
     vault: Option<solana_program::pubkey::Pubkey>,
-    vault_ncn_ticket: Option<solana_program::pubkey::Pubkey>,
     ncn_vault_ticket: Option<solana_program::pubkey::Pubkey>,
     restaking_program_id: Option<solana_program::pubkey::Pubkey>,
     vault_program_id: Option<solana_program::pubkey::Pubkey>,
@@ -123,14 +107,6 @@ pub struct RegisterVaultBuilder {
 impl RegisterVaultBuilder {
     pub fn new() -> Self {
         Self::default()
-    }
-    #[inline(always)]
-    pub fn restaking_config(
-        &mut self,
-        restaking_config: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
-        self.restaking_config = Some(restaking_config);
-        self
     }
     #[inline(always)]
     pub fn vault_registry(&mut self, vault_registry: solana_program::pubkey::Pubkey) -> &mut Self {
@@ -145,14 +121,6 @@ impl RegisterVaultBuilder {
     #[inline(always)]
     pub fn vault(&mut self, vault: solana_program::pubkey::Pubkey) -> &mut Self {
         self.vault = Some(vault);
-        self
-    }
-    #[inline(always)]
-    pub fn vault_ncn_ticket(
-        &mut self,
-        vault_ncn_ticket: solana_program::pubkey::Pubkey,
-    ) -> &mut Self {
-        self.vault_ncn_ticket = Some(vault_ncn_ticket);
         self
     }
     #[inline(always)]
@@ -200,11 +168,9 @@ impl RegisterVaultBuilder {
     #[allow(clippy::clone_on_copy)]
     pub fn instruction(&self) -> solana_program::instruction::Instruction {
         let accounts = RegisterVault {
-            restaking_config: self.restaking_config.expect("restaking_config is not set"),
             vault_registry: self.vault_registry.expect("vault_registry is not set"),
             ncn: self.ncn.expect("ncn is not set"),
             vault: self.vault.expect("vault is not set"),
-            vault_ncn_ticket: self.vault_ncn_ticket.expect("vault_ncn_ticket is not set"),
             ncn_vault_ticket: self.ncn_vault_ticket.expect("ncn_vault_ticket is not set"),
             restaking_program_id: self
                 .restaking_program_id
@@ -218,15 +184,11 @@ impl RegisterVaultBuilder {
 
 /// `register_vault` CPI accounts.
 pub struct RegisterVaultCpiAccounts<'a, 'b> {
-    pub restaking_config: &'b solana_program::account_info::AccountInfo<'a>,
-
     pub vault_registry: &'b solana_program::account_info::AccountInfo<'a>,
 
     pub ncn: &'b solana_program::account_info::AccountInfo<'a>,
 
     pub vault: &'b solana_program::account_info::AccountInfo<'a>,
-
-    pub vault_ncn_ticket: &'b solana_program::account_info::AccountInfo<'a>,
 
     pub ncn_vault_ticket: &'b solana_program::account_info::AccountInfo<'a>,
 
@@ -240,15 +202,11 @@ pub struct RegisterVaultCpi<'a, 'b> {
     /// The program to invoke.
     pub __program: &'b solana_program::account_info::AccountInfo<'a>,
 
-    pub restaking_config: &'b solana_program::account_info::AccountInfo<'a>,
-
     pub vault_registry: &'b solana_program::account_info::AccountInfo<'a>,
 
     pub ncn: &'b solana_program::account_info::AccountInfo<'a>,
 
     pub vault: &'b solana_program::account_info::AccountInfo<'a>,
-
-    pub vault_ncn_ticket: &'b solana_program::account_info::AccountInfo<'a>,
 
     pub ncn_vault_ticket: &'b solana_program::account_info::AccountInfo<'a>,
 
@@ -264,11 +222,9 @@ impl<'a, 'b> RegisterVaultCpi<'a, 'b> {
     ) -> Self {
         Self {
             __program: program,
-            restaking_config: accounts.restaking_config,
             vault_registry: accounts.vault_registry,
             ncn: accounts.ncn,
             vault: accounts.vault,
-            vault_ncn_ticket: accounts.vault_ncn_ticket,
             ncn_vault_ticket: accounts.ncn_vault_ticket,
             restaking_program_id: accounts.restaking_program_id,
             vault_program_id: accounts.vault_program_id,
@@ -307,11 +263,7 @@ impl<'a, 'b> RegisterVaultCpi<'a, 'b> {
             bool,
         )],
     ) -> solana_program::entrypoint::ProgramResult {
-        let mut accounts = Vec::with_capacity(8 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
-            *self.restaking_config.key,
-            false,
-        ));
+        let mut accounts = Vec::with_capacity(6 + remaining_accounts.len());
         accounts.push(solana_program::instruction::AccountMeta::new(
             *self.vault_registry.key,
             false,
@@ -322,10 +274,6 @@ impl<'a, 'b> RegisterVaultCpi<'a, 'b> {
         ));
         accounts.push(solana_program::instruction::AccountMeta::new_readonly(
             *self.vault.key,
-            false,
-        ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
-            *self.vault_ncn_ticket.key,
             false,
         ));
         accounts.push(solana_program::instruction::AccountMeta::new_readonly(
@@ -354,13 +302,11 @@ impl<'a, 'b> RegisterVaultCpi<'a, 'b> {
             accounts,
             data,
         };
-        let mut account_infos = Vec::with_capacity(8 + 1 + remaining_accounts.len());
+        let mut account_infos = Vec::with_capacity(6 + 1 + remaining_accounts.len());
         account_infos.push(self.__program.clone());
-        account_infos.push(self.restaking_config.clone());
         account_infos.push(self.vault_registry.clone());
         account_infos.push(self.ncn.clone());
         account_infos.push(self.vault.clone());
-        account_infos.push(self.vault_ncn_ticket.clone());
         account_infos.push(self.ncn_vault_ticket.clone());
         account_infos.push(self.restaking_program_id.clone());
         account_infos.push(self.vault_program_id.clone());
@@ -380,14 +326,12 @@ impl<'a, 'b> RegisterVaultCpi<'a, 'b> {
 ///
 /// ### Accounts:
 ///
-///   0. `[]` restaking_config
-///   1. `[writable]` vault_registry
-///   2. `[]` ncn
-///   3. `[]` vault
-///   4. `[]` vault_ncn_ticket
-///   5. `[]` ncn_vault_ticket
-///   6. `[]` restaking_program_id
-///   7. `[]` vault_program_id
+///   0. `[writable]` vault_registry
+///   1. `[]` ncn
+///   2. `[]` vault
+///   3. `[]` ncn_vault_ticket
+///   4. `[]` restaking_program_id
+///   5. `[]` vault_program_id
 #[derive(Clone, Debug)]
 pub struct RegisterVaultCpiBuilder<'a, 'b> {
     instruction: Box<RegisterVaultCpiBuilderInstruction<'a, 'b>>,
@@ -397,25 +341,15 @@ impl<'a, 'b> RegisterVaultCpiBuilder<'a, 'b> {
     pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(RegisterVaultCpiBuilderInstruction {
             __program: program,
-            restaking_config: None,
             vault_registry: None,
             ncn: None,
             vault: None,
-            vault_ncn_ticket: None,
             ncn_vault_ticket: None,
             restaking_program_id: None,
             vault_program_id: None,
             __remaining_accounts: Vec::new(),
         });
         Self { instruction }
-    }
-    #[inline(always)]
-    pub fn restaking_config(
-        &mut self,
-        restaking_config: &'b solana_program::account_info::AccountInfo<'a>,
-    ) -> &mut Self {
-        self.instruction.restaking_config = Some(restaking_config);
-        self
     }
     #[inline(always)]
     pub fn vault_registry(
@@ -433,14 +367,6 @@ impl<'a, 'b> RegisterVaultCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn vault(&mut self, vault: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.vault = Some(vault);
-        self
-    }
-    #[inline(always)]
-    pub fn vault_ncn_ticket(
-        &mut self,
-        vault_ncn_ticket: &'b solana_program::account_info::AccountInfo<'a>,
-    ) -> &mut Self {
-        self.instruction.vault_ncn_ticket = Some(vault_ncn_ticket);
         self
     }
     #[inline(always)]
@@ -511,11 +437,6 @@ impl<'a, 'b> RegisterVaultCpiBuilder<'a, 'b> {
         let instruction = RegisterVaultCpi {
             __program: self.instruction.__program,
 
-            restaking_config: self
-                .instruction
-                .restaking_config
-                .expect("restaking_config is not set"),
-
             vault_registry: self
                 .instruction
                 .vault_registry
@@ -524,11 +445,6 @@ impl<'a, 'b> RegisterVaultCpiBuilder<'a, 'b> {
             ncn: self.instruction.ncn.expect("ncn is not set"),
 
             vault: self.instruction.vault.expect("vault is not set"),
-
-            vault_ncn_ticket: self
-                .instruction
-                .vault_ncn_ticket
-                .expect("vault_ncn_ticket is not set"),
 
             ncn_vault_ticket: self
                 .instruction
@@ -555,11 +471,9 @@ impl<'a, 'b> RegisterVaultCpiBuilder<'a, 'b> {
 #[derive(Clone, Debug)]
 struct RegisterVaultCpiBuilderInstruction<'a, 'b> {
     __program: &'b solana_program::account_info::AccountInfo<'a>,
-    restaking_config: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     vault_registry: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ncn: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     vault: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    vault_ncn_ticket: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ncn_vault_ticket: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     restaking_program_id: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     vault_program_id: Option<&'b solana_program::account_info::AccountInfo<'a>>,

--- a/core/src/instruction.rs
+++ b/core/src/instruction.rs
@@ -44,14 +44,12 @@ pub enum TipRouterInstruction {
     ReallocVaultRegistry,
 
     /// Registers a vault to the vault registry
-    #[account(0, name = "restaking_config")]
-    #[account(1, writable, name = "vault_registry")]
-    #[account(2, name = "ncn")]
-    #[account(3, name = "vault")]
-    #[account(4, name = "vault_ncn_ticket")]
-    #[account(5, name = "ncn_vault_ticket")]
-    #[account(6, name = "restaking_program_id")]
-    #[account(7, name = "vault_program_id")]
+    #[account(0, writable, name = "vault_registry")]
+    #[account(1, name = "ncn")]
+    #[account(2, name = "vault")]
+    #[account(3, name = "ncn_vault_ticket")]
+    #[account(4, name = "restaking_program_id")]
+    #[account(5, name = "vault_program_id")]
     RegisterVault,
 
     // ---------------------------------------------------- //

--- a/idl/jito_tip_router.json
+++ b/idl/jito_tip_router.json
@@ -142,11 +142,6 @@
       "name": "RegisterVault",
       "accounts": [
         {
-          "name": "restakingConfig",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
           "name": "vaultRegistry",
           "isMut": true,
           "isSigner": false
@@ -158,11 +153,6 @@
         },
         {
           "name": "vault",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "vaultNcnTicket",
           "isMut": false,
           "isSigner": false
         },

--- a/integration_tests/tests/fixtures/test_builder.rs
+++ b/integration_tests/tests/fixtures/test_builder.rs
@@ -11,7 +11,6 @@ use jito_tip_router_core::{
     constants::{JITOSOL_MINT, JTO_SOL_FEED},
     ncn_fee_group::NcnFeeGroup,
 };
-use jito_vault_core::vault_ncn_ticket::VaultNcnTicket;
 use solana_program::{
     clock::Clock, native_token::sol_to_lamports, program_pack::Pack, pubkey::Pubkey,
     system_instruction::transfer,
@@ -528,9 +527,6 @@ impl TestBuilder {
 
             let st_mint = vault_client.get_vault(&vault).await?.supported_mint;
 
-            let vault_ncn_ticket =
-                VaultNcnTicket::find_program_address(&jito_vault_program::id(), &vault, &ncn).0;
-
             let ncn_vault_ticket =
                 NcnVaultTicket::find_program_address(&jito_restaking_program::id(), &ncn, &vault).0;
 
@@ -546,7 +542,7 @@ impl TestBuilder {
                 .await?;
 
             tip_router_client
-                .do_register_vault(ncn, vault, vault_ncn_ticket, ncn_vault_ticket)
+                .do_register_vault(ncn, vault, ncn_vault_ticket)
                 .await?;
         }
 

--- a/integration_tests/tests/fixtures/tip_router_client.rs
+++ b/integration_tests/tests/fixtures/tip_router_client.rs
@@ -753,40 +753,26 @@ impl TipRouterClient {
         &mut self,
         ncn: Pubkey,
         vault: Pubkey,
-        vault_ncn_ticket: Pubkey,
         ncn_vault_ticket: Pubkey,
     ) -> TestResult<()> {
-        let restaking_config_address =
-            Config::find_program_address(&jito_restaking_program::id()).0;
         let vault_registry =
             VaultRegistry::find_program_address(&jito_tip_router_program::id(), &ncn).0;
 
-        self.register_vault(
-            restaking_config_address,
-            vault_registry,
-            ncn,
-            vault,
-            vault_ncn_ticket,
-            ncn_vault_ticket,
-        )
-        .await
+        self.register_vault(vault_registry, ncn, vault, ncn_vault_ticket)
+            .await
     }
 
     pub async fn register_vault(
         &mut self,
-        restaking_config: Pubkey,
         vault_registry: Pubkey,
         ncn: Pubkey,
         vault: Pubkey,
-        vault_ncn_ticket: Pubkey,
         ncn_vault_ticket: Pubkey,
     ) -> TestResult<()> {
         let ix = RegisterVaultBuilder::new()
-            .restaking_config(restaking_config)
             .vault_registry(vault_registry)
             .ncn(ncn)
             .vault(vault)
-            .vault_ncn_ticket(vault_ncn_ticket)
             .ncn_vault_ticket(ncn_vault_ticket)
             .restaking_program_id(jito_restaking_program::id())
             .vault_program_id(jito_vault_program::id())

--- a/integration_tests/tests/tip_router/register_vault.rs
+++ b/integration_tests/tests/tip_router/register_vault.rs
@@ -2,7 +2,6 @@
 mod tests {
     use jito_restaking_core::{config::Config, ncn_vault_ticket::NcnVaultTicket};
     use jito_tip_router_core::{constants::JTO_SOL_FEED, ncn_fee_group::NcnFeeGroup};
-    use jito_vault_core::vault_ncn_ticket::VaultNcnTicket;
     use solana_sdk::{signature::Keypair, signer::Signer};
 
     use crate::fixtures::{test_builder::TestBuilder, TestResult};
@@ -29,12 +28,6 @@ mod tests {
             .await?;
 
         let vault = vault_root.vault_pubkey;
-        let vault_ncn_ticket = VaultNcnTicket::find_program_address(
-            &jito_vault_program::id(),
-            &vault_root.vault_pubkey,
-            &ncn_root.ncn_pubkey,
-        )
-        .0;
         let ncn_vault_ticket = NcnVaultTicket::find_program_address(
             &jito_restaking_program::id(),
             &ncn_root.ncn_pubkey,
@@ -74,12 +67,7 @@ mod tests {
 
         // Register mint
         tip_router_client
-            .do_register_vault(
-                ncn_root.ncn_pubkey,
-                vault,
-                vault_ncn_ticket,
-                ncn_vault_ticket,
-            )
+            .do_register_vault(ncn_root.ncn_pubkey, vault, ncn_vault_ticket)
             .await?;
 
         // Verify mint was registered by checking tracked mints
@@ -99,14 +87,12 @@ mod tests {
 
         // Try to register mint without initialization
         let vault = Keypair::new();
-        let vault_ncn_ticket = Keypair::new();
         let ncn_vault_ticket = Keypair::new();
 
         let result = tip_router_client
             .do_register_vault(
                 ncn_root.ncn_pubkey,
                 vault.pubkey(),
-                vault_ncn_ticket.pubkey(),
                 ncn_vault_ticket.pubkey(),
             )
             .await;
@@ -139,12 +125,7 @@ mod tests {
             .await?;
 
         let vault = vault_root.vault_pubkey;
-        let vault_ncn_ticket = VaultNcnTicket::find_program_address(
-            &jito_vault_program::id(),
-            &vault_root.vault_pubkey,
-            &ncn_root.ncn_pubkey,
-        )
-        .0;
+
         let ncn_vault_ticket = NcnVaultTicket::find_program_address(
             &jito_restaking_program::id(),
             &ncn_root.ncn_pubkey,
@@ -184,24 +165,14 @@ mod tests {
 
         // Register mint first time
         tip_router_client
-            .do_register_vault(
-                ncn_root.ncn_pubkey,
-                vault,
-                vault_ncn_ticket,
-                ncn_vault_ticket,
-            )
+            .do_register_vault(ncn_root.ncn_pubkey, vault, ncn_vault_ticket)
             .await?;
 
         fixture.warp_slot_incremental(1).await?;
 
         // Register same mint again
         tip_router_client
-            .do_register_vault(
-                ncn_root.ncn_pubkey,
-                vault,
-                vault_ncn_ticket,
-                ncn_vault_ticket,
-            )
+            .do_register_vault(ncn_root.ncn_pubkey, vault, ncn_vault_ticket)
             .await?;
 
         // Verify mint was only registered once

--- a/program/src/register_vault.rs
+++ b/program/src/register_vault.rs
@@ -1,7 +1,7 @@
 use jito_bytemuck::AccountDeserialize;
-use jito_restaking_core::{config::Config, ncn::Ncn, ncn_vault_ticket::NcnVaultTicket};
+use jito_restaking_core::{ncn::Ncn, ncn_vault_ticket::NcnVaultTicket};
 use jito_tip_router_core::vault_registry::VaultRegistry;
-use jito_vault_core::{vault::Vault, vault_ncn_ticket::VaultNcnTicket};
+use jito_vault_core::vault::Vault;
 use solana_program::{
     account_info::AccountInfo,
     entrypoint::ProgramResult,
@@ -12,7 +12,7 @@ use solana_program::{
 };
 
 pub fn process_register_vault(program_id: &Pubkey, accounts: &[AccountInfo]) -> ProgramResult {
-    let [restaking_config, vault_registry, ncn, vault, vault_ncn_ticket, ncn_vault_ticket, restaking_program_id, vault_program_id] =
+    let [vault_registry, ncn, vault, ncn_vault_ticket, restaking_program_id, vault_program_id] =
         accounts
     else {
         return Err(ProgramError::NotEnoughAccountKeys);
@@ -21,7 +21,6 @@ pub fn process_register_vault(program_id: &Pubkey, accounts: &[AccountInfo]) -> 
     VaultRegistry::load(program_id, ncn.key, vault_registry, true)?;
     Ncn::load(restaking_program_id.key, ncn, false)?;
     Vault::load(vault_program_id.key, vault, false)?;
-    VaultNcnTicket::load(vault_program_id.key, vault_ncn_ticket, vault, ncn, false)?;
     NcnVaultTicket::load(
         restaking_program_id.key,
         ncn_vault_ticket,
@@ -30,34 +29,8 @@ pub fn process_register_vault(program_id: &Pubkey, accounts: &[AccountInfo]) -> 
         false,
     )?;
 
-    let epoch_length = {
-        let restaking_config_data = restaking_config.data.borrow();
-        Config::try_from_slice_unchecked(&restaking_config_data)?.epoch_length()
-    };
-
     let clock = Clock::get()?;
     let slot = clock.slot;
-
-    // Verify tickets are active
-    let vault_ncn_ticket_data = vault_ncn_ticket.data.borrow();
-    let vault_ncn_ticket = VaultNcnTicket::try_from_slice_unchecked(&vault_ncn_ticket_data)?;
-    if !vault_ncn_ticket
-        .state
-        .is_active_or_cooldown(slot, epoch_length)
-    {
-        msg!("Vault NCN ticket is not enabled");
-        return Err(ProgramError::InvalidAccountData);
-    }
-
-    let ncn_vault_ticket_data = ncn_vault_ticket.data.borrow();
-    let ncn_vault_ticket = NcnVaultTicket::try_from_slice_unchecked(&ncn_vault_ticket_data)?;
-    if !ncn_vault_ticket
-        .state
-        .is_active_or_cooldown(slot, epoch_length)
-    {
-        msg!("NCN vault ticket is not enabled");
-        return Err(ProgramError::InvalidAccountData);
-    }
 
     let mut vault_registry_data = vault_registry.try_borrow_mut_data()?;
     let vault_registry = VaultRegistry::try_from_slice_unchecked_mut(&mut vault_registry_data)?;

--- a/program/src/snapshot_vault_operator_delegation.rs
+++ b/program/src/snapshot_vault_operator_delegation.rs
@@ -48,8 +48,11 @@ pub fn process_snapshot_vault_operator_delegation(
     Operator::load(restaking_program.key, operator, false)?;
     Vault::load(vault_program.key, vault, false)?;
 
-    VaultNcnTicket::load(vault_program.key, vault_ncn_ticket, vault, ncn, false)?;
     NcnVaultTicket::load(restaking_program.key, ncn_vault_ticket, ncn, vault, false)?;
+
+    if !vault_ncn_ticket.data_is_empty() {
+        VaultNcnTicket::load(vault_program.key, vault_ncn_ticket, vault, ncn, false)?;
+    }
 
     if !vault_operator_delegation.data_is_empty() {
         VaultOperatorDelegation::load(
@@ -93,23 +96,28 @@ pub fn process_snapshot_vault_operator_delegation(
         (vault_account.vault_index(), vault_account.supported_mint)
     };
 
-    //TODO move to helper function
     let is_active: bool = {
-        let vault_ncn_ticket_data = vault_ncn_ticket.data.borrow();
-        let vault_ncn_ticket_account =
-            VaultNcnTicket::try_from_slice_unchecked(&vault_ncn_ticket_data)?;
+        let ncn_vault_okay = {
+            let ncn_vault_ticket_data = ncn_vault_ticket.data.borrow();
+            let ncn_vault_ticket_account =
+                NcnVaultTicket::try_from_slice_unchecked(&ncn_vault_ticket_data)?;
+            ncn_vault_ticket_account
+                .state
+                .is_active(current_slot, ncn_epoch_length)
+        };
 
-        let ncn_vault_ticket_data = ncn_vault_ticket.data.borrow();
-        let ncn_vault_ticket_account =
-            NcnVaultTicket::try_from_slice_unchecked(&ncn_vault_ticket_data)?;
-
-        let vault_ncn_okay = vault_ncn_ticket_account
-            .state
-            .is_active(current_slot, ncn_epoch_length);
-
-        let ncn_vault_okay = ncn_vault_ticket_account
-            .state
-            .is_active(current_slot, ncn_epoch_length);
+        let vault_ncn_okay = {
+            if vault_ncn_ticket.data_is_empty() {
+                false
+            } else {
+                let vault_ncn_ticket_data = vault_ncn_ticket.data.borrow();
+                let vault_ncn_ticket_account =
+                    VaultNcnTicket::try_from_slice_unchecked(&vault_ncn_ticket_data)?;
+                vault_ncn_ticket_account
+                    .state
+                    .is_active(current_slot, ncn_epoch_length)
+            }
+        };
 
         let delegation_dne = vault_operator_delegation.data_is_empty();
 


### PR DESCRIPTION
We just need to know if NcnVaultTicket exists to register the ticket. 
When we take vault operator delegation, we check the state of both NcnVaultTicket and VaultNcnTicket