### PR TITLE
operator: Emit cluster tag in metrics

### DIFF
--- a/cli/src/keeper/keeper_loop.rs
+++ b/cli/src/keeper/keeper_loop.rs
@@ -52,13 +52,14 @@ pub async fn check_and_timeout_error<T>(
     result: &Result<T>,
     error_timeout_ms: u64,
     keeper_epoch: u64,
+    cluster_name: &str,
 ) -> bool {
     if let Err(e) = result {
         let error = format!("{:?}", e);
         let message = format!("Error: [{}] \n{}\n\n", title, error);
 
         log::error!("{}", message);
-        emit_error(title, error, message, keeper_epoch).await;
+        emit_error(title, error, message, keeper_epoch, cluster_name).await;
         timeout_error(error_timeout_ms).await;
         true
     } else {
@@ -89,7 +90,7 @@ pub async fn startup_keeper(
     emit_metrics: bool,
     metrics_only: bool,
     run_migration: bool,
-    cluster_label: String,
+    cluster_name: String,
     region: String,
 ) -> Result<()> {
     let mut state: KeeperState = KeeperState::default();
@@ -115,7 +116,7 @@ pub async fn startup_keeper(
 
     set_host_id(format!(
         "tip-router-keeper_{}_{}_{}",
-        region, cluster_label, hostname
+        region, cluster_name, hostname
     ));
 
     loop {
@@ -130,6 +131,7 @@ pub async fn startup_keeper(
                 &result,
                 error_timeout_ms,
                 state.epoch,
+                &cluster_name,
             )
             .await
             {
@@ -177,13 +179,14 @@ pub async fn startup_keeper(
         // This includes validators info, epoch info, ticket states and more
         if emit_metrics {
             info!("\n\nB. Emit NCN Metrics - {}\n", current_keeper_epoch);
-            let result = emit_ncn_metrics(handler, start_of_loop).await;
+            let result = emit_ncn_metrics(handler, start_of_loop, &cluster_name).await;
 
             check_and_timeout_error(
                 "Emit NCN Metrics".to_string(),
                 &result,
                 error_timeout_ms,
                 state.epoch,
+                &cluster_name,
             )
             .await;
         }
@@ -200,6 +203,7 @@ pub async fn startup_keeper(
                 &result,
                 error_timeout_ms,
                 state.epoch,
+                &cluster_name,
             )
             .await
             {
@@ -219,6 +223,7 @@ pub async fn startup_keeper(
                     &result,
                     error_timeout_ms,
                     state.epoch,
+                    &cluster_name,
                 )
                 .await
                 {
@@ -238,6 +243,7 @@ pub async fn startup_keeper(
                 &result,
                 error_timeout_ms,
                 state.epoch,
+                &cluster_name,
             )
             .await
             {
@@ -268,6 +274,7 @@ pub async fn startup_keeper(
                     &result,
                     error_timeout_ms,
                     state.epoch,
+                    &cluster_name,
                 )
                 .await;
 
@@ -296,6 +303,7 @@ pub async fn startup_keeper(
                 &result,
                 error_timeout_ms,
                 state.epoch,
+                &cluster_name,
             )
             .await;
         }
@@ -323,6 +331,7 @@ pub async fn startup_keeper(
                 &result,
                 error_timeout_ms,
                 state.epoch,
+                &cluster_name,
             )
             .await
             {
@@ -333,13 +342,14 @@ pub async fn startup_keeper(
         // Emits metrics for the Epoch State
         if emit_metrics {
             info!("\n\nD. Emit Epoch Metrics - {}\n", current_keeper_epoch);
-            let result = emit_epoch_metrics(handler, state.epoch).await;
+            let result = emit_epoch_metrics(handler, state.epoch, &cluster_name).await;
 
             check_and_timeout_error(
                 "Emit NCN Metrics".to_string(),
                 &result,
                 error_timeout_ms,
                 state.epoch,
+                &cluster_name,
             )
             .await;
         }
@@ -358,6 +368,7 @@ pub async fn startup_keeper(
                 &result,
                 error_timeout_ms,
                 state.epoch,
+                &cluster_name,
             )
             .await
             {
@@ -376,7 +387,14 @@ pub async fn startup_keeper(
             info!("\n\nF. Timeout - {}\n", current_keeper_epoch);
 
             timeout_keeper(loop_timeout_ms).await;
-            emit_heartbeat(tick, run_operations, emit_metrics, run_migration).await;
+            emit_heartbeat(
+                tick,
+                run_operations,
+                emit_metrics,
+                run_migration,
+                &cluster_name,
+            )
+            .await;
             tick += 1;
         }
     }

--- a/cli/src/keeper/keeper_loop.rs
+++ b/cli/src/keeper/keeper_loop.rs
@@ -377,6 +377,15 @@ pub async fn startup_keeper(
 
             epoch_stall = !run_operations || result.unwrap();
 
+            emit_heartbeat(
+                tick,
+                run_operations,
+                emit_metrics,
+                run_migration,
+                &cluster_name,
+            )
+            .await;
+
             if epoch_stall {
                 info!("\n\nSTALL DETECTED FOR {}\n\n", current_keeper_epoch);
             }
@@ -387,14 +396,6 @@ pub async fn startup_keeper(
             info!("\n\nF. Timeout - {}\n", current_keeper_epoch);
 
             timeout_keeper(loop_timeout_ms).await;
-            emit_heartbeat(
-                tick,
-                run_operations,
-                emit_metrics,
-                run_migration,
-                &cluster_name,
-            )
-            .await;
             tick += 1;
         }
     }

--- a/tip-router-operator-cli/src/cli.rs
+++ b/tip-router-operator-cli/src/cli.rs
@@ -47,6 +47,12 @@ pub struct Cli {
     #[deprecated(since = "1.1.0", note = "use --save-path instead")]
     pub meta_merkle_tree_dir: Option<PathBuf>,
 
+    #[arg(long, env, default_value = "mainnet")]
+    pub cluster: String,
+
+    #[arg(long, env, default_value = "local")]
+    pub region: String,
+
     #[command(subcommand)]
     pub command: Commands,
 }

--- a/tip-router-operator-cli/src/ledger_utils.rs
+++ b/tip-router-operator-cli/src/ledger_utils.rs
@@ -52,6 +52,7 @@ pub fn get_bank_from_ledger(
     desired_slot: &Slot,
     save_snapshot: bool,
     snapshot_save_path: PathBuf,
+    cluster: &str,
 ) -> Arc<Bank> {
     let start_time = Instant::now();
 
@@ -62,6 +63,8 @@ pub fn get_bank_from_ledger(
         ("state", "validate_path_start", String),
         ("step", 0, i64),
         ("version", Version::default().to_string(), String),
+        ("duration_ms", start_time.elapsed().as_millis() as i64, i64),
+        "cluster" => cluster
     );
 
     // STEP 1: Load genesis config //
@@ -72,6 +75,7 @@ pub fn get_bank_from_ledger(
         ("state", "load_genesis_start", String),
         ("step", 1, i64),
         ("duration_ms", start_time.elapsed().as_millis() as i64, i64),
+        "cluster" => cluster
     );
 
     let genesis_config = match open_genesis_config(ledger_path, MAX_GENESIS_ARCHIVE_UNPACKED_SIZE) {
@@ -84,6 +88,7 @@ pub fn get_bank_from_ledger(
                 ("state", "load_genesis", String),
                 ("step", 1, i64),
                 ("error", format!("{:?}", e), String),
+                "cluster" => cluster,
             );
             panic!("Failed to load genesis config: {}", e); // TODO should panic here?
         }
@@ -97,6 +102,7 @@ pub fn get_bank_from_ledger(
         ("state", "load_blockstore_start", String),
         ("step", 2, i64),
         ("duration_ms", start_time.elapsed().as_millis() as i64, i64),
+        "cluster" => cluster
     );
 
     let access_type = AccessType::Secondary;
@@ -144,6 +150,7 @@ pub fn get_bank_from_ledger(
                 ("step", 2, i64),
                 ("error", error_str, String),
                 ("duration_ms", start_time.elapsed().as_millis() as i64, i64),
+                "cluster" => cluster,
             );
             panic!("{}", error_str);
         }
@@ -157,6 +164,7 @@ pub fn get_bank_from_ledger(
                 ("step", 2, i64),
                 ("error", error_str, String),
                 ("duration_ms", start_time.elapsed().as_millis() as i64, i64),
+                "cluster" => cluster,
             );
             panic!("{}", error_str);
         }
@@ -182,6 +190,7 @@ pub fn get_bank_from_ledger(
         ("state", "load_snapshot_config_start", String),
         ("step", 3, i64),
         ("duration_ms", start_time.elapsed().as_millis() as i64, i64),
+        "cluster" => cluster
     );
 
     let snapshot_config = SnapshotConfig {
@@ -228,6 +237,7 @@ pub fn get_bank_from_ledger(
                     ("step", 2, i64),
                     ("error", error_str, String),
                     ("duration_ms", start_time.elapsed().as_millis() as i64, i64),
+                    "cluster" => cluster,
                 );
                 panic!("{}", error_str);
             }
@@ -243,6 +253,7 @@ pub fn get_bank_from_ledger(
                     ("step", 2, i64),
                     ("error", error_str, String),
                     ("duration_ms", start_time.elapsed().as_millis() as i64, i64),
+                    "cluster" => cluster,
                 );
                 panic!("{}", error_str);
             }
@@ -268,6 +279,7 @@ pub fn get_bank_from_ledger(
             Some(full_snapshots_path),
             Some(incremental_snapshots_path),
             operator_address.clone(),
+            cluster,
         ) {
             Ok(res) => res,
             Err(e) => {
@@ -279,6 +291,7 @@ pub fn get_bank_from_ledger(
                     ("step", 4, i64),
                     ("error", format!("{:?}", e), String),
                     ("duration_ms", start_time.elapsed().as_millis() as i64, i64),
+                    "cluster" => cluster,
                 );
                 panic!("Failed to load bank forks: {}", e);
             }
@@ -359,6 +372,7 @@ pub fn get_bank_from_ledger(
         ("bank_hash", working_bank.hash().to_string(), String),
         ("step", 5, i64),
         ("duration_ms", start_time.elapsed().as_millis() as i64, i64),
+        "cluster" => cluster,
     );
 
     exit.store(true, Ordering::Relaxed);
@@ -384,6 +398,7 @@ pub fn get_bank_from_ledger(
                     ("step", 6, i64),
                     ("error", format!("{:?}", e), String),
                     ("duration_ms", start_time.elapsed().as_millis() as i64, i64),
+                    "cluster" => cluster,
                 );
                 panic!("Failed to create snapshot: {}", e);
             }
@@ -412,6 +427,7 @@ pub fn get_bank_from_ledger(
         ("state", "get_bank_from_ledger_success", String),
         ("step", 6, i64),
         ("duration_ms", start_time.elapsed().as_millis() as i64, i64),
+        "cluster" => cluster,
     );
     working_bank
 }
@@ -523,6 +539,7 @@ mod tests {
             &desired_slot,
             true,
             full_snapshots_path.clone(),
+            "mainnet",
         );
         assert_eq!(res.slot(), desired_slot);
         // Assert that the snapshot was created

--- a/tip-router-operator-cli/src/lib.rs
+++ b/tip-router-operator-cli/src/lib.rs
@@ -207,6 +207,7 @@ pub fn load_bank_from_snapshot(cli: Cli, slot: u64, save_snapshot: bool) -> Arc<
 }
 
 // STAGE 2 CreateStakeMeta
+#[allow(clippy::too_many_arguments)]
 pub fn create_stake_meta(
     operator_address: String,
     epoch: u64,

--- a/tip-router-operator-cli/src/lib.rs
+++ b/tip-router-operator-cli/src/lib.rs
@@ -202,6 +202,7 @@ pub fn load_bank_from_snapshot(cli: Cli, slot: u64, save_snapshot: bool) -> Arc<
         &slot,
         save_snapshot,
         backup_snapshots_dir,
+        &cli.cluster,
     )
 }
 
@@ -214,6 +215,7 @@ pub fn create_stake_meta(
     tip_payment_program_id: &Pubkey,
     save_path: &Path,
     save: bool,
+    cluster: &str,
 ) -> StakeMetaCollection {
     let start = Instant::now();
 
@@ -233,7 +235,8 @@ pub fn create_stake_meta(
                 ("status", "error", String),
                 ("error", error_str, String),
                 ("state", "stake_meta_generation", String),
-                ("duration_ms", start.elapsed().as_millis() as i64, i64)
+                ("duration_ms", start.elapsed().as_millis() as i64, i64),
+                "cluster" => cluster,
             );
             panic!("{}", error_str);
         }
@@ -259,7 +262,8 @@ pub fn create_stake_meta(
         ("state", "create_stake_meta", String),
         ("step", 2, i64),
         ("epoch", stake_meta_coll.epoch, i64),
-        ("duration_ms", start.elapsed().as_millis() as i64, i64)
+        ("duration_ms", start.elapsed().as_millis() as i64, i64),
+        "cluster" => cluster,
     );
     stake_meta_coll
 }
@@ -275,6 +279,7 @@ pub fn create_merkle_tree_collection(
     protocol_fee_bps: u64,
     save_path: &Path,
     save: bool,
+    cluster: &str,
 ) -> GeneratedMerkleTreeCollection {
     let start = Instant::now();
 
@@ -296,7 +301,8 @@ pub fn create_merkle_tree_collection(
                 ("status", "error", String),
                 ("error", error_str, String),
                 ("state", "merkle_tree_generation", String),
-                ("duration_ms", start.elapsed().as_millis() as i64, i64)
+                ("duration_ms", start.elapsed().as_millis() as i64, i64),
+                "cluster" => cluster
             );
             panic!("{}", error_str);
         }
@@ -324,7 +330,8 @@ pub fn create_merkle_tree_collection(
                     ("status", "error", String),
                     ("error", error_str, String),
                     ("state", "merkle_root_file_write", String),
-                    ("duration_ms", start.elapsed().as_millis() as i64, i64)
+                    ("duration_ms", start.elapsed().as_millis() as i64, i64),
+                    "cluster" => cluster
                 );
                 panic!("{:?}", e);
             }
@@ -336,7 +343,8 @@ pub fn create_merkle_tree_collection(
         ("state", "meta_merkle_tree_creation", String),
         ("step", 3, i64),
         ("epoch", epoch, i64),
-        ("duration_ms", start.elapsed().as_millis() as i64, i64)
+        ("duration_ms", start.elapsed().as_millis() as i64, i64),
+        "cluster" => cluster
     );
     merkle_tree_coll
 }
@@ -348,6 +356,7 @@ pub fn create_meta_merkle_tree(
     epoch: u64,
     save_path: &Path,
     save: bool,
+    cluster: &str,
 ) -> MetaMerkleTree {
     let start = Instant::now();
     let meta_merkle_tree =
@@ -362,7 +371,8 @@ pub fn create_meta_merkle_tree(
                     ("status", "error", String),
                     ("error", error_str, String),
                     ("state", "merkle_tree_generation", String),
-                    ("duration_ms", start.elapsed().as_millis() as i64, i64)
+                    ("duration_ms", start.elapsed().as_millis() as i64, i64),
+                    "cluster" => cluster,
                 );
                 panic!("{}", error_str);
             }
@@ -388,7 +398,8 @@ pub fn create_meta_merkle_tree(
                     ("status", "error", String),
                     ("error", error_str, String),
                     ("state", "merkle_root_file_write", String),
-                    ("duration_ms", start.elapsed().as_millis() as i64, i64)
+                    ("duration_ms", start.elapsed().as_millis() as i64, i64),
+                    "cluster" => cluster,
                 );
                 panic!("{:?}", e);
             }
@@ -401,7 +412,8 @@ pub fn create_meta_merkle_tree(
         ("state", "meta_merkle_tree_creation", String),
         ("step", 4, i64),
         ("epoch", epoch, i64),
-        ("duration_ms", start.elapsed().as_millis() as i64, i64)
+        ("duration_ms", start.elapsed().as_millis() as i64, i64),
+        "cluster" => cluster,
     );
 
     meta_merkle_tree

--- a/tip-router-operator-cli/src/load_and_process_ledger.rs
+++ b/tip-router-operator-cli/src/load_and_process_ledger.rs
@@ -118,6 +118,7 @@ pub enum LoadAndProcessLedgerError {
 //     })
 // }
 
+#[allow(clippy::too_many_arguments)]
 pub fn load_and_process_ledger(
     arg_matches: &ArgMatches,
     genesis_config: &GenesisConfig,

--- a/tip-router-operator-cli/src/load_and_process_ledger.rs
+++ b/tip-router-operator-cli/src/load_and_process_ledger.rs
@@ -126,6 +126,7 @@ pub fn load_and_process_ledger(
     snapshot_archive_path: Option<PathBuf>,
     incremental_snapshot_archive_path: Option<PathBuf>,
     operator_address: String,
+    cluster: &str,
 ) -> Result<(Arc<RwLock<BankForks>>, Option<StartingSnapshotHashes>), LoadAndProcessLedgerError> {
     let bank_snapshots_dir = if blockstore.is_primary_access() {
         blockstore.ledger_path().join("snapshot")
@@ -404,6 +405,7 @@ pub fn load_and_process_ledger(
         ("operator", operator_address, String),
         ("state", "process_blockstore_from_root_start", String),
         ("step", 4, i64),
+        "cluster" => cluster,
     );
 
     let result = blockstore_processor::process_blockstore_from_root(

--- a/tip-router-operator-cli/src/process_epoch.rs
+++ b/tip-router-operator-cli/src/process_epoch.rs
@@ -174,7 +174,8 @@ pub async fn loop_stages(
                                 ("status", "error", String),
                                 ("error", e.to_string(), String),
                                 ("state", "create_stake_meta", String),
-                                ("duration_ms", start.elapsed().as_millis() as i64, i64)
+                                ("duration_ms", start.elapsed().as_millis() as i64, i64),
+                                "cluster" => &cli.cluster,
                             );
                             panic!("{}", e.to_string());
                         }
@@ -188,6 +189,7 @@ pub async fn loop_stages(
                     tip_payment_program_id,
                     &cli.get_save_path(),
                     save_stages,
+                    &cli.cluster,
                 ));
                 // we should be able to safely drop the bank in this loop
                 bank = None;
@@ -217,6 +219,7 @@ pub async fn loop_stages(
                     protocol_fee_bps,
                     &cli.get_save_path(),
                     save_stages,
+                    &cli.cluster,
                 ));
 
                 stake_meta_collection = None;
@@ -237,6 +240,7 @@ pub async fn loop_stages(
                     // This is defaulted to true because the output file is required by the
                     //  task that sets TipDistributionAccounts' merkle roots
                     true,
+                    &cli.cluster,
                 );
                 datapoint_info!(
                     "tip_router_cli.process_epoch",
@@ -250,6 +254,7 @@ pub async fn loop_stages(
                         String
                     ),
                     ("version", Version::default().to_string(), String),
+                    "cluster" => &cli.cluster,
                 );
                 stage = OperatorState::CastVote;
             }
@@ -270,6 +275,7 @@ pub async fn loop_stages(
                     cli.submit_as_memo,
                     // We let the submit task handle setting merkle roots
                     false,
+                    &cli.cluster,
                 )
                 .await?;
                 stage = OperatorState::WaitForNextEpoch;

--- a/tip-router-operator-cli/src/submit.rs
+++ b/tip-router-operator-cli/src/submit.rs
@@ -59,6 +59,7 @@ pub async fn submit_recent_epochs_to_ncn(
             tip_distribution_program_id,
             cli_args.submit_as_memo,
             set_merkle_roots,
+            &cli_args.cluster,
         )
         .await
         {
@@ -82,6 +83,7 @@ pub async fn submit_to_ncn(
     tip_distribution_program_id: &Pubkey,
     submit_as_memo: bool,
     set_merkle_roots: bool,
+    cluster: &str,
 ) -> Result<(), anyhow::Error> {
     let epoch_info = client.get_epoch_info().await?;
     let meta_merkle_tree = MetaMerkleTree::new_from_file(meta_merkle_tree_path)?;
@@ -171,7 +173,8 @@ pub async fn submit_to_ncn(
                         String
                     ),
                     ("version", Version::default().to_string(), String),
-                    ("tx_sig", format!("{:?}", signature), String)
+                    ("tx_sig", format!("{:?}", signature), String),
+                    "cluster" => cluster,
                 );
                 info!(
                     "Cast vote for epoch {} with signature {:?}",
@@ -189,7 +192,8 @@ pub async fn submit_to_ncn(
                         String
                     ),
                     ("status", "error", String),
-                    ("error", format!("{:?}", e), String)
+                    ("error", format!("{:?}", e), String),
+                    "cluster" => cluster,
                 );
                 info!(
                     "Failed to cast vote for epoch {}: {:?}",
@@ -237,7 +241,8 @@ pub async fn submit_to_ncn(
                     ("operator_address", operator_address.to_string(), String),
                     ("epoch", tip_router_target_epoch, i64),
                     ("num_success", num_success, i64),
-                    ("num_failed", num_failed, i64)
+                    ("num_failed", num_failed, i64),
+                    "cluster" => cluster,
                 );
                 info!(
                     "Set merkle root for {} tip distribution accounts, failed for {}",
@@ -250,7 +255,8 @@ pub async fn submit_to_ncn(
                     ("operator_address", operator_address.to_string(), String),
                     ("epoch", tip_router_target_epoch, i64),
                     ("status", "error", String),
-                    ("error", format!("{:?}", e), String)
+                    ("error", format!("{:?}", e), String),
+                    "cluster" => cluster,
                 );
                 error!("Failed to set merkle roots: {:?}", e);
             }


### PR DESCRIPTION
**Problem**
We would like to differentiate between instances of tip-router-operator running in against different clusters within our metrics yet lack the ability to do so.

**Solution**
- Differentiate between hosts within the same region/cluster by creating the host_id as "{service_name}_{cluster}_{region}_{hostname}"
- Wire the `cluster` of the operator into the emitted metrics as a tag