### PR TITLE
Fix: Avoid infinite loop

### DIFF
--- a/cli/src/keeper/keeper_loop.rs
+++ b/cli/src/keeper/keeper_loop.rs
@@ -93,6 +93,8 @@ pub async fn startup_keeper(
     cluster_name: String,
     region: String,
 ) -> Result<()> {
+    assert!(handler.ncn().is_ok(), "miss NCN address!");
+
     let mut state: KeeperState = KeeperState::default();
     let mut epoch_stall = false;
     let mut current_keeper_epoch = handler.epoch;


### PR DESCRIPTION
- If ncn is not set, keeper process infinite process
- Add assertion `handler.ncn().is_ok()`