### PR TITLE
FIX: Rounding Error

### DIFF
--- a/core/src/base_reward_router.rs
+++ b/core/src/base_reward_router.rs
@@ -485,6 +485,7 @@ impl BaseRewardRouter {
                 .checked_add(rewards)
                 .ok_or(TipRouterError::ArithmeticOverflow)?,
         );
+
         Ok(())
     }
 
@@ -498,6 +499,8 @@ impl BaseRewardRouter {
                 .checked_sub(rewards)
                 .ok_or(TipRouterError::ArithmeticUnderflowError)?,
         );
+
+        self.increment_rewards_processed(rewards)?;
 
         Ok(())
     }
@@ -556,8 +559,6 @@ impl BaseRewardRouter {
                 .ok_or(TipRouterError::ArithmeticOverflow)?,
         );
 
-        self.increment_rewards_processed(rewards)?;
-
         Ok(())
     }
 
@@ -601,8 +602,6 @@ impl BaseRewardRouter {
                 .checked_add(rewards)
                 .ok_or(TipRouterError::ArithmeticOverflow)?,
         );
-
-        self.increment_rewards_processed(rewards)?;
 
         Ok(())
     }

--- a/core/src/ncn_reward_router.rs
+++ b/core/src/ncn_reward_router.rs
@@ -480,6 +480,8 @@ impl NcnRewardRouter {
                 .ok_or(TipRouterError::ArithmeticUnderflowError)?,
         );
 
+        self.increment_rewards_processed(rewards)?;
+
         Ok(())
     }
 
@@ -525,13 +527,12 @@ impl NcnRewardRouter {
             return Ok(());
         }
 
-        self.increment_rewards_processed(rewards)?;
-
         self.operator_rewards = PodU64::from(
             self.operator_rewards()
                 .checked_add(rewards)
                 .ok_or(TipRouterError::ArithmeticOverflow)?,
         );
+
         Ok(())
     }
 
@@ -567,8 +568,6 @@ impl NcnRewardRouter {
         if rewards == 0 {
             return Ok(());
         }
-
-        self.increment_rewards_processed(rewards)?;
 
         for vault_reward in self.vault_reward_routes.iter_mut() {
             if vault_reward.vault().eq(vault) {

--- a/integration_tests/tests/fixtures/test_builder.rs
+++ b/integration_tests/tests/fixtures/test_builder.rs
@@ -879,6 +879,8 @@ impl TestBuilder {
 
         // route rewards
         tip_router_client.do_route_base_rewards(ncn, epoch).await?;
+        // Should be able to route twice
+        tip_router_client.do_route_base_rewards(ncn, epoch).await?;
 
         let base_reward_router = tip_router_client.get_base_reward_router(ncn, epoch).await?;
 
@@ -934,6 +936,10 @@ impl TestBuilder {
             let operator = operator_root.operator_pubkey;
 
             for group in NcnFeeGroup::all_groups().iter() {
+                tip_router_client
+                    .do_route_ncn_rewards(*group, ncn, operator, epoch)
+                    .await?;
+                // Should be able to route twice
                 tip_router_client
                     .do_route_ncn_rewards(*group, ncn, operator, epoch)
                     .await?;


### PR DESCRIPTION
+ Rounding Error is fixed

Before, when we would call the following, it would double count for the `leftover_rewards` in `rewards_processed`
```rust
            // DAO gets any remainder
            {
                let leftover_rewards = self.ncn_fee_group_rewards(group)?;

                self.route_from_ncn_fee_group_rewards(group, leftover_rewards)?;
                self.route_to_base_fee_group_rewards(BaseFeeGroup::dao(), leftover_rewards)?;
            }
```

This is because we increment `rewards_processed` when we route to the `ncn_fee_group_rewards` or `base_fee_group_rewards`, however in the example above, we routed to ncn, counted and then routed to base, counted.

The fix is to increment `rewards_processed` only when we route from the reward pool. ( Note, `rewards_processed` is only decremented on the distribute functions )

This has also been changed in NcnRewardRouter for coherence.