### PR TITLE
operator: emit heartbeats without blocking steps

### DIFF
--- a/tip-router-operator-cli/src/main.rs
+++ b/tip-router-operator-cli/src/main.rs
@@ -82,16 +82,6 @@ async fn main() -> Result<()> {
         "cluster" => &cli.cluster,
     );
 
-    tokio::spawn(async move {
-        loop {
-            datapoint_info!(
-                "tip_router_cli.heartbeat",
-                ("host_id", host_id.clone(), String),
-            );
-            sleep(Duration::from_secs(60)).await;
-        }
-    });
-
     // Will panic if the user did not set --save-path or the deprecated --meta-merkle-tree-dir
     let save_path = cli.get_save_path();
 
@@ -166,6 +156,19 @@ async fn main() -> Result<()> {
                 );
                 std::fs::create_dir_all(&backup_snapshots_dir)?;
             }
+
+            let operator_address = cli.operator_address.clone();
+            let cluster = cli.cluster.clone();
+            tokio::spawn(async move {
+                loop {
+                    datapoint_info!(
+                        "tip_router_cli.heartbeat",
+                        ("operator_address", operator_address, String),
+                        "cluster" => cluster,
+                    );
+                    sleep(Duration::from_secs(60)).await;
+                }
+            });
 
             // Check for new meta merkle trees and submit to NCN periodically
             tokio::spawn(async move {

--- a/tip-router-operator-cli/src/main.rs
+++ b/tip-router-operator-cli/src/main.rs
@@ -82,6 +82,16 @@ async fn main() -> Result<()> {
         "cluster" => &cli.cluster,
     );
 
+    tokio::spawn(async move {
+        loop {
+            datapoint_info!(
+                "tip_router_cli.heartbeat",
+                ("host_id", host_id.clone(), String),
+            );
+            sleep(Duration::from_secs(60)).await;
+        }
+    });
+
     // Will panic if the user did not set --save-path or the deprecated --meta-merkle-tree-dir
     let save_path = cli.get_save_path();
 


### PR DESCRIPTION
**Problem**
There is a scenario where our alerts are falsely suggesting operator downtime due to the logic surrounding metrics emit calls.

**Solution**
- Emit a heartbeat metric in its own periodic looping tokio task