### PR TITLE
AUDIT: Update when tickets are considered active

### DIFF
--- a/program/src/realloc_operator_snapshot.rs
+++ b/program/src/realloc_operator_snapshot.rs
@@ -78,13 +78,16 @@ pub fn process_realloc_operator_snapshot(
             let ncn_operator_state_account =
                 NcnOperatorState::try_from_slice_unchecked(&ncn_operator_state_data)?;
 
+            // If the NCN removes an operator, it should immediately be barred from the snapshot
             let ncn_operator_okay = ncn_operator_state_account
                 .ncn_opt_in_state
                 .is_active(current_slot, ncn_epoch_length);
 
+            // If the operator removes itself from the ncn, it should still be able to participate
+            // while it is cooling down
             let operator_ncn_okay = ncn_operator_state_account
                 .operator_opt_in_state
-                .is_active(current_slot, ncn_epoch_length);
+                .is_active_or_cooldown(current_slot, ncn_epoch_length);
 
             let ncn_operator_index = ncn_operator_state_account.index();
 

--- a/program/src/snapshot_vault_operator_delegation.rs
+++ b/program/src/snapshot_vault_operator_delegation.rs
@@ -103,6 +103,8 @@ pub fn process_snapshot_vault_operator_delegation(
             let ncn_vault_ticket_data = ncn_vault_ticket.data.borrow();
             let ncn_vault_ticket_account =
                 NcnVaultTicket::try_from_slice_unchecked(&ncn_vault_ticket_data)?;
+
+            // If the NCN removes a vault, it should immediately be barred from the snapshot
             ncn_vault_ticket_account
                 .state
                 .is_active(current_slot, ncn_epoch_length)
@@ -117,7 +119,7 @@ pub fn process_snapshot_vault_operator_delegation(
                     VaultNcnTicket::try_from_slice_unchecked(&vault_ncn_ticket_data)?;
                 vault_ncn_ticket_account
                     .state
-                    .is_active(current_slot, ncn_epoch_length)
+                    .is_active_or_cooldown(current_slot, ncn_epoch_length)
             }
         };
 

--- a/program/src/snapshot_vault_operator_delegation.rs
+++ b/program/src/snapshot_vault_operator_delegation.rs
@@ -117,6 +117,10 @@ pub fn process_snapshot_vault_operator_delegation(
                 let vault_ncn_ticket_data = vault_ncn_ticket.data.borrow();
                 let vault_ncn_ticket_account =
                     VaultNcnTicket::try_from_slice_unchecked(&vault_ncn_ticket_data)?;
+
+                // If a vault removes itself from the ncn, it should still be able to participate
+                // until it is finished cooling down - this is so the operators with delegation
+                // from this vault can still participate
                 vault_ncn_ticket_account
                     .state
                     .is_active_or_cooldown(current_slot, ncn_epoch_length)


### PR DESCRIPTION
- When the NCN makes a ticket invalid - it should take effect immediately 
- When the operator or vault makes a ticket invalid - it can still participate until it is cooled down