### PR TITLE
AUDIT: Operator Index

### DIFF
--- a/clients/js/jito_tip_router/errors/jitoTipRouter.ts
+++ b/clients/js/jito_tip_router/errors/jitoTipRouter.ts
@@ -172,6 +172,8 @@ export const JITO_TIP_ROUTER_ERROR__ACCOUNT_ALREADY_INITIALIZED = 0x2243; // 877
 export const JITO_TIP_ROUTER_ERROR__BAD_BALLOT = 0x2244; // 8772
 /** VotingIsNotOver: Cannot route until voting is over */
 export const JITO_TIP_ROUTER_ERROR__VOTING_IS_NOT_OVER = 0x2245; // 8773
+/** OperatorIsNotInSnapshot: Operator is not in snapshot */
+export const JITO_TIP_ROUTER_ERROR__OPERATOR_IS_NOT_IN_SNAPSHOT = 0x2246; // 8774
 
 export type JitoTipRouterError =
   | typeof JITO_TIP_ROUTER_ERROR__ACCOUNT_ALREADY_INITIALIZED
@@ -225,6 +227,7 @@ export type JitoTipRouterError =
   | typeof JITO_TIP_ROUTER_ERROR__NO_VAULTS_IN_REGISTRY
   | typeof JITO_TIP_ROUTER_ERROR__OPERATOR_ADMIN_INVALID
   | typeof JITO_TIP_ROUTER_ERROR__OPERATOR_FINALIZED
+  | typeof JITO_TIP_ROUTER_ERROR__OPERATOR_IS_NOT_IN_SNAPSHOT
   | typeof JITO_TIP_ROUTER_ERROR__OPERATOR_REWARD_LIST_FULL
   | typeof JITO_TIP_ROUTER_ERROR__OPERATOR_REWARD_NOT_FOUND
   | typeof JITO_TIP_ROUTER_ERROR__OPERATOR_VOTES_FULL
@@ -308,6 +311,7 @@ if (process.env.NODE_ENV !== 'production') {
     [JITO_TIP_ROUTER_ERROR__NO_VAULTS_IN_REGISTRY]: `There are no vaults in the registry`,
     [JITO_TIP_ROUTER_ERROR__OPERATOR_ADMIN_INVALID]: `Operator admin needs to sign its vote`,
     [JITO_TIP_ROUTER_ERROR__OPERATOR_FINALIZED]: `Operator is already finalized - should not happen`,
+    [JITO_TIP_ROUTER_ERROR__OPERATOR_IS_NOT_IN_SNAPSHOT]: `Operator is not in snapshot`,
     [JITO_TIP_ROUTER_ERROR__OPERATOR_REWARD_LIST_FULL]: `Operator reward list full`,
     [JITO_TIP_ROUTER_ERROR__OPERATOR_REWARD_NOT_FOUND]: `Operator Reward not found`,
     [JITO_TIP_ROUTER_ERROR__OPERATOR_VOTES_FULL]: `Operator votes full`,

--- a/clients/rust/jito_tip_router/src/generated/errors/jito_tip_router.rs
+++ b/clients/rust/jito_tip_router/src/generated/errors/jito_tip_router.rs
@@ -247,6 +247,9 @@ pub enum JitoTipRouterError {
     /// 8773 - Cannot route until voting is over
     #[error("Cannot route until voting is over")]
     VotingIsNotOver = 0x2245,
+    /// 8774 - Operator is not in snapshot
+    #[error("Operator is not in snapshot")]
+    OperatorIsNotInSnapshot = 0x2246,
 }
 
 impl solana_program::program_error::PrintProgramError for JitoTipRouterError {

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -163,6 +163,8 @@ pub enum TipRouterError {
     BadBallot,
     #[error("Cannot route until voting is over")]
     VotingIsNotOver,
+    #[error("Operator is not in snapshot")]
+    OperatorIsNotInSnapshot,
 }
 
 impl<T> DecodeError<T> for TipRouterError {

--- a/idl/jito_tip_router.json
+++ b/idl/jito_tip_router.json
@@ -3622,6 +3622,11 @@
       "code": 8773,
       "name": "VotingIsNotOver",
       "msg": "Cannot route until voting is over"
+    },
+    {
+      "code": 8774,
+      "name": "OperatorIsNotInSnapshot",
+      "msg": "Operator is not in snapshot"
     }
   ],
   "metadata": {

--- a/integration_tests/tests/tip_router/initialize_operator_snapshot.rs
+++ b/integration_tests/tests/tip_router/initialize_operator_snapshot.rs
@@ -1,9 +1,13 @@
 #[cfg(test)]
 mod tests {
 
-    use jito_tip_router_core::{constants::MAX_REALLOC_BYTES, epoch_snapshot::OperatorSnapshot};
+    use jito_tip_router_core::{
+        constants::MAX_REALLOC_BYTES, epoch_snapshot::OperatorSnapshot, error::TipRouterError,
+    };
 
-    use crate::fixtures::{test_builder::TestBuilder, TestResult};
+    use crate::fixtures::{
+        test_builder::TestBuilder, tip_router_client::assert_tip_router_error, TestResult,
+    };
 
     #[tokio::test]
     async fn test_initialize_operator_snapshot() -> TestResult<()> {
@@ -58,6 +62,40 @@ mod tests {
         // Verify initial state
         assert_eq!(*operator_snapshot.operator(), operator);
         assert_eq!(*operator_snapshot.ncn(), ncn);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_add_operator_after_epoch_snapshot() -> TestResult<()> {
+        let mut fixture = TestBuilder::new().await;
+        let mut tip_router_client = fixture.tip_router_client();
+
+        let mut test_ncn = fixture.create_initial_test_ncn(1, 1, None).await?;
+        fixture.add_epoch_state_for_test_ncn(&test_ncn).await?;
+
+        fixture.warp_slot_incremental(1000).await?;
+
+        fixture.add_admin_weights_for_test_ncn(&test_ncn).await?;
+        fixture.add_epoch_snapshot_to_test_ncn(&test_ncn).await?;
+
+        // Add New Operator
+        fixture
+            .add_operators_to_test_ncn(&mut test_ncn, 1, None)
+            .await?;
+
+        let clock = fixture.clock().await;
+        let epoch = clock.epoch;
+        let ncn = test_ncn.ncn_root.ncn_pubkey;
+        // Last added operator
+        let operator = test_ncn.operators[1].operator_pubkey;
+
+        // Initialize operator snapshot
+        let result = tip_router_client
+            .do_initialize_operator_snapshot(operator, ncn, epoch)
+            .await;
+
+        assert_tip_router_error(result, TipRouterError::OperatorIsNotInSnapshot);
 
         Ok(())
     }


### PR DESCRIPTION
Operator Snapshot cannot be initialized if the `ncn_operator_state`'s index is >= `epoch_snapshot`'s operator count.

This would happen if the NCN added the operator after the Epoch Snapshot has been taken and the Operator count has been set