### PR TITLE
Don't panic on missing node

### DIFF
--- a/integration_tests/tests/tip_router/bpf/set_merkle_root.rs
+++ b/integration_tests/tests/tip_router/bpf/set_merkle_root.rs
@@ -270,7 +270,8 @@ mod set_merkle_root {
         // Get proof for vote_account
         let node = meta_merkle_tree_fixture
             .meta_merkle_tree
-            .get_node(&tip_distribution_address);
+            .get_node(&tip_distribution_address)
+            .expect("Node should exist in merkle tree");
         let proof = node.proof.clone().unwrap();
 
         ballot_box_fixture
@@ -423,7 +424,8 @@ mod set_merkle_root {
         // Get proof for vote_account
         let node = meta_merkle_tree_fixture
             .meta_merkle_tree
-            .get_node(&tip_distribution_address);
+            .get_node(&tip_distribution_address)
+            .expect("Node should exist in merkle tree");
         let proof = node.proof.clone().unwrap();
 
         let ballot_box = tip_router_client.get_ballot_box(ncn, epoch).await?;
@@ -508,7 +510,8 @@ mod set_merkle_root {
         .0;
         let node = meta_merkle_tree_fixture
             .meta_merkle_tree
-            .get_node(&tip_distribution_address);
+            .get_node(&tip_distribution_address)
+            .expect("Node should exist in merkle tree");
         let proof = node.proof.clone().unwrap();
 
         fixture.warp_epoch_incremental(1).await?;

--- a/meta_merkle_tree/src/meta_merkle_tree.rs
+++ b/meta_merkle_tree/src/meta_merkle_tree.rs
@@ -97,14 +97,13 @@ impl MetaMerkleTree {
         Ok(())
     }
 
-    pub fn get_node(&self, tip_distribution_account: &Pubkey) -> TreeNode {
+    pub fn get_node(&self, tip_distribution_account: &Pubkey) -> Option<TreeNode> {
         for i in self.tree_nodes.iter() {
             if i.tip_distribution_account == *tip_distribution_account {
-                return i.clone();
+                return Some(i.clone());
             }
         }
-
-        panic!("Claimant not found in tree");
+        None
     }
 
     fn validate(&self) -> Result<()> {

--- a/tip-router-operator-cli/src/main.rs
+++ b/tip-router-operator-cli/src/main.rs
@@ -46,24 +46,6 @@ async fn main() -> Result<()> {
 
     info!("Ensuring localhost RPC is caught up with remote validator...");
 
-    let try_catchup =
-        tip_router_operator_cli::solana_cli::catchup(cli.rpc_url.to_owned(), cli.localhost_port);
-    if let Err(ref e) = &try_catchup {
-        datapoint_error!(
-            "tip_router_cli.main",
-            ("operator_address", cli.operator_address, String),
-            ("status", "error", String),
-            ("error", e.to_string(), String),
-            ("state", "bootstrap", String),
-            "cluster" => &cli.cluster,
-        );
-        error!("Failed to catch up: {}", e);
-    }
-
-    if let Ok(command_output) = &try_catchup {
-        info!("{}", command_output);
-    }
-
     // Ensure backup directory and
     cli.force_different_backup_snapshot_dir();
 
@@ -158,6 +140,27 @@ async fn main() -> Result<()> {
 
             let operator_address = cli.operator_address.clone();
             let cluster = cli.cluster.clone();
+
+            let try_catchup = tip_router_operator_cli::solana_cli::catchup(
+                cli.rpc_url.to_owned(),
+                cli.localhost_port,
+            );
+            if let Err(ref e) = &try_catchup {
+                datapoint_error!(
+                    "tip_router_cli.main",
+                    ("operator_address", cli.operator_address, String),
+                    ("status", "error", String),
+                    ("error", e.to_string(), String),
+                    ("state", "bootstrap", String),
+                    "cluster" => &cli.cluster,
+                );
+                error!("Failed to catch up: {}", e);
+            }
+
+            if let Ok(command_output) = &try_catchup {
+                info!("{}", command_output);
+            }
+
             tokio::spawn(async move {
                 loop {
                     datapoint_info!(

--- a/tip-router-operator-cli/src/tip_router.rs
+++ b/tip-router-operator-cli/src/tip_router.rs
@@ -122,7 +122,12 @@ pub async fn set_merkle_roots_batched(
     let instructions = tip_distribution_accounts
         .iter()
         .filter_map(|(key, tip_distribution_account)| {
-            let meta_merkle_node = meta_merkle_tree.get_node(key);
+            let meta_merkle_node = if let Some(node) = meta_merkle_tree.get_node(key) {
+                node
+            } else {
+                error!("No node found for tip distribution account, maybe the account has zero tips? {:?}", key);
+                return None;
+            };
 
             let proof = if let Some(proof) = meta_merkle_node.proof {
                 proof


### PR DESCRIPTION
Noticed 3 TDAs with zero tips that caused a panic because their nodes did not exist in the MetaMerkleTree, and all three had zero tips. Patching to ensure we can set merkle roots and kick off claims.

Nodes:

```
Claimant not found in tree: J8ub95fqxUZbEjLFurVMUMN9wfAHHgbTh84bhkopRJse
[2025-06-05T19:46:53Z ERROR tip_router_operator_cli::tip_router] No node found for tip distribution account J8ub95fqxUZbEjLFurVMUMN9wfAHHgbTh84bhkopRJse
Claimant not found in tree: DGy6Tj63soeNqfKao3Y2cNT5EJKacqLwA8SERoXGDptQ
[2025-06-05T19:46:53Z ERROR tip_router_operator_cli::tip_router] No node found for tip distribution account DGy6Tj63soeNqfKao3Y2cNT5EJKacqLwA8SERoXGDptQ
Claimant not found in tree: H195qWWwZbBub3ehWcUsZdfvhEusvtTTRj2Wz2C44hZR
[2025-06-05T19:46:53Z ERROR tip_router_operator_cli::tip_router] No node found for tip distribution account H195qWWwZbBub3ehWcUsZdfvhEusvtTTRj2Wz2C44hZR
```