### PR TITLE
gcp_uploader: Update monitor merkle uploads service

### DIFF
--- a/gcp_uploader/monitor-merkle-uploads.service
+++ b/gcp_uploader/monitor-merkle-uploads.service
@@ -5,8 +5,9 @@ After=network.target
 [Service]
 Type=simple
 User=core
-ExecStart=/home/core/gcp_uploader \
+ExecStart=/home/core/jito-tip-router/target/release/gcp_uploader \
     --directory /solana/snapshots/operator-saves \
+    --snapshot-directory /solana/snapshots/autosnapshot \
     --cluster mainnet \
     --interval 600
 Restart=always


### PR DESCRIPTION
**Problem**
The monitor merkle uploads service config file has drifted from the required arguments of the underlying service.

**Solution**
- Correct the path of the executable
- Add `snapshot-directory` arg with value `/solana/snapshots/autosnapshot`