### PR TITLE
gcp_uploader: Support epoch snapshot uploads 

### DIFF
--- a/gcp_uploader/src/main.rs
+++ b/gcp_uploader/src/main.rs
@@ -70,7 +70,7 @@ async fn main() -> Result<()> {
         "Starting file monitor in {} with {} second polling interval",
         args.directory, args.interval
     );
-    println!("Looking for files matching patterns: '*_merkle_tree_collection.json', '*_stake_meta_collection.json', and '*_meta_merkle_tree.json'");
+    println!("Looking for files matching patterns: '*_merkle_tree_collection.json', '*_stake_meta_collection.json', and 'snapshot-*-*.tar.zst'");
 
     // Main monitoring loop
     loop {


### PR DESCRIPTION
**Problem**
We would like to support the uploading of epoch snapshot files to GCP via the tip-router gcp_uploader. At the moment, there is no support for this filename pattern in the uploader logic.

**Solution**
- Change `scan_and_upload_files` to accept a slice of `&Regex` rather than individual regex args for extensibility
- Add `Regex::new(r"^snapshot-\d+-[a-zA-Z0-9]+-.*\.tar\.zst$")` to the list of regex passed to `scan_and_upload_files`