### PR TITLE
patch 1.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10134,7 +10134,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tip-router-operator-cli"
-version = "0.1.0"
+version = "1.1.1"
 dependencies = [
  "anchor-lang 0.30.1",
  "anyhow",

--- a/tip-router-operator-cli/Cargo.toml
+++ b/tip-router-operator-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tip-router-operator-cli"
-version = "0.1.0"
+version = "1.1.1"
 edition = "2021"
 description = "CLI for Jito Tip Router"
 

--- a/tip-router-operator-cli/src/claim.rs
+++ b/tip-router-operator-cli/src/claim.rs
@@ -78,7 +78,7 @@ pub async fn claim_mev_tips_with_emit(
     let keypair = read_keypair_file(cli.keypair_path.clone())
         .map_err(|e| anyhow::anyhow!("Failed to read keypair file: {:?}", e))?;
     let keypair = Arc::new(keypair);
-    let meta_merkle_tree_dir = cli.save_path.clone();
+    let meta_merkle_tree_dir = cli.get_save_path().clone();
     let rpc_url = cli.rpc_url.clone();
     let merkle_tree_coll_path = meta_merkle_tree_dir.join(merkle_tree_collection_file_name(epoch));
     let mut merkle_tree_coll = GeneratedMerkleTreeCollection::new_from_file(&merkle_tree_coll_path)

--- a/tip-router-operator-cli/src/cli.rs
+++ b/tip-router-operator-cli/src/cli.rs
@@ -37,26 +37,37 @@ pub struct Cli {
     #[arg(long, env, default_value_t = 1)]
     pub micro_lamports: u64,
 
-    #[arg(
-        long,
-        env,
-        alias = "meta-merkle-tree-dir",
-        help = "Path to save data (formerly meta-merkle-tree-dir)"
-    )]
-    pub save_path: PathBuf,
+    #[arg(long, env, help = "Path to save data (formerly meta-merkle-tree-dir)")]
+    pub save_path: Option<PathBuf>,
+
+    #[arg(short, long, env, help = "Path to save data (deprecated)")]
+    #[deprecated(since = "1.1.0", note = "use --save-path instead")]
+    pub meta_merkle_tree_dir: Option<PathBuf>,
 
     #[command(subcommand)]
     pub command: Commands,
 }
 
 impl Cli {
+    #[allow(deprecated)]
+    pub fn get_save_path(&self) -> PathBuf {
+        if let Some(save_path) = self.save_path.to_owned() {
+            save_path
+        } else if let Some(save_path) = self.meta_merkle_tree_dir.to_owned() {
+            save_path
+        } else {
+            panic!("--save-path argument must be set");
+        }
+    }
+
     pub fn create_save_path(&self) {
-        if !self.save_path.exists() {
+        let save_path = self.get_save_path();
+        if !save_path.exists() {
             info!(
                 "Creating Tip Router save directory at {}",
-                self.save_path.display()
+                save_path.display()
             );
-            std::fs::create_dir_all(&self.save_path).unwrap();
+            std::fs::create_dir_all(&save_path).unwrap();
         }
     }
 

--- a/tip-router-operator-cli/src/cli.rs
+++ b/tip-router-operator-cli/src/cli.rs
@@ -53,11 +53,12 @@ impl Cli {
     pub fn get_save_path(&self) -> PathBuf {
         self.save_path.to_owned().map_or_else(
             || {
-                if let Some(save_path) = self.meta_merkle_tree_dir.to_owned() {
-                    save_path
-                } else {
-                    panic!("--save-path argument must be set");
-                }
+                self.meta_merkle_tree_dir.to_owned().map_or_else(
+                    || {
+                        panic!("--save-path argument must be set");
+                    },
+                    |save_path| save_path,
+                )
             },
             |save_path| save_path,
         )

--- a/tip-router-operator-cli/src/cli.rs
+++ b/tip-router-operator-cli/src/cli.rs
@@ -51,13 +51,16 @@ pub struct Cli {
 impl Cli {
     #[allow(deprecated)]
     pub fn get_save_path(&self) -> PathBuf {
-        if let Some(save_path) = self.save_path.to_owned() {
-            save_path
-        } else if let Some(save_path) = self.meta_merkle_tree_dir.to_owned() {
-            save_path
-        } else {
-            panic!("--save-path argument must be set");
-        }
+        self.save_path.to_owned().map_or_else(
+            || {
+                if let Some(save_path) = self.meta_merkle_tree_dir.to_owned() {
+                    save_path
+                } else {
+                    panic!("--save-path argument must be set");
+                }
+            },
+            |save_path| save_path,
+        )
     }
 
     pub fn create_save_path(&self) {

--- a/tip-router-operator-cli/src/process_epoch.rs
+++ b/tip-router-operator-cli/src/process_epoch.rs
@@ -185,7 +185,7 @@ pub async fn loop_stages(
                     bank.as_ref().expect("Bank was not set"),
                     tip_distribution_program_id,
                     tip_payment_program_id,
-                    &cli.save_path,
+                    &cli.get_save_path(),
                     save_stages,
                 ));
                 // we should be able to safely drop the bank in this loop
@@ -197,7 +197,9 @@ pub async fn loop_stages(
                 let some_stake_meta_collection = match stake_meta_collection.to_owned() {
                     Some(collection) => collection,
                     None => {
-                        let file = cli.save_path.join(stake_meta_file_name(epoch_to_process));
+                        let file = cli
+                            .get_save_path()
+                            .join(stake_meta_file_name(epoch_to_process));
                         StakeMetaCollection::new_from_file(&file)?
                     }
                 };
@@ -217,7 +219,7 @@ pub async fn loop_stages(
                     epoch_to_process,
                     ncn_address,
                     protocol_fee_bps,
-                    &cli.save_path,
+                    &cli.get_save_path(),
                     save_stages,
                 ));
 
@@ -230,7 +232,7 @@ pub async fn loop_stages(
                     Some(collection) => collection,
                     None => {
                         let file = cli
-                            .save_path
+                            .get_save_path()
                             .join(merkle_tree_collection_file_name(epoch_to_process));
                         GeneratedMerkleTreeCollection::new_from_file(&file)?
                     }
@@ -240,7 +242,7 @@ pub async fn loop_stages(
                     cli.operator_address.clone(),
                     some_merkle_tree_collection,
                     epoch_to_process,
-                    &cli.save_path,
+                    &cli.get_save_path(),
                     // This is defaulted to true because the output file is required by the
                     //  task that sets TipDistributionAccounts' merkle roots
                     true,
@@ -250,7 +252,7 @@ pub async fn loop_stages(
             OperatorState::CastVote => {
                 let meta_merkle_tree_path = PathBuf::from(format!(
                     "{}/{}",
-                    cli.save_path.display(),
+                    cli.get_save_path().display(),
                     meta_merkle_tree_file_name(epoch_to_process)
                 ));
                 let operator_address = Pubkey::from_str(&cli.operator_address)?;

--- a/tip-router-operator-cli/src/submit.rs
+++ b/tip-router-operator-cli/src/submit.rs
@@ -41,7 +41,7 @@ pub async fn submit_recent_epochs_to_ncn(
     for i in 0..num_monitored_epochs {
         let process_epoch = epoch.epoch.checked_sub(i).unwrap();
 
-        let meta_merkle_tree_dir = cli_args.save_path.clone();
+        let meta_merkle_tree_dir = cli_args.get_save_path();
         let target_meta_merkle_tree_file = meta_merkle_tree_file_name(process_epoch);
         let target_meta_merkle_tree_path = meta_merkle_tree_dir.join(target_meta_merkle_tree_file);
         if !target_meta_merkle_tree_path.exists() {


### PR DESCRIPTION
* update version to 1.1.1
* refactor `CLI`
    * make --save-path and --meta-merkle-tree-dir optional arguments, where one must be present
    * Brings back ENV var support for META_MERKLE_TREE_DIR
    * marked --meta-merkle-tree-dir as deprecated