### PR TITLE
operator: confirm cast_vote transactions

### DIFF
--- a/tip-router-operator-cli/src/tip_router.rs
+++ b/tip-router-operator-cli/src/tip_router.rs
@@ -43,7 +43,7 @@ pub async fn cast_vote(
     meta_merkle_root: [u8; 32],
     tip_router_epoch: u64,
     submit_as_memo: bool,
-) -> EllipsisClientResult<Signature> {
+) -> Result<Signature> {
     let epoch_state =
         EpochState::find_program_address(tip_router_program_id, ncn, tip_router_epoch).0;
 
@@ -82,10 +82,9 @@ pub async fn cast_vote(
 
     info!("Submitting meta merkle root {:?}", meta_merkle_root);
 
-    let tx = Transaction::new_with_payer(&[ix], Some(&payer.pubkey()));
-    client
-        .process_transaction(tx, &[payer, operator_voter])
-        .await
+    let mut tx = Transaction::new_with_payer(&[ix], Some(&payer.pubkey()));
+    tx.sign(&[payer, operator_voter], client.fetch_latest_blockhash().await?);
+    Ok(client.send_and_confirm_transaction(&tx).await?)
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/tip-router-operator-cli/src/tip_router.rs
+++ b/tip-router-operator-cli/src/tip_router.rs
@@ -83,7 +83,10 @@ pub async fn cast_vote(
     info!("Submitting meta merkle root {:?}", meta_merkle_root);
 
     let mut tx = Transaction::new_with_payer(&[ix], Some(&payer.pubkey()));
-    tx.sign(&[payer, operator_voter], client.fetch_latest_blockhash().await?);
+    tx.sign(
+        &[payer, operator_voter],
+        client.fetch_latest_blockhash().await?,
+    );
     Ok(client.send_and_confirm_transaction(&tx).await?)
 }
 

--- a/tip-router-operator-cli/src/tip_router.rs
+++ b/tip-router-operator-cli/src/tip_router.rs
@@ -82,8 +82,9 @@ pub async fn cast_vote(
 
     info!("Submitting meta merkle root {:?}", meta_merkle_root);
 
-    let mut tx = Transaction::new_with_payer(&[ix], Some(&payer.pubkey()));
-    tx.sign(
+    let tx = Transaction::new_signed_with_payer(
+        &[ix],
+        Some(&payer.pubkey()),
         &[payer, operator_voter],
         client.fetch_latest_blockhash().await?,
     );


### PR DESCRIPTION
**Problem**
Tip router operator performs process_transaction which returns as an `Ok` when the transaction is successfully submitted to the validator with no regard for commitment and confirmation. As a result, `cast_vote` metrics do not reflect the actual success rate of the operation.

**Solution**
- Use the `send_and_confirm_transaction` function in `cast_vote` to get the function's return value 
- Existing calling logic will correctly report votes that fail to land