### PR TITLE
fix: move catchup to load bank, make heartbeat configurable

### DIFF
--- a/tip-router-operator-cli/src/cli.rs
+++ b/tip-router-operator-cli/src/cli.rs
@@ -56,6 +56,9 @@ pub struct Cli {
     #[arg(long, env, default_value = "8899")]
     pub localhost_port: u16,
 
+    #[arg(long, env, default_value = "900")]
+    pub heartbeat_interval_seconds: u64,
+
     #[command(subcommand)]
     pub command: Commands,
 }

--- a/tip-router-operator-cli/src/main.rs
+++ b/tip-router-operator-cli/src/main.rs
@@ -25,6 +25,7 @@ use ::{
     tokio::{sync::Mutex, time::sleep},
 };
 
+
 #[tokio::main]
 async fn main() -> Result<()> {
     env_logger::init();
@@ -166,7 +167,7 @@ async fn main() -> Result<()> {
                         ("operator_address", operator_address, String),
                         "cluster" => cluster,
                     );
-                    sleep(Duration::from_secs(60)).await;
+                    sleep(Duration::from_secs(cli.heartbeat_interval_seconds)).await;
                 }
             });
 
@@ -356,7 +357,7 @@ async fn main() -> Result<()> {
 
                         // Sleep before the next iteration
                         info!("Sleeping for 30 minutes before next claim cycle");
-                        sleep(Duration::from_secs(1800)).await;
+                        sleep(Duration::from_secs(900)).await;
                     }
                 });
             }

--- a/tip-router-operator-cli/src/main.rs
+++ b/tip-router-operator-cli/src/main.rs
@@ -4,7 +4,7 @@ use ::{
     clap::Parser,
     ellipsis_client::EllipsisClient,
     log::{error, info},
-    solana_metrics::{datapoint_error, datapoint_info, datapoint_trace, set_host_id},
+    solana_metrics::{datapoint_error, datapoint_info, set_host_id},
     solana_rpc_client::nonblocking::rpc_client::RpcClient,
     solana_sdk::{pubkey::Pubkey, signer::keypair::read_keypair_file},
     std::process::Command,
@@ -24,7 +24,6 @@ use ::{
     },
     tokio::{sync::Mutex, time::sleep},
 };
-
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -162,7 +161,7 @@ async fn main() -> Result<()> {
             let cluster = cli.cluster.clone();
             tokio::spawn(async move {
                 loop {
-                    datapoint_trace!(
+                    datapoint_info!(
                         "tip_router_cli.heartbeat",
                         ("operator_address", operator_address, String),
                         "cluster" => cluster,

--- a/tip-router-operator-cli/src/process_epoch.rs
+++ b/tip-router-operator-cli/src/process_epoch.rs
@@ -131,6 +131,26 @@ pub async fn loop_stages(
     loop {
         match stage {
             OperatorState::LoadBankFromSnapshot => {
+                info!("Ensuring localhost RPC is caught up with remote validator...");
+
+                let try_catchup =
+                    crate::solana_cli::catchup(cli.rpc_url.to_owned(), cli.localhost_port);
+                if let Err(ref e) = try_catchup {
+                    datapoint_error!(
+                        "tip_router_cli.load_bank_from_snapshot",
+                        ("operator_address", operator_address, String),
+                        ("epoch", epoch_to_process, i64),
+                        ("status", "error", String),
+                        ("error", e.to_string(), String),
+                        ("state", "load_bank_from_snapshot", String),
+                        "cluster" => &cli.cluster,
+                    );
+                    error!("Failed to catch up: {}", e);
+                }
+
+                if let Ok(command_output) = try_catchup {
+                    info!("{}", command_output);
+                }
                 let incremental_snapshots_path = cli.backup_snapshots_dir.clone();
                 wait_for_optimal_incremental_snapshot(incremental_snapshots_path, slot_to_process)
                     .await?;
@@ -153,29 +173,6 @@ pub async fn loop_stages(
                         incremental_snapshots_path: _,
                         backup_snapshots_dir,
                     } = cli.get_snapshot_paths();
-
-                    info!("Ensuring localhost RPC is caught up with remote validator...");
-
-                    let try_catchup =
-                        crate::solana_cli::catchup(cli.rpc_url.to_owned(), cli.localhost_port);
-                    if let Err(ref e) = try_catchup {
-                        datapoint_error!(
-                            "tip_router_cli.create_stake_meta",
-                            ("operator_address", operator_address, String),
-                            ("epoch", epoch_to_process, i64),
-                            ("status", "error", String),
-                            ("error", e.to_string(), String),
-                            ("state", "create_stake_meta", String),
-                            ("duration_ms", start.elapsed().as_millis() as i64, i64),
-                            "cluster" => &cli.cluster,
-                        );
-                        error!("Failed to catch up: {}", e);
-                    }
-
-                    if let Ok(command_output) = try_catchup {
-                        info!("{}", command_output);
-                    }
-
                     // We can safely expect to use the backup_snapshots_dir as the full snapshot path because
                     //  _get_bank_from_snapshot_at_slot_ expects the snapshot at the exact `slot` to have
                     //  already been taken.


### PR DESCRIPTION
**Problem**
Recently tip-router-rpc1 operator crashed due to missing blockstore data with respect to the target slot. We cannot ensure that the necessary blockstore data is present unless our localhost rpc is caught up.

**Solution**
- Move catchup logic to run **before** load_bank_from_snapshot, making a best effort to sync the blockstore before attempting to read from it
- Make `heartbeat_interval_seconds` configurable for operators

