### PR TITLE
fix: Handle case where old logic should be used prior to start epoch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "tip-router-operator-cli/repo-at-older-commit"]
+	path = tip-router-operator-cli/repo-at-older-commit
+	url = https://github.com/jito-foundation/jito-tip-router.git
+	branch = tj/branch-v1.2.0-operator

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "tip-router-operator-cli/repo-at-older-commit"]
 	path = tip-router-operator-cli/repo-at-older-commit
 	url = https://github.com/jito-foundation/jito-tip-router.git
-	branch = tj/branch-v1.2.0-operator
+	branch = v1.2.0-operator-legacy

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4171,6 +4171,90 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
+name = "legacy-meta-merkle-tree"
+version = "0.0.1"
+dependencies = [
+ "anchor-lang 0.30.1",
+ "borsh 0.10.4",
+ "bytemuck",
+ "fast-math",
+ "hex",
+ "jito-bytemuck",
+ "jito-jsm-core",
+ "jito-restaking-core",
+ "jito-restaking-sdk",
+ "jito-tip-distribution-sdk",
+ "jito-tip-payment-sdk",
+ "jito-vault-core",
+ "jito-vault-sdk",
+ "log",
+ "rand 0.8.5",
+ "serde",
+ "serde_json",
+ "shank",
+ "solana-program",
+ "solana-sdk",
+ "spl-associated-token-account 6.0.0",
+ "spl-math",
+ "spl-token 7.0.0",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "legacy-tip-router-operator-cli"
+version = "1.2.0"
+dependencies = [
+ "anchor-lang 0.30.1",
+ "anyhow",
+ "base64 0.13.1",
+ "clap 2.34.0",
+ "clap 4.5.23",
+ "crossbeam-channel",
+ "ellipsis-client",
+ "env_logger 0.10.2",
+ "hex",
+ "im",
+ "itertools 0.11.0",
+ "jito-bytemuck",
+ "jito-tip-distribution-sdk",
+ "jito-tip-payment-sdk",
+ "jito-tip-router-client",
+ "jito-tip-router-core",
+ "jito-tip-router-program",
+ "legacy-meta-merkle-tree",
+ "log",
+ "rand 0.8.5",
+ "serde",
+ "serde_json",
+ "solana-account-decoder",
+ "solana-accounts-db",
+ "solana-clap-utils",
+ "solana-client",
+ "solana-core",
+ "solana-geyser-plugin-manager",
+ "solana-gossip",
+ "solana-ledger",
+ "solana-measure",
+ "solana-metrics",
+ "solana-program",
+ "solana-program-test",
+ "solana-rpc",
+ "solana-rpc-client",
+ "solana-rpc-client-api",
+ "solana-runtime",
+ "solana-sdk",
+ "solana-stake-program",
+ "solana-streamer",
+ "solana-transaction-status",
+ "solana-unified-scheduler-pool",
+ "solana-vote",
+ "spl-memo 6.0.0",
+ "tempfile",
+ "thiserror 1.0.69",
+ "tokio",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.169"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10277,6 +10361,7 @@ dependencies = [
  "jito-tip-router-client",
  "jito-tip-router-core",
  "jito-tip-router-program",
+ "legacy-tip-router-operator-cli",
  "log",
  "meta-merkle-tree",
  "rand 0.8.5",

--- a/tip-router-operator-cli/Cargo.toml
+++ b/tip-router-operator-cli/Cargo.toml
@@ -23,6 +23,7 @@ jito-tip-payment-sdk = { workspace = true }
 jito-tip-router-client = { workspace = true }
 jito-tip-router-core = { workspace = true }
 jito-tip-router-program = { workspace = true }
+legacy-tip-router-operator-cli = { package = "legacy-tip-router-operator-cli", path = "./repo-at-older-commit/tip-router-operator-cli" }
 log = { workspace = true }
 meta-merkle-tree = { workspace = true }
 rand = { workspace = true }

--- a/tip-router-operator-cli/src/main.rs
+++ b/tip-router-operator-cli/src/main.rs
@@ -295,6 +295,39 @@ async fn main() -> Result<()> {
                 });
             }
 
+            // If before the new stake meta epoch, use the old loop stages. This old loop
+            // stages will break once it hits the configured priority fee go live date
+            let current_epoch_info = rpc_client.get_epoch_info().await?;
+            let snapshot_paths = cli.get_snapshot_paths();
+            if current_epoch_info.epoch
+                < legacy_tip_router_operator_cli::PRIORITY_FEE_MERKLE_TREE_START_EPOCH
+            {
+                let save_path = cli.get_save_path();
+                legacy_tip_router_operator_cli::process_epoch::loop_stages(
+                    rpc_client.clone(),
+                    cli.keypair_path.clone(),
+                    cli.operator_address.clone(),
+                    legacy_tip_router_operator_cli::cli::SnapshotPaths {
+                        ledger_path: snapshot_paths.ledger_path,
+                        account_paths: snapshot_paths.account_paths,
+                        full_snapshots_path: snapshot_paths.full_snapshots_path,
+                        incremental_snapshots_path: snapshot_paths.incremental_snapshots_path,
+                        backup_snapshots_dir: snapshot_paths.backup_snapshots_dir,
+                    },
+                    save_path,
+                    cli.submit_as_memo,
+                    legacy_tip_router_operator_cli::OperatorState::WaitForNextEpoch,
+                    override_target_slot,
+                    &tip_router_program_id,
+                    &tip_distribution_program_id,
+                    &tip_payment_program_id,
+                    &ncn_address,
+                    save_snapshot,
+                    save_stages,
+                )
+                .await?;
+            }
+
             // Endless loop that transitions between stages of the operator process.
             process_epoch::loop_stages(
                 rpc_client,


### PR DESCRIPTION
* Relies on a submodule for using the legacy process_epoch code