### PR TITLE
Keeper: use hostname/container id in metrics host id

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,13 +25,7 @@ jobs:
         with:
           crate: cargo-audit
       - run: |
-          cargo audit \
-            --ignore RUSTSEC-2022-0093 \
-            --ignore RUSTSEC-2023-0065 \
-            --ignore RUSTSEC-2024-0344 \
-            --ignore RUSTSEC-2024-0421 \
-            --ignore RUSTSEC-2024-0375 \
-            --ignore RUSTSEC-2025-0009
+          cargo audit --ignore RUSTSEC-2022-0093 --ignore RUSTSEC-2024-0344 --ignore RUSTSEC-2024-0421 --ignore RUSTSEC-2024-0375 --ignore RUSTSEC-2025-0009 --ignore RUSTSEC-2025-0022
 
   code_gen:
     name: code generation

--- a/cli/src/args.rs
+++ b/cli/src/args.rs
@@ -30,6 +30,15 @@ pub struct Args {
     #[arg(
         long,
         global = true,
+        env = "REGION",
+        default_value = "local",
+        help = "Region label for metrics purposes"
+    )]
+    pub region: String,
+
+    #[arg(
+        long,
+        global = true,
         env = "COMMITMENT",
         default_value = "confirmed",
         help = "Commitment level"
@@ -158,6 +167,13 @@ pub enum ProgramCommand {
         run_migration: bool,
         #[arg(long, env, help = "Cluster label for metrics purposes")]
         cluster_label: Cluster,
+        #[arg(
+            long,
+            env,
+            default_value = "local",
+            help = "Region for metrics purposes"
+        )]
+        region: String,
     },
     /// Crank Functions
     CrankUpdateAllVaults {},

--- a/cli/src/args.rs
+++ b/cli/src/args.rs
@@ -166,7 +166,7 @@ pub enum ProgramCommand {
         #[arg(long, env, help = "Run migration")]
         run_migration: bool,
         #[arg(long, env, help = "Cluster label for metrics purposes")]
-        cluster_label: Cluster,
+        cluster: Cluster,
         #[arg(
             long,
             env,

--- a/cli/src/args.rs
+++ b/cli/src/args.rs
@@ -25,7 +25,7 @@ pub struct Args {
         default_value_t = Cluster::Mainnet,
         help = "Cluster label for metrics purposes"
     )]
-    pub cluster_label: Cluster,
+    pub cluster: Cluster,
 
     #[arg(
         long,

--- a/cli/src/args.rs
+++ b/cli/src/args.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-use clap::{Parser, Subcommand};
+use clap::{Parser, Subcommand, ValueEnum};
 use solana_sdk::clock::DEFAULT_SLOTS_PER_EPOCH;
 
 #[derive(Parser)]
@@ -17,6 +17,15 @@ pub struct Args {
         help = "RPC URL to use"
     )]
     pub rpc_url: String,
+
+    #[arg(
+        long,
+        global = true,
+        env = "CLUSTER",
+        default_value_t = Cluster::Mainnet,
+        help = "Cluster label for metrics purposes"
+    )]
+    pub cluster_label: Cluster,
 
     #[arg(
         long,
@@ -147,6 +156,8 @@ pub enum ProgramCommand {
         metrics_only: bool,
         #[arg(long, env, help = "Run migration")]
         run_migration: bool,
+        #[arg(long, env, help = "Cluster label for metrics purposes")]
+        cluster_label: Cluster,
     },
     /// Crank Functions
     CrankUpdateAllVaults {},
@@ -438,5 +449,22 @@ impl fmt::Display for Args {
         writeln!(f, "\n")?;
 
         Ok(())
+    }
+}
+
+#[derive(ValueEnum, Debug, Clone)]
+pub enum Cluster {
+    Mainnet,
+    Testnet,
+    Localnet,
+}
+
+impl fmt::Display for Cluster {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Mainnet => write!(f, "mainnet"),
+            Self::Testnet => write!(f, "testnet"),
+            Self::Localnet => write!(f, "localnet"),
+        }
     }
 }

--- a/cli/src/args.rs
+++ b/cli/src/args.rs
@@ -21,24 +21,6 @@ pub struct Args {
     #[arg(
         long,
         global = true,
-        env = "CLUSTER",
-        default_value_t = Cluster::Mainnet,
-        help = "Cluster label for metrics purposes"
-    )]
-    pub cluster: Cluster,
-
-    #[arg(
-        long,
-        global = true,
-        env = "REGION",
-        default_value = "local",
-        help = "Region label for metrics purposes"
-    )]
-    pub region: String,
-
-    #[arg(
-        long,
-        global = true,
         env = "COMMITMENT",
         default_value = "confirmed",
         help = "Commitment level"

--- a/cli/src/handler.rs
+++ b/cli/src/handler.rs
@@ -69,7 +69,7 @@ impl CliHandler {
         let rpc_url = args.rpc_url.clone();
         CommitmentConfig::confirmed();
 
-        let cluster_label = args.cluster_label.clone().to_string();
+        let cluster_label = args.cluster.clone().to_string();
 
         let commitment = CommitmentConfig::from_str(&args.commitment)?;
 

--- a/cli/src/handler.rs
+++ b/cli/src/handler.rs
@@ -48,6 +48,7 @@ use switchboard_on_demand_client::SbContext;
 
 pub struct CliHandler {
     pub rpc_url: String,
+    pub cluster_label: String,
     pub commitment: CommitmentConfig,
     keypair: Option<Keypair>,
     pub restaking_program_id: Pubkey,
@@ -67,6 +68,9 @@ impl CliHandler {
     pub async fn from_args(args: &Args) -> Result<Self> {
         let rpc_url = args.rpc_url.clone();
         CommitmentConfig::confirmed();
+
+        let cluster_label = args.cluster_label.clone().to_string();
+
         let commitment = CommitmentConfig::from_str(&args.commitment)?;
 
         let keypair = args
@@ -109,6 +113,7 @@ impl CliHandler {
             rpc_client,
             retries: args.transaction_retries,
             priority_fee_micro_lamports: args.priority_fee_micro_lamports,
+            cluster_label,
         };
 
         handler.epoch = {
@@ -182,6 +187,7 @@ impl CliHandler {
                 emit_metrics,
                 metrics_only,
                 run_migration,
+                cluster_label,
             } => {
                 startup_keeper(
                     self,
@@ -192,6 +198,7 @@ impl CliHandler {
                     emit_metrics,
                     metrics_only,
                     run_migration,
+                    cluster_label.to_string(),
                 )
                 .await
             }

--- a/cli/src/handler.rs
+++ b/cli/src/handler.rs
@@ -48,7 +48,6 @@ use switchboard_on_demand_client::SbContext;
 
 pub struct CliHandler {
     pub rpc_url: String,
-    pub cluster_label: String,
     pub commitment: CommitmentConfig,
     keypair: Option<Keypair>,
     pub restaking_program_id: Pubkey,
@@ -68,8 +67,6 @@ impl CliHandler {
     pub async fn from_args(args: &Args) -> Result<Self> {
         let rpc_url = args.rpc_url.clone();
         CommitmentConfig::confirmed();
-
-        let cluster_label = args.cluster.clone().to_string();
 
         let commitment = CommitmentConfig::from_str(&args.commitment)?;
 
@@ -113,7 +110,6 @@ impl CliHandler {
             rpc_client,
             retries: args.transaction_retries,
             priority_fee_micro_lamports: args.priority_fee_micro_lamports,
-            cluster_label,
         };
 
         handler.epoch = {

--- a/cli/src/handler.rs
+++ b/cli/src/handler.rs
@@ -188,6 +188,7 @@ impl CliHandler {
                 metrics_only,
                 run_migration,
                 cluster_label,
+                region,
             } => {
                 startup_keeper(
                     self,
@@ -199,6 +200,7 @@ impl CliHandler {
                     metrics_only,
                     run_migration,
                     cluster_label.to_string(),
+                    region.to_string(),
                 )
                 .await
             }

--- a/cli/src/handler.rs
+++ b/cli/src/handler.rs
@@ -187,7 +187,7 @@ impl CliHandler {
                 emit_metrics,
                 metrics_only,
                 run_migration,
-                cluster_label,
+                cluster,
                 region,
             } => {
                 startup_keeper(
@@ -199,7 +199,7 @@ impl CliHandler {
                     emit_metrics,
                     metrics_only,
                     run_migration,
-                    cluster_label.to_string(),
+                    cluster.to_string(),
                     region.to_string(),
                 )
                 .await

--- a/cli/src/keeper/keeper_loop.rs
+++ b/cli/src/keeper/keeper_loop.rs
@@ -15,6 +15,8 @@ use crate::{
 use anyhow::Result;
 use jito_tip_router_core::epoch_state::State;
 use log::info;
+use solana_metrics::set_host_id;
+use std::process::Command;
 
 pub async fn progress_epoch(
     is_epoch_completed: bool,
@@ -81,6 +83,7 @@ pub async fn startup_keeper(
     emit_metrics: bool,
     metrics_only: bool,
     run_migration: bool,
+    cluster_label: String,
 ) -> Result<()> {
     let mut state: KeeperState = KeeperState::default();
     let mut epoch_stall = false;
@@ -94,6 +97,16 @@ pub async fn startup_keeper(
 
     let run_operations = !metrics_only && !run_migration;
     let emit_metrics = emit_metrics || metrics_only;
+
+    let hostname_cmd = Command::new("hostname")
+        .output()
+        .expect("Failed to execute hostname command");
+
+    let hostname = String::from_utf8_lossy(&hostname_cmd.stdout)
+        .trim()
+        .to_string();
+
+    set_host_id(format!("{}_{}", cluster_label, hostname));
 
     loop {
         // If there is a new epoch, this will do a full vault update on *all* vaults

--- a/cli/src/keeper/keeper_loop.rs
+++ b/cli/src/keeper/keeper_loop.rs
@@ -84,6 +84,7 @@ pub async fn startup_keeper(
     metrics_only: bool,
     run_migration: bool,
     cluster_label: String,
+    region: String,
 ) -> Result<()> {
     let mut state: KeeperState = KeeperState::default();
     let mut epoch_stall = false;
@@ -106,7 +107,10 @@ pub async fn startup_keeper(
         .trim()
         .to_string();
 
-    set_host_id(format!("{}_{}", cluster_label, hostname));
+    set_host_id(format!(
+        "tip-router-keeper_{}_{}_{}",
+        region, cluster_label, hostname
+    ));
 
     loop {
         // If there is a new epoch, this will do a full vault update on *all* vaults

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -25,6 +25,8 @@ services:
     volumes:
       - ./credentials:/credentials
     restart: on-failure:5
+    deploy:
+      replicas: 2
   jito-tip-router-ncn-keeper-metrics-only:
     build:
       context: .
@@ -76,3 +78,5 @@ services:
     volumes:
       - ./credentials:/credentials
     restart: on-failure:5
+    deploy:
+      replicas: 2

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -22,6 +22,7 @@ services:
       - METRICS_ONLY=false
       - RUN_MIGRATION=false
       - TRANSACTION_RETRIES=2
+      - REGION=${REGION}
     volumes:
       - ./credentials:/credentials
     restart: on-failure:5

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -26,8 +26,6 @@ services:
     volumes:
       - ./credentials:/credentials
     restart: on-failure:5
-    deploy:
-      replicas: 2
   jito-tip-router-ncn-keeper-metrics-only:
     build:
       context: .
@@ -79,5 +77,3 @@ services:
     volumes:
       - ./credentials:/credentials
     restart: on-failure:5
-    deploy:
-      replicas: 2

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -48,6 +48,7 @@ services:
       - EMIT_METRICS=true
       - METRICS_ONLY=true
       - RUN_MIGRATION=false
+      - REGION=${REGION}
     volumes:
       - ./credentials:/credentials
     restart: on-failure:5
@@ -74,6 +75,7 @@ services:
       - METRICS_ONLY=false
       - RUN_MIGRATION=true
       - TRANSACTION_RETRIES=5
+      - REGION=${REGION}
     volumes:
       - ./credentials:/credentials
     restart: on-failure:5

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -78,6 +78,7 @@ services:
       - RUN_MIGRATION=true
       - TRANSACTION_RETRIES=5
       - REGION=${REGION}
+      - CLUSTER=${CLUSTER}
     volumes:
       - ./credentials:/credentials
     restart: on-failure:5

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -23,6 +23,7 @@ services:
       - RUN_MIGRATION=false
       - TRANSACTION_RETRIES=2
       - REGION=${REGION}
+      - CLUSTER=${CLUSTER}
     volumes:
       - ./credentials:/credentials
     restart: on-failure:5
@@ -49,6 +50,7 @@ services:
       - METRICS_ONLY=true
       - RUN_MIGRATION=false
       - REGION=${REGION}
+      - CLUSTER=${CLUSTER}
     volumes:
       - ./credentials:/credentials
     restart: on-failure:5


### PR DESCRIPTION
**Problem**
We would like to scale up our keeper instances for redundancy purposes but lack the necessary changes to differentiate between replicas of a service from a metrics perspective.

**Solution**
- Use the `HOSTNAME` env var as a component of the `solana_metrics` `host_id` to differentiate between replicas in our monitoring systems
- Ignore RUSTSEC-2025-0022 as this is a brand new vulnerability from transitive deps and will be addressed or ignored upstream


**Local Run Log Output**
See `solana_metrics::metrics host id`
```
[2025-04-07T23:10:57Z INFO  stakenet_keeper] Stakenet Keeper Configuration:
    -------------------------------
    JSON RPC URL: INCLUDE YOUR RPC URL HERE
    Gossip Entrypoint: None
    Keypair Path: "./credentials/keypair.json"
    Oracle Authority Keypair Path: Some("./credentials/oracle_authority.json")
    Validator History Program ID: HistoryJTGbKQD2mRgLZ3XhqHnN811Qpez8X9kCcGHoa
    Tip Distribution Program ID: 4R3gSG8BpU4t19KYj8CfnbtRpnT8gtk4dvTHxVRwc2r7
    Steward Program ID: Stewardf95sJbmtcZsyagb2dg4Mo8eVQho8gpECvLx8
    Steward Config: jitoVjT9jRUyeXHzvCwzPgHj7yWNRhLcUoXtes4wtjv
    Validator History Interval: 300 seconds
    Steward Interval: 301 seconds
    Metrics Interval: 60 seconds
    Priority Fees: 20000 microlamports
    Retry Count: 100
    Confirmation Seconds: 30
    Cluster: Mainnet
    Run Cluster History: true
    Run Copy Vote Accounts: true
    Run MEV Commission: true
    Run MEV Earned: true
    Run Stake Upload: false
    Run Gossip Upload: false
    Run Steward: true
    Run Emit Metrics: false
    Full Startup: true
    No Pack: false
    Pay for New Accounts: false
    Cool Down Range: 20 minutes
    Region: localhost
    -------------------------------
    
    
[2025-04-07T23:10:57Z INFO  solana_metrics::metrics] host id: stakenet-keeper_localhost_mainnet_Erics-MBP.MG8702
```