### PR TITLE
operator: tidy up logs - use datapoint_trace for heartbeat

### DIFF
--- a/tip-router-operator-cli/src/main.rs
+++ b/tip-router-operator-cli/src/main.rs
@@ -4,7 +4,7 @@ use ::{
     clap::Parser,
     ellipsis_client::EllipsisClient,
     log::{error, info},
-    solana_metrics::{datapoint_error, datapoint_info, set_host_id},
+    solana_metrics::{datapoint_error, datapoint_info, datapoint_trace, set_host_id},
     solana_rpc_client::nonblocking::rpc_client::RpcClient,
     solana_sdk::{pubkey::Pubkey, signer::keypair::read_keypair_file},
     std::process::Command,
@@ -161,7 +161,7 @@ async fn main() -> Result<()> {
             let cluster = cli.cluster.clone();
             tokio::spawn(async move {
                 loop {
-                    datapoint_info!(
+                    datapoint_trace!(
                         "tip_router_cli.heartbeat",
                         ("operator_address", operator_address, String),
                         "cluster" => cluster,


### PR DESCRIPTION
**Problem**

Using `datapoint_info` to emit heartbeat metrics makes the logs noisy.

**Solution**
- s/datapoint_info/datapoint_trace for the heartbeat task

