### PR TITLE
tip-router-operator-cli: bump version to 1.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11291,7 +11291,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tip-router-operator-cli"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "anchor-lang 0.31.1",
  "anyhow",

--- a/tip-router-operator-cli/Cargo.toml
+++ b/tip-router-operator-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tip-router-operator-cli"
-version = "1.2.0"
+version = "1.3.0"
 edition = "2021"
 description = "CLI for Jito Tip Router"
 


### PR DESCRIPTION
This change upgrades the version of tip-router-operator-cli from 1.2.0 to 1.3.0

- Improved handling of claimant not found in merkle tree
- Upgrade solana related dependencies to 2.2
- Remove ellipsis client dependency
- Ensure the local validator is caught up before loading bank from snapshot
- Improved solana metrics: cast_vote txns should correctly report errors, periodic heartbeat emit, cluster tag
- print-tx flag for displaying transaction information from the CLI
- Addition of `CLUSTER` and `REGION` env vars for more granular metrics
- The keeper will no longer try to create, uncreatable NcnRewardRouters
- Support for additional filename patterns within gcp_uploader