### PR TITLE
fix: operator loop_stages legacy fallback

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "tip-router-operator-cli/repo-at-older-commit"]
 	path = tip-router-operator-cli/repo-at-older-commit
         url = https://github.com/jito-foundation/jito-tip-router.git
-        branch = gzalz/final/v1.3.0-legacy
+        branch = v1.3.0-legacy

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "tip-router-operator-cli/repo-at-older-commit"]
 	path = tip-router-operator-cli/repo-at-older-commit
-	url = https://github.com/jito-foundation/jito-tip-router.git
+        url = https://github.com/jito-foundation/jito-tip-router.git
+        branch = v1.3.0-legacy

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "tip-router-operator-cli/repo-at-older-commit"]
 	path = tip-router-operator-cli/repo-at-older-commit
         url = https://github.com/jito-foundation/jito-tip-router.git
-        branch = v1.3.0-legacy
+        branch = gzalz/final/v1.3.0-legacy

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,3 @@
 [submodule "tip-router-operator-cli/repo-at-older-commit"]
 	path = tip-router-operator-cli/repo-at-older-commit
 	url = https://github.com/jito-foundation/jito-tip-router.git
-	branch = v1.2.0-operator-legacy

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4069,6 +4069,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
+name = "legacy-meta-merkle-tree"
+version = "0.0.1"
+dependencies = [
+ "anchor-lang 0.31.1",
+ "borsh 0.10.4",
+ "bytemuck",
+ "fast-math",
+ "hex",
+ "jito-bytemuck",
+ "jito-jsm-core",
+ "jito-restaking-core",
+ "jito-restaking-sdk",
+ "jito-tip-distribution-sdk",
+ "jito-tip-payment-sdk",
+ "jito-vault-core",
+ "jito-vault-sdk",
+ "log",
+ "rand 0.8.5",
+ "serde",
+ "serde_json",
+ "shank",
+ "solana-program",
+ "solana-sdk",
+ "spl-associated-token-account",
+ "spl-math",
+ "spl-token 7.0.0",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "legacy-tip-router-operator-cli"
 version = "1.3.0"
 dependencies = [
@@ -4083,14 +4113,13 @@ dependencies = [
  "im",
  "itertools 0.11.0",
  "jito-bytemuck",
- "jito-priority-fee-distribution-sdk",
  "jito-tip-distribution-sdk",
  "jito-tip-payment-sdk",
  "jito-tip-router-client",
  "jito-tip-router-core",
  "jito-tip-router-program",
+ "legacy-meta-merkle-tree",
  "log",
- "meta-merkle-tree",
  "rand 0.8.5",
  "serde",
  "serde_json",
@@ -4436,6 +4465,7 @@ dependencies = [
  "jito-tip-payment-sdk",
  "jito-vault-core",
  "jito-vault-sdk",
+ "legacy-meta-merkle-tree",
  "log",
  "rand 0.8.5",
  "serde",
@@ -11374,6 +11404,7 @@ dependencies = [
  "jito-tip-router-client",
  "jito-tip-router-core",
  "jito-tip-router-program",
+ "legacy-meta-merkle-tree",
  "legacy-tip-router-operator-cli",
  "log",
  "meta-merkle-tree",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4069,6 +4069,60 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
+name = "legacy-tip-router-operator-cli"
+version = "1.3.0"
+dependencies = [
+ "anchor-lang 0.31.1",
+ "anyhow",
+ "base64 0.13.1",
+ "clap 2.34.0",
+ "clap 4.5.23",
+ "crossbeam-channel",
+ "env_logger 0.10.2",
+ "hex",
+ "im",
+ "itertools 0.11.0",
+ "jito-bytemuck",
+ "jito-priority-fee-distribution-sdk",
+ "jito-tip-distribution-sdk",
+ "jito-tip-payment-sdk",
+ "jito-tip-router-client",
+ "jito-tip-router-core",
+ "jito-tip-router-program",
+ "log",
+ "meta-merkle-tree",
+ "rand 0.8.5",
+ "serde",
+ "serde_json",
+ "solana-account-decoder",
+ "solana-accounts-db",
+ "solana-clap-utils",
+ "solana-client",
+ "solana-core",
+ "solana-geyser-plugin-manager",
+ "solana-gossip",
+ "solana-ledger",
+ "solana-measure",
+ "solana-metrics",
+ "solana-program",
+ "solana-program-test",
+ "solana-rpc",
+ "solana-rpc-client",
+ "solana-rpc-client-api",
+ "solana-runtime",
+ "solana-sdk",
+ "solana-stake-program",
+ "solana-streamer",
+ "solana-transaction-status",
+ "solana-unified-scheduler-pool",
+ "solana-vote",
+ "spl-memo 6.0.0",
+ "tempfile",
+ "thiserror 1.0.69",
+ "tokio",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11320,6 +11374,7 @@ dependencies = [
  "jito-tip-router-client",
  "jito-tip-router-core",
  "jito-tip-router-program",
+ "legacy-tip-router-operator-cli",
  "log",
  "meta-merkle-tree",
  "rand 0.8.5",

--- a/meta_merkle_tree/Cargo.toml
+++ b/meta_merkle_tree/Cargo.toml
@@ -24,6 +24,7 @@ jito-tip-distribution-sdk = { workspace = true }
 jito-tip-payment-sdk = { workspace = true }
 jito-vault-core = { workspace = true }
 jito-vault-sdk = { workspace = true }
+legacy-meta-merkle-tree = { package = "legacy-meta-merkle-tree", path = "../tip-router-operator-cli/repo-at-older-commit/meta_merkle_tree" }
 log = { workspace = true }
 rand = { workspace = true }
 serde = { workspace = true }

--- a/meta_merkle_tree/src/generated_merkle_tree.rs
+++ b/meta_merkle_tree/src/generated_merkle_tree.rs
@@ -319,16 +319,6 @@ impl TreeNode {
             protocol_fee_amount,
         )];
 
-        // Generate validator node only if fee is > 0.
-        if validator_amount > 0 {
-            tree_nodes.push(Self::generate_validator_node(
-                &stake_meta.validator_vote_account,
-                distribution_account_pubkey,
-                distribution_program_id,
-                validator_amount,
-            ))
-        }
-
         tree_nodes.extend(
             stake_meta
                 .delegations

--- a/meta_merkle_tree/src/generated_merkle_tree.rs
+++ b/meta_merkle_tree/src/generated_merkle_tree.rs
@@ -294,7 +294,7 @@ impl GeneratedMerkleTreeCollection {
         }
     }
 
-    pub fn to_legacy(&self, distribution_program: &Pubkey) -> LegacyGeneratedMerkleTreeCollection {
+    pub fn to_legacy(&self) -> LegacyGeneratedMerkleTreeCollection {
         LegacyGeneratedMerkleTreeCollection {
             generated_merkle_trees: self
                 .generated_merkle_trees
@@ -356,7 +356,7 @@ impl TreeNode {
         // validator_fee_bps
         let validator_amount = mul_div(total_tips, validator_fee_bps as u64, MAX_BPS as u64)?;
 
-        let (validator_amount, remaining_total_rewards) = validator_amount
+        let (_validator_amount, remaining_total_rewards) = validator_amount
             .checked_add(protocol_fee_amount)
             .map_or((validator_amount, None), |total_fees| {
                 if total_fees > total_tips {

--- a/meta_merkle_tree/src/generated_merkle_tree.rs
+++ b/meta_merkle_tree/src/generated_merkle_tree.rs
@@ -3,6 +3,13 @@ use jito_tip_distribution_sdk::{
     jito_tip_distribution::ID as TIP_DISTRIBUTION_ID, CLAIM_STATUS_SEED,
 };
 use jito_vault_core::MAX_BPS;
+use legacy_meta_merkle_tree::generated_merkle_tree::Delegation as LegacyDelegation;
+use legacy_meta_merkle_tree::generated_merkle_tree::GeneratedMerkleTree as LegacyGeneratedMerkleTree;
+use legacy_meta_merkle_tree::generated_merkle_tree::GeneratedMerkleTreeCollection as LegacyGeneratedMerkleTreeCollection;
+use legacy_meta_merkle_tree::generated_merkle_tree::StakeMeta as LegacyStakeMeta;
+use legacy_meta_merkle_tree::generated_merkle_tree::StakeMetaCollection as LegacyStakeMetaCollection;
+use legacy_meta_merkle_tree::generated_merkle_tree::TipDistributionMeta as LegacyDistributionMeta;
+use legacy_meta_merkle_tree::generated_merkle_tree::TreeNode as LegacyTreeNode;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use solana_program::{
     clock::{Epoch, Slot},
@@ -158,6 +165,46 @@ impl GeneratedMerkleTree {
             max_total_claim: total_tips,
         })
     }
+
+    pub fn from_legacy(legacy_tree: LegacyGeneratedMerkleTree) -> Self {
+        GeneratedMerkleTree {
+            distribution_program: TIP_DISTRIBUTION_ID, // Legacy trees are always from the tip
+            // distribution program
+            distribution_account: legacy_tree.tip_distribution_account,
+            merkle_root_upload_authority: legacy_tree.merkle_root_upload_authority,
+            merkle_root: legacy_tree.merkle_root,
+            tree_nodes: legacy_tree
+                .tree_nodes
+                .into_iter()
+                .map(TreeNode::from_legacy)
+                .collect(),
+            max_total_claim: legacy_tree.max_total_claim,
+            max_num_nodes: legacy_tree.max_num_nodes,
+        }
+    }
+
+    pub fn to_legacy(&self) -> LegacyGeneratedMerkleTree {
+        LegacyGeneratedMerkleTree {
+            tip_distribution_account: self.distribution_account,
+            merkle_root_upload_authority: self.merkle_root_upload_authority,
+            merkle_root: self.merkle_root,
+            tree_nodes: self
+                .tree_nodes
+                .iter()
+                .map(|node| LegacyTreeNode {
+                    claimant: node.claimant,
+                    claim_status_pubkey: node.claim_status_pubkey,
+                    claim_status_bump: node.claim_status_bump,
+                    staker_pubkey: node.staker_pubkey,
+                    withdrawer_pubkey: node.withdrawer_pubkey,
+                    amount: node.amount,
+                    proof: node.proof.clone(),
+                })
+                .collect(),
+            max_total_claim: self.max_total_claim,
+            max_num_nodes: self.max_num_nodes,
+        }
+    }
 }
 
 impl GeneratedMerkleTreeCollection {
@@ -232,6 +279,32 @@ impl GeneratedMerkleTreeCollection {
         let mut file = File::create(path)?;
         file.write_all(serialized.as_bytes())?;
         Ok(())
+    }
+
+    pub fn from_legacy(legacy_collection: LegacyGeneratedMerkleTreeCollection) -> Self {
+        Self {
+            generated_merkle_trees: legacy_collection
+                .generated_merkle_trees
+                .into_iter()
+                .map(|legacy_tree| GeneratedMerkleTree::from_legacy(legacy_tree))
+                .collect(),
+            bank_hash: legacy_collection.bank_hash,
+            epoch: legacy_collection.epoch,
+            slot: legacy_collection.slot,
+        }
+    }
+
+    pub fn to_legacy(&self, distribution_program: &Pubkey) -> LegacyGeneratedMerkleTreeCollection {
+        LegacyGeneratedMerkleTreeCollection {
+            generated_merkle_trees: self
+                .generated_merkle_trees
+                .iter()
+                .map(|tree| tree.to_legacy())
+                .collect(),
+            bank_hash: self.bank_hash.clone(),
+            epoch: self.epoch,
+            slot: self.slot,
+        }
     }
 }
 
@@ -449,6 +522,30 @@ impl TreeNode {
         hasher.hash(self.amount.to_le_bytes().as_ref());
         hasher.result()
     }
+
+    pub fn from_legacy(legacy_tree_node: LegacyTreeNode) -> Self {
+        Self {
+            claimant: legacy_tree_node.claimant,
+            claim_status_pubkey: legacy_tree_node.claim_status_pubkey,
+            claim_status_bump: legacy_tree_node.claim_status_bump,
+            staker_pubkey: legacy_tree_node.staker_pubkey,
+            withdrawer_pubkey: legacy_tree_node.withdrawer_pubkey,
+            amount: legacy_tree_node.amount,
+            proof: legacy_tree_node.proof,
+        }
+    }
+
+    pub fn to_legacy(&self) -> LegacyTreeNode {
+        LegacyTreeNode {
+            claimant: self.claimant,
+            claim_status_pubkey: self.claim_status_pubkey,
+            claim_status_bump: self.claim_status_bump,
+            staker_pubkey: self.staker_pubkey,
+            withdrawer_pubkey: self.withdrawer_pubkey,
+            amount: self.amount,
+            proof: self.proof.clone(),
+        }
+    }
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -490,6 +587,35 @@ impl StakeMetaCollection {
         let mut file = File::create(path).unwrap();
         file.write_all(serialized.as_bytes()).unwrap();
     }
+
+    pub fn to_legacy(&self) -> LegacyStakeMetaCollection {
+        LegacyStakeMetaCollection {
+            stake_metas: self
+                .stake_metas
+                .iter()
+                .map(|meta| meta.to_legacy())
+                .collect(),
+            tip_distribution_program_id: self.tip_distribution_program_id,
+            bank_hash: self.bank_hash.clone(),
+            epoch: self.epoch,
+            slot: self.slot,
+        }
+    }
+
+    pub fn from_legacy(legacy_stake_meta_collection: LegacyStakeMetaCollection) -> Self {
+        Self {
+            stake_metas: legacy_stake_meta_collection
+                .stake_metas
+                .into_iter()
+                .map(|meta| StakeMeta::from_legacy(meta))
+                .collect(),
+            tip_distribution_program_id: legacy_stake_meta_collection.tip_distribution_program_id,
+            priority_fee_distribution_program_id: PRIORITY_FEE_DISTRIBUTION_ID,
+            bank_hash: legacy_stake_meta_collection.bank_hash,
+            epoch: legacy_stake_meta_collection.epoch,
+            slot: legacy_stake_meta_collection.slot,
+        }
+    }
 }
 
 #[derive(Clone, Deserialize, Serialize, Debug, PartialEq, Eq)]
@@ -514,6 +640,44 @@ pub struct StakeMeta {
 
     /// The validator's delegation commission rate as a percentage between 0-100.
     pub commission: u8,
+}
+
+impl StakeMeta {
+    pub fn to_legacy(&self) -> LegacyStakeMeta {
+        LegacyStakeMeta {
+            validator_vote_account: self.validator_vote_account,
+            validator_node_pubkey: self.validator_node_pubkey,
+            maybe_tip_distribution_meta: self
+                .maybe_tip_distribution_meta
+                .as_ref()
+                .map(|meta| meta.to_legacy()),
+            delegations: self
+                .delegations
+                .iter()
+                .map(|delegation| delegation.to_legacy())
+                .collect(),
+            total_delegated: self.total_delegated,
+            commission: self.commission,
+        }
+    }
+
+    pub fn from_legacy(legacy_stake_meta: LegacyStakeMeta) -> Self {
+        Self {
+            validator_vote_account: legacy_stake_meta.validator_vote_account,
+            validator_node_pubkey: legacy_stake_meta.validator_node_pubkey,
+            maybe_tip_distribution_meta: legacy_stake_meta
+                .maybe_tip_distribution_meta
+                .map(TipDistributionMeta::from_legacy),
+            maybe_priority_fee_distribution_meta: None, // Legacy does not have priority fee distribution
+            delegations: legacy_stake_meta
+                .delegations
+                .into_iter()
+                .map(Delegation::from_legacy)
+                .collect(),
+            total_delegated: legacy_stake_meta.total_delegated,
+            commission: legacy_stake_meta.commission,
+        }
+    }
 }
 
 impl Ord for StakeMeta {
@@ -545,6 +709,26 @@ pub struct TipDistributionMeta {
     pub validator_fee_bps: u16,
 }
 
+impl TipDistributionMeta {
+    pub fn to_legacy(&self) -> LegacyDistributionMeta {
+        LegacyDistributionMeta {
+            merkle_root_upload_authority: self.merkle_root_upload_authority,
+            tip_distribution_pubkey: self.tip_distribution_pubkey,
+            total_tips: self.total_tips,
+            validator_fee_bps: self.validator_fee_bps,
+        }
+    }
+
+    pub fn from_legacy(legacy_meta: LegacyDistributionMeta) -> Self {
+        Self {
+            merkle_root_upload_authority: legacy_meta.merkle_root_upload_authority,
+            tip_distribution_pubkey: legacy_meta.tip_distribution_pubkey,
+            total_tips: legacy_meta.total_tips,
+            validator_fee_bps: legacy_meta.validator_fee_bps,
+        }
+    }
+}
+
 #[derive(Clone, Deserialize, Serialize, Debug, PartialEq, Eq)]
 pub struct PriorityFeeDistributionMeta {
     #[serde(with = "pubkey_string_conversion")]
@@ -574,6 +758,26 @@ pub struct Delegation {
 
     /// Lamports delegated by the stake account
     pub lamports_delegated: u64,
+}
+
+impl Delegation {
+    pub fn to_legacy(&self) -> LegacyDelegation {
+        LegacyDelegation {
+            stake_account_pubkey: self.stake_account_pubkey,
+            staker_pubkey: self.staker_pubkey,
+            withdrawer_pubkey: self.withdrawer_pubkey,
+            lamports_delegated: self.lamports_delegated,
+        }
+    }
+
+    pub fn from_legacy(legacy_delegation: LegacyDelegation) -> Self {
+        Self {
+            stake_account_pubkey: legacy_delegation.stake_account_pubkey,
+            staker_pubkey: legacy_delegation.staker_pubkey,
+            withdrawer_pubkey: legacy_delegation.withdrawer_pubkey,
+            lamports_delegated: legacy_delegation.lamports_delegated,
+        }
+    }
 }
 
 impl Ord for Delegation {

--- a/tip-router-operator-cli/Cargo.toml
+++ b/tip-router-operator-cli/Cargo.toml
@@ -24,6 +24,7 @@ jito-tip-router-core = { workspace = true }
 jito-tip-router-program = { workspace = true }
 legacy-tip-router-operator-cli = { package = "legacy-tip-router-operator-cli", path = "./repo-at-older-commit/tip-router-operator-cli" }
 log = { workspace = true }
+legacy-meta-merkle-tree = { package = "legacy-meta-merkle-tree", path = "./repo-at-older-commit/meta_merkle_tree" }
 meta-merkle-tree = { workspace = true }
 rand = { workspace = true }
 serde = { workspace = true }

--- a/tip-router-operator-cli/Cargo.toml
+++ b/tip-router-operator-cli/Cargo.toml
@@ -22,6 +22,7 @@ jito-tip-payment-sdk = { workspace = true }
 jito-tip-router-client = { workspace = true }
 jito-tip-router-core = { workspace = true }
 jito-tip-router-program = { workspace = true }
+legacy-tip-router-operator-cli = { package = "legacy-tip-router-operator-cli", path = "./repo-at-older-commit/tip-router-operator-cli" }
 log = { workspace = true }
 meta-merkle-tree = { workspace = true }
 rand = { workspace = true }

--- a/tip-router-operator-cli/src/claim.rs
+++ b/tip-router-operator-cli/src/claim.rs
@@ -296,6 +296,7 @@ pub async fn legacy_handle_claim_mev_tips(
     rpc_url: String,
 ) -> Result<(), anyhow::Error> {
     let meta_merkle_tree_dir = cli.get_save_path().clone();
+    let merkle_tree_coll_path = meta_merkle_tree_dir.join(merkle_tree_collection_file_name(epoch));
     let mut merkle_tree_coll =
         LegacyGeneratedMerkleTreeCollection::new_from_file(&meta_merkle_tree_dir)
             .map_err(|e| anyhow::anyhow!(e))?;

--- a/tip-router-operator-cli/src/claim.rs
+++ b/tip-router-operator-cli/src/claim.rs
@@ -298,7 +298,7 @@ pub async fn legacy_handle_claim_mev_tips(
     let meta_merkle_tree_dir = cli.get_save_path().clone();
     let merkle_tree_coll_path = meta_merkle_tree_dir.join(merkle_tree_collection_file_name(epoch));
     let mut merkle_tree_coll =
-        LegacyGeneratedMerkleTreeCollection::new_from_file(&meta_merkle_tree_dir)
+        LegacyGeneratedMerkleTreeCollection::new_from_file(&merkle_tree_coll_path)
             .map_err(|e| anyhow::anyhow!(e))?;
 
     let tip_router_config_address = Config::find_program_address(&tip_router_program_id, &ncn).0;

--- a/tip-router-operator-cli/src/claim.rs
+++ b/tip-router-operator-cli/src/claim.rs
@@ -6,6 +6,8 @@ use jito_tip_distribution_sdk::{
 };
 use jito_tip_router_client::instructions::ClaimWithPayerBuilder;
 use jito_tip_router_core::{account_payer::AccountPayer, config::Config};
+use legacy_meta_merkle_tree::generated_merkle_tree::GeneratedMerkleTreeCollection as LegacyGeneratedMerkleTreeCollection;
+use legacy_tip_router_operator_cli::claim::ClaimMevError as LegacyClaimMevError;
 use log::{info, warn};
 use meta_merkle_tree::generated_merkle_tree::GeneratedMerkleTreeCollection;
 use rand::{prelude::SliceRandom, thread_rng};
@@ -146,10 +148,56 @@ pub async fn claim_mev_tips_with_emit(
     let keypair = read_keypair_file(cli.keypair_path.clone())
         .map_err(|e| anyhow::anyhow!("Failed to read keypair file: {:?}", e))?;
     let keypair = Arc::new(keypair);
-    let meta_merkle_tree_dir = cli.get_save_path().clone();
     let rpc_url = cli.rpc_url.clone();
-    let merkle_tree_coll_path = meta_merkle_tree_dir.join(merkle_tree_collection_file_name(epoch));
-    let mut merkle_tree_coll = GeneratedMerkleTreeCollection::new_from_file(&merkle_tree_coll_path)
+    if epoch < legacy_tip_router_operator_cli::PRIORITY_FEE_MERKLE_TREE_START_EPOCH {
+        handle_claim_mev_tips(
+            cli,
+            epoch,
+            tip_distribution_program_id,
+            priority_fee_distribution_program_id,
+            tip_router_program_id,
+            ncn,
+            max_loop_duration,
+            &file_path,
+            file_mutex,
+            &keypair,
+            rpc_url,
+        )
+        .await?;
+    } else {
+        legacy_handle_claim_mev_tips(
+            cli,
+            epoch,
+            tip_distribution_program_id,
+            tip_router_program_id,
+            ncn,
+            max_loop_duration,
+            &file_path,
+            file_mutex,
+            &keypair,
+            rpc_url,
+        )
+        .await?;
+    }
+
+    Ok(())
+}
+
+pub async fn handle_claim_mev_tips(
+    cli: &Cli,
+    epoch: u64,
+    tip_distribution_program_id: Pubkey,
+    priority_fee_distribution_program_id: Pubkey,
+    tip_router_program_id: Pubkey,
+    ncn: Pubkey,
+    max_loop_duration: Duration,
+    file_path: &PathBuf,
+    file_mutex: &Arc<Mutex<()>>,
+    keypair: &Arc<Keypair>,
+    rpc_url: String,
+) -> Result<(), anyhow::Error> {
+    let meta_merkle_tree_dir = cli.get_save_path().clone();
+    let mut merkle_tree_coll = GeneratedMerkleTreeCollection::new_from_file(&meta_merkle_tree_dir)
         .map_err(|e| anyhow::anyhow!(e))?;
 
     let tip_router_config_address = Config::find_program_address(&tip_router_program_id, &ncn).0;
@@ -231,7 +279,104 @@ pub async fn claim_mev_tips_with_emit(
         ("sol_balance", lamports_to_sol(claimer_balance), f64),
         "cluster" => &cli.cluster,
     );
+    Ok(())
+}
 
+pub async fn legacy_handle_claim_mev_tips(
+    cli: &Cli,
+    epoch: u64,
+    tip_distribution_program_id: Pubkey,
+    tip_router_program_id: Pubkey,
+    ncn: Pubkey,
+    max_loop_duration: Duration,
+    file_path: &PathBuf,
+    file_mutex: &Arc<Mutex<()>>,
+    keypair: &Arc<Keypair>,
+    rpc_url: String,
+) -> Result<(), anyhow::Error> {
+    let meta_merkle_tree_dir = cli.get_save_path().clone();
+    let mut merkle_tree_coll =
+        LegacyGeneratedMerkleTreeCollection::new_from_file(&meta_merkle_tree_dir)
+            .map_err(|e| anyhow::anyhow!(e))?;
+
+    let tip_router_config_address = Config::find_program_address(&tip_router_program_id, &ncn).0;
+
+    // Fix wrong claim status pubkeys for 1 epoch -- noop if already correct
+    for tree in merkle_tree_coll.generated_merkle_trees.iter_mut() {
+        if tree.merkle_root_upload_authority != tip_router_config_address {
+            continue;
+        }
+        for node in tree.tree_nodes.iter_mut() {
+            let (claim_status_pubkey, claim_status_bump) = derive_claim_status_account_address(
+                &tip_distribution_program_id,
+                &node.claimant,
+                &tree.tip_distribution_account,
+            );
+            node.claim_status_pubkey = claim_status_pubkey;
+            node.claim_status_bump = claim_status_bump;
+        }
+    }
+
+    let start = Instant::now();
+
+    match legacy_tip_router_operator_cli::claim::claim_mev_tips(
+        &merkle_tree_coll,
+        rpc_url.clone(),
+        rpc_url.clone(),
+        tip_distribution_program_id,
+        tip_router_program_id,
+        ncn,
+        &keypair,
+        max_loop_duration,
+        cli.claim_microlamports,
+        file_path,
+        file_mutex,
+        &cli.operator_address,
+        &cli.cluster,
+    )
+    .await
+    {
+        Ok(()) => {
+            datapoint_info!(
+                "claim_mev_workflow",
+                ("operator", cli.operator_address, String),
+                ("epoch", epoch, i64),
+                ("transactions_left", 0, i64),
+                ("elapsed_us", start.elapsed().as_micros(), i64),
+                "cluster" => &cli.cluster,
+            );
+        }
+        Err(LegacyClaimMevError::NotFinished { transactions_left }) => {
+            datapoint_info!(
+                "claim_mev_workflow",
+                ("operator", cli.operator_address, String),
+                ("epoch", epoch, i64),
+                ("transactions_left", transactions_left, i64),
+                ("elapsed_us", start.elapsed().as_micros(), i64),
+                "cluster" => &cli.cluster,
+            );
+        }
+        Err(e) => {
+            datapoint_error!(
+                "claim_mev_workflow",
+                ("operator", cli.operator_address, String),
+                ("epoch", epoch, i64),
+                ("error", e.to_string(), String),
+                ("elapsed_us", start.elapsed().as_micros(), i64),
+                "cluster" => &cli.cluster,
+            );
+        }
+    }
+
+    let claimer_balance = get_claimer_balance(rpc_url, &keypair).await?;
+    datapoint_info!(
+        "claimer_info",
+        ("claimer", keypair.pubkey().to_string(), String),
+        ("epoch", epoch, i64),
+        ("lamport_balance", claimer_balance, i64),
+        ("sol_balance", lamports_to_sol(claimer_balance), f64),
+        "cluster" => &cli.cluster,
+    );
     Ok(())
 }
 

--- a/tip-router-operator-cli/src/claim.rs
+++ b/tip-router-operator-cli/src/claim.rs
@@ -197,7 +197,8 @@ pub async fn handle_claim_mev_tips(
     rpc_url: String,
 ) -> Result<(), anyhow::Error> {
     let meta_merkle_tree_dir = cli.get_save_path().clone();
-    let mut merkle_tree_coll = GeneratedMerkleTreeCollection::new_from_file(&meta_merkle_tree_dir)
+    let merkle_tree_coll_path = meta_merkle_tree_dir.join(merkle_tree_collection_file_name(epoch));
+    let mut merkle_tree_coll = GeneratedMerkleTreeCollection::new_from_file(&merkle_tree_coll_path)
         .map_err(|e| anyhow::anyhow!(e))?;
 
     let tip_router_config_address = Config::find_program_address(&tip_router_program_id, &ncn).0;

--- a/tip-router-operator-cli/src/claim.rs
+++ b/tip-router-operator-cli/src/claim.rs
@@ -149,7 +149,7 @@ pub async fn claim_mev_tips_with_emit(
         .map_err(|e| anyhow::anyhow!("Failed to read keypair file: {:?}", e))?;
     let keypair = Arc::new(keypair);
     let rpc_url = cli.rpc_url.clone();
-    if epoch < legacy_tip_router_operator_cli::PRIORITY_FEE_MERKLE_TREE_START_EPOCH {
+    if epoch >= legacy_tip_router_operator_cli::PRIORITY_FEE_MERKLE_TREE_START_EPOCH {
         handle_claim_mev_tips(
             cli,
             epoch,

--- a/tip-router-operator-cli/src/claim.rs
+++ b/tip-router-operator-cli/src/claim.rs
@@ -149,7 +149,21 @@ pub async fn claim_mev_tips_with_emit(
         .map_err(|e| anyhow::anyhow!("Failed to read keypair file: {:?}", e))?;
     let keypair = Arc::new(keypair);
     let rpc_url = cli.rpc_url.clone();
-    if epoch >= legacy_tip_router_operator_cli::PRIORITY_FEE_MERKLE_TREE_START_EPOCH {
+    if epoch < legacy_tip_router_operator_cli::PRIORITY_FEE_MERKLE_TREE_START_EPOCH {
+        legacy_handle_claim_mev_tips(
+            cli,
+            epoch,
+            tip_distribution_program_id,
+            tip_router_program_id,
+            ncn,
+            max_loop_duration,
+            &file_path,
+            file_mutex,
+            &keypair,
+            rpc_url,
+        )
+        .await?;
+    } else {
         handle_claim_mev_tips(
             cli,
             epoch,
@@ -164,22 +178,7 @@ pub async fn claim_mev_tips_with_emit(
             rpc_url,
         )
         .await?;
-    } else {
-        legacy_handle_claim_mev_tips(
-            cli,
-            epoch,
-            tip_distribution_program_id,
-            tip_router_program_id,
-            ncn,
-            max_loop_duration,
-            &file_path,
-            file_mutex,
-            &keypair,
-            rpc_url,
-        )
-        .await?;
     }
-
     Ok(())
 }
 

--- a/tip-router-operator-cli/src/cli.rs
+++ b/tip-router-operator-cli/src/cli.rs
@@ -306,7 +306,6 @@ impl Commands {
             } => legacy_tip_router_operator_cli::Commands::Run {
                 ncn_address,
                 tip_distribution_program_id,
-                priority_fee_distribution_program_id,
                 tip_payment_program_id,
                 tip_router_program_id,
                 num_monitored_epochs,
@@ -332,7 +331,6 @@ impl Commands {
             } => legacy_tip_router_operator_cli::Commands::SubmitEpoch {
                 ncn_address,
                 tip_distribution_program_id,
-                priority_fee_distribution_program_id,
                 tip_router_program_id,
                 epoch,
                 set_merkle_roots,
@@ -346,7 +344,6 @@ impl Commands {
             } => legacy_tip_router_operator_cli::Commands::ClaimTips {
                 tip_router_program_id,
                 tip_distribution_program_id,
-                priority_fee_distribution_program_id,
                 ncn_address,
                 epoch,
             },
@@ -361,7 +358,6 @@ impl Commands {
                 epoch,
                 slot,
                 tip_distribution_program_id,
-                priority_fee_distribution_program_id,
                 tip_payment_program_id,
                 save,
             },

--- a/tip-router-operator-cli/src/cli.rs
+++ b/tip-router-operator-cli/src/cli.rs
@@ -291,7 +291,7 @@ impl Commands {
             Commands::Run {
                 ncn_address,
                 tip_distribution_program_id,
-                priority_fee_distribution_program_id,
+                priority_fee_distribution_program_id: _,
                 tip_payment_program_id,
                 tip_router_program_id,
                 num_monitored_epochs,
@@ -324,7 +324,7 @@ impl Commands {
             Commands::SubmitEpoch {
                 ncn_address,
                 tip_distribution_program_id,
-                priority_fee_distribution_program_id,
+                priority_fee_distribution_program_id: _,
                 tip_router_program_id,
                 epoch,
                 set_merkle_roots,
@@ -338,7 +338,7 @@ impl Commands {
             Commands::ClaimTips {
                 tip_router_program_id,
                 tip_distribution_program_id,
-                priority_fee_distribution_program_id,
+                priority_fee_distribution_program_id: _,
                 ncn_address,
                 epoch,
             } => legacy_tip_router_operator_cli::Commands::ClaimTips {
@@ -351,7 +351,7 @@ impl Commands {
                 epoch,
                 slot,
                 tip_distribution_program_id,
-                priority_fee_distribution_program_id,
+                priority_fee_distribution_program_id: _,
                 tip_payment_program_id,
                 save,
             } => legacy_tip_router_operator_cli::Commands::CreateStakeMeta {

--- a/tip-router-operator-cli/src/cli.rs
+++ b/tip-router-operator-cli/src/cli.rs
@@ -68,6 +68,29 @@ pub struct Cli {
 }
 
 impl Cli {
+    pub fn as_legacy(&self) -> legacy_tip_router_operator_cli::Cli {
+        legacy_tip_router_operator_cli::Cli {
+            keypair_path: self.keypair_path.clone(),
+            operator_address: self.operator_address.clone(),
+            rpc_url: self.rpc_url.clone(),
+            ledger_path: self.ledger_path.clone(),
+            full_snapshots_path: self.full_snapshots_path.clone(),
+            backup_snapshots_dir: self.backup_snapshots_dir.clone(),
+            snapshot_output_dir: self.snapshot_output_dir.clone(),
+            submit_as_memo: self.submit_as_memo,
+            claim_microlamports: self.claim_microlamports,
+            vote_microlamports: self.vote_microlamports,
+            save_path: self.save_path.clone(),
+            claim_tips_epoch_filepath: self.claim_tips_epoch_filepath.clone(),
+            meta_merkle_tree_dir: self.meta_merkle_tree_dir.clone(),
+            cluster: self.cluster.clone(),
+            region: self.region.clone(),
+            localhost_port: self.localhost_port,
+            heartbeat_interval_seconds: self.heartbeat_interval_seconds,
+            command: self.command.clone().as_legacy(),
+        }
+    }
+
     #[allow(deprecated)]
     pub fn get_save_path(&self) -> PathBuf {
         self.save_path.to_owned().map_or_else(
@@ -260,4 +283,102 @@ pub enum Commands {
         #[arg(long, env, default_value = "true")]
         save: bool,
     },
+}
+
+impl Commands {
+    pub fn as_legacy(self) -> legacy_tip_router_operator_cli::Commands {
+        match self {
+            Commands::Run {
+                ncn_address,
+                tip_distribution_program_id,
+                priority_fee_distribution_program_id,
+                tip_payment_program_id,
+                tip_router_program_id,
+                num_monitored_epochs,
+                override_target_slot,
+                set_merkle_roots,
+                claim_tips,
+                claim_tips_metrics,
+                claim_tips_epoch_lookback,
+                starting_stage,
+                save_stages,
+                save_snapshot,
+            } => legacy_tip_router_operator_cli::Commands::Run {
+                ncn_address,
+                tip_distribution_program_id,
+                priority_fee_distribution_program_id,
+                tip_payment_program_id,
+                tip_router_program_id,
+                num_monitored_epochs,
+                override_target_slot,
+                set_merkle_roots,
+                claim_tips,
+                claim_tips_metrics,
+                claim_tips_epoch_lookback,
+                starting_stage: starting_stage.as_legacy(),
+                save_stages,
+                save_snapshot,
+            },
+            Commands::SnapshotSlot { slot } => {
+                legacy_tip_router_operator_cli::Commands::SnapshotSlot { slot }
+            }
+            Commands::SubmitEpoch {
+                ncn_address,
+                tip_distribution_program_id,
+                priority_fee_distribution_program_id,
+                tip_router_program_id,
+                epoch,
+                set_merkle_roots,
+            } => legacy_tip_router_operator_cli::Commands::SubmitEpoch {
+                ncn_address,
+                tip_distribution_program_id,
+                priority_fee_distribution_program_id,
+                tip_router_program_id,
+                epoch,
+                set_merkle_roots,
+            },
+            Commands::ClaimTips {
+                tip_router_program_id,
+                tip_distribution_program_id,
+                priority_fee_distribution_program_id,
+                ncn_address,
+                epoch,
+            } => legacy_tip_router_operator_cli::Commands::ClaimTips {
+                tip_router_program_id,
+                tip_distribution_program_id,
+                priority_fee_distribution_program_id,
+                ncn_address,
+                epoch,
+            },
+            Commands::CreateStakeMeta {
+                epoch,
+                slot,
+                tip_distribution_program_id,
+                priority_fee_distribution_program_id,
+                tip_payment_program_id,
+                save,
+            } => legacy_tip_router_operator_cli::Commands::CreateStakeMeta {
+                epoch,
+                slot,
+                tip_distribution_program_id,
+                priority_fee_distribution_program_id,
+                tip_payment_program_id,
+                save,
+            },
+            Commands::CreateMerkleTreeCollection {
+                tip_router_program_id,
+                ncn_address,
+                epoch,
+                save,
+            } => legacy_tip_router_operator_cli::Commands::CreateMerkleTreeCollection {
+                tip_router_program_id,
+                ncn_address,
+                epoch,
+                save,
+            },
+            Commands::CreateMetaMerkleTree { epoch, save } => {
+                legacy_tip_router_operator_cli::Commands::CreateMetaMerkleTree { epoch, save }
+            }
+        }
+    }
 }

--- a/tip-router-operator-cli/src/lib.rs
+++ b/tip-router-operator-cli/src/lib.rs
@@ -73,6 +73,29 @@ pub enum OperatorState {
     WaitForNextEpoch,
 }
 
+impl OperatorState {
+    pub fn as_legacy(&self) -> legacy_tip_router_operator_cli::OperatorState {
+        match self {
+            OperatorState::LoadBankFromSnapshot => {
+                legacy_tip_router_operator_cli::OperatorState::LoadBankFromSnapshot
+            }
+            OperatorState::CreateStakeMeta => {
+                legacy_tip_router_operator_cli::OperatorState::CreateStakeMeta
+            }
+            OperatorState::CreateMerkleTreeCollection => {
+                legacy_tip_router_operator_cli::OperatorState::CreateMerkleTreeCollection
+            }
+            OperatorState::CreateMetaMerkleTree => {
+                legacy_tip_router_operator_cli::OperatorState::CreateMetaMerkleTree
+            }
+            OperatorState::CastVote => legacy_tip_router_operator_cli::OperatorState::CastVote,
+            OperatorState::WaitForNextEpoch => {
+                legacy_tip_router_operator_cli::OperatorState::WaitForNextEpoch
+            }
+        }
+    }
+}
+
 pub fn stake_meta_file_name(epoch: u64) -> String {
     format!("{}_stake_meta_collection.json", epoch)
 }

--- a/tip-router-operator-cli/src/main.rs
+++ b/tip-router-operator-cli/src/main.rs
@@ -275,29 +275,28 @@ async fn main() -> Result<()> {
                             }
                             } else {
                                 match legacy_tip_router_operator_cli::claim::emit_claim_mev_tips_metrics(
-                                &cli_ref.as_legacy(),
-                                epoch_to_emit,
-                                tip_distribution_program_id,
-                                tip_router_program_id,
-                                ncn_address,
-                                &file_path_ref,
-                                &file_mutex_ref,
-                            )
-                            .await
-                            {
-                                Ok(_) => {
-                                    info!(
-                                        "Successfully emitted claim metrics for epoch {}",
-                                        epoch_to_emit
-                                    );
+                                    &cli_ref.as_legacy(),
+                                    epoch_to_emit,
+                                    tip_distribution_program_id,
+                                    tip_router_program_id,
+                                    ncn_address,
+                                    &file_path_ref,
+                                    &file_mutex_ref,
+                                ).await
+                                {
+                                    Ok(_) => {
+                                        info!(
+                                            "Successfully emitted claim metrics for epoch {}",
+                                            epoch_to_emit
+                                        );
+                                    }
+                                    Err(e) => {
+                                        error!(
+                                            "Error emitting claim metrics for epoch {}: {}",
+                                            epoch_to_emit, e
+                                        );
+                                    }
                                 }
-                                Err(e) => {
-                                    error!(
-                                        "Error emitting claim metrics for epoch {}: {}",
-                                        epoch_to_emit, e
-                                    );
-                                }
-                            }
                             }
                         }
 

--- a/tip-router-operator-cli/src/main.rs
+++ b/tip-router-operator-cli/src/main.rs
@@ -367,12 +367,6 @@ async fn main() -> Result<()> {
                 });
             }
 
-            // If before the new stake meta epoch, use the old loop stages. This old loop
-
-            // stages will break once it hits the configured priority fee go live date
-
-            let snapshot_paths = cli.get_snapshot_paths();
-
             let current_epoch_info = rpc_client.get_epoch_info().await?;
 
             // Endless loop that transitions between stages of the operator process.

--- a/tip-router-operator-cli/src/main.rs
+++ b/tip-router-operator-cli/src/main.rs
@@ -382,7 +382,6 @@ async fn main() -> Result<()> {
                 &ncn_address,
                 save_snapshot,
                 save_stages,
-                current_epoch_info,
             )
             .await?;
         }

--- a/tip-router-operator-cli/src/main.rs
+++ b/tip-router-operator-cli/src/main.rs
@@ -247,6 +247,7 @@ async fn main() -> Result<()> {
 
                             info!("Emitting Claim Metrics for epoch {}", epoch_to_emit);
                             let cli_ref = cli_clone.clone();
+                            if epoch_to_emit >= legacy_tip_router_operator_cli::PRIORITY_FEE_MERKLE_TREE_START_EPOCH {
                             match emit_claim_mev_tips_metrics(
                                 &cli_ref,
                                 epoch_to_emit,
@@ -271,6 +272,32 @@ async fn main() -> Result<()> {
                                         epoch_to_emit, e
                                     );
                                 }
+                            }
+                            } else {
+                                match legacy_tip_router_operator_cli::claim::emit_claim_mev_tips_metrics(
+                                &cli_ref.as_legacy(),
+                                epoch_to_emit,
+                                tip_distribution_program_id,
+                                tip_router_program_id,
+                                ncn_address,
+                                &file_path_ref,
+                                &file_mutex_ref,
+                            )
+                            .await
+                            {
+                                Ok(_) => {
+                                    info!(
+                                        "Successfully emitted claim metrics for epoch {}",
+                                        epoch_to_emit
+                                    );
+                                }
+                                Err(e) => {
+                                    error!(
+                                        "Error emitting claim metrics for epoch {}: {}",
+                                        epoch_to_emit, e
+                                    );
+                                }
+                            }
                             }
                         }
 

--- a/tip-router-operator-cli/src/main.rs
+++ b/tip-router-operator-cli/src/main.rs
@@ -371,169 +371,9 @@ async fn main() -> Result<()> {
 
             // stages will break once it hits the configured priority fee go live date
 
-            let current_epoch_info = rpc_client.get_epoch_info().await?;
-
             let snapshot_paths = cli.get_snapshot_paths();
 
-            if current_epoch_info.epoch
-                < legacy_tip_router_operator_cli::PRIORITY_FEE_MERKLE_TREE_START_EPOCH
-            {
-                let save_path = cli.get_save_path();
-
-                let legacy_operator_stage = match starting_stage {
-                    tip_router_operator_cli::OperatorState::LoadBankFromSnapshot => {
-                        legacy_tip_router_operator_cli::OperatorState::LoadBankFromSnapshot
-                    }
-                    tip_router_operator_cli::OperatorState::CreateStakeMeta => {
-                        legacy_tip_router_operator_cli::OperatorState::CreateStakeMeta
-                    }
-                    tip_router_operator_cli::OperatorState::CreateMerkleTreeCollection => {
-                        legacy_tip_router_operator_cli::OperatorState::CreateMerkleTreeCollection
-                    }
-                    tip_router_operator_cli::OperatorState::CreateMetaMerkleTree => {
-                        legacy_tip_router_operator_cli::OperatorState::CreateMetaMerkleTree
-                    }
-                    tip_router_operator_cli::OperatorState::CastVote => {
-                        legacy_tip_router_operator_cli::OperatorState::CastVote
-                    }
-                    tip_router_operator_cli::OperatorState::WaitForNextEpoch => {
-                        legacy_tip_router_operator_cli::OperatorState::WaitForNextEpoch
-                    }
-                };
-
-                let legacy_command: legacy_tip_router_operator_cli::Commands = match cli.command {
-                    Commands::Run {
-                        ncn_address,
-                        tip_distribution_program_id,
-                        priority_fee_distribution_program_id,
-                        tip_payment_program_id,
-                        tip_router_program_id,
-                        num_monitored_epochs,
-                        override_target_slot,
-                        set_merkle_roots,
-                        claim_tips,
-                        claim_tips_metrics,
-                        claim_tips_epoch_lookback,
-                        starting_stage: _,
-                        save_stages,
-                        save_snapshot,
-                    } => legacy_tip_router_operator_cli::Commands::Run {
-                        ncn_address,
-                        tip_distribution_program_id,
-                        priority_fee_distribution_program_id,
-                        tip_payment_program_id,
-                        tip_router_program_id,
-                        num_monitored_epochs,
-                        override_target_slot,
-                        set_merkle_roots,
-                        claim_tips,
-                        claim_tips_metrics,
-                        claim_tips_epoch_lookback,
-                        starting_stage: legacy_operator_stage,
-                        save_stages,
-                        save_snapshot,
-                    },
-                    Commands::SnapshotSlot { slot } => {
-                        legacy_tip_router_operator_cli::Commands::SnapshotSlot { slot }
-                    }
-                    Commands::SubmitEpoch {
-                        ncn_address,
-                        tip_distribution_program_id,
-                        priority_fee_distribution_program_id,
-                        tip_router_program_id,
-                        epoch,
-                        set_merkle_roots,
-                    } => legacy_tip_router_operator_cli::Commands::SubmitEpoch {
-                        ncn_address,
-                        tip_distribution_program_id,
-                        priority_fee_distribution_program_id,
-                        tip_router_program_id,
-                        epoch,
-                        set_merkle_roots,
-                    },
-                    Commands::ClaimTips {
-                        tip_router_program_id,
-                        tip_distribution_program_id,
-                        priority_fee_distribution_program_id,
-                        ncn_address,
-                        epoch,
-                    } => legacy_tip_router_operator_cli::Commands::ClaimTips {
-                        tip_router_program_id,
-                        tip_distribution_program_id,
-                        priority_fee_distribution_program_id,
-                        ncn_address,
-                        epoch,
-                    },
-                    Commands::CreateStakeMeta {
-                        epoch,
-                        slot,
-                        tip_distribution_program_id,
-                        priority_fee_distribution_program_id,
-                        tip_payment_program_id,
-                        save,
-                    } => legacy_tip_router_operator_cli::Commands::CreateStakeMeta {
-                        epoch,
-                        slot,
-                        tip_distribution_program_id,
-                        priority_fee_distribution_program_id,
-                        tip_payment_program_id,
-                        save,
-                    },
-                    Commands::CreateMerkleTreeCollection {
-                        tip_router_program_id,
-                        ncn_address,
-                        epoch,
-                        save,
-                    } => legacy_tip_router_operator_cli::Commands::CreateMerkleTreeCollection {
-                        tip_router_program_id,
-                        ncn_address,
-                        epoch,
-                        save,
-                    },
-                    Commands::CreateMetaMerkleTree { epoch, save } => {
-                        legacy_tip_router_operator_cli::Commands::CreateMetaMerkleTree {
-                            epoch,
-                            save,
-                        }
-                    }
-                };
-
-                let legacy_cli = legacy_tip_router_operator_cli::Cli {
-                    keypair_path: cli.keypair_path.clone(),
-                    operator_address: cli.operator_address.clone(),
-                    rpc_url: cli.rpc_url.clone(),
-                    ledger_path: cli.ledger_path.clone(),
-                    full_snapshots_path: cli.full_snapshots_path.clone(),
-                    backup_snapshots_dir: cli.backup_snapshots_dir.clone(),
-                    snapshot_output_dir: cli.snapshot_output_dir.clone(),
-                    submit_as_memo: cli.submit_as_memo,
-                    claim_microlamports: cli.claim_microlamports,
-                    vote_microlamports: cli.vote_microlamports,
-                    save_path: Some(save_path),
-                    claim_tips_epoch_filepath: cli.claim_tips_epoch_filepath.clone(),
-                    meta_merkle_tree_dir: cli.meta_merkle_tree_dir.clone(),
-                    cluster: cli.cluster.clone(),
-                    region: cli.region.clone(),
-                    localhost_port: cli.localhost_port,
-                    heartbeat_interval_seconds: cli.heartbeat_interval_seconds,
-                    command: legacy_command,
-                };
-
-                legacy_tip_router_operator_cli::process_epoch::loop_stages(
-                    rpc_client.clone(),
-                    legacy_cli,
-                    legacy_operator_stage,
-                    override_target_slot,
-                    &tip_router_program_id,
-                    &tip_distribution_program_id,
-                    &priority_fee_distribution_program_id,
-                    &tip_payment_program_id,
-                    &ncn_address,
-                    save_snapshot,
-                    save_stages,
-                )
-                .await?;
-            }
+            let current_epoch_info = rpc_client.get_epoch_info().await?;
 
             // Endless loop that transitions between stages of the operator process.
             process_epoch::loop_stages(
@@ -548,6 +388,7 @@ async fn main() -> Result<()> {
                 &ncn_address,
                 save_snapshot,
                 save_stages,
+                current_epoch_info,
             )
             .await?;
         }

--- a/tip-router-operator-cli/src/process_epoch.rs
+++ b/tip-router-operator-cli/src/process_epoch.rs
@@ -215,18 +215,18 @@ pub async fn loop_stages(
                 if current_epoch_info.epoch
                     < legacy_tip_router_operator_cli::PRIORITY_FEE_MERKLE_TREE_START_EPOCH
                 {
-                    stake_meta_collection =
-                        Some(legacy_tip_router_operator_cli::create_stake_meta(
+                    stake_meta_collection = Some(StakeMetaCollection::from_legacy(
+                        legacy_tip_router_operator_cli::create_stake_meta(
                             operator_address.clone(),
                             epoch_to_process,
                             bank.as_ref().expect("Bank was not set"),
                             tip_distribution_program_id,
-                            priority_fee_distribution_program_id,
                             tip_payment_program_id,
                             &cli.get_save_path(),
                             save_stages,
                             &cli.cluster,
-                        ));
+                        ),
+                    ));
                 } else {
                     stake_meta_collection = Some(create_stake_meta(
                         operator_address.clone(),
@@ -266,9 +266,9 @@ pub async fn loop_stages(
                                 &cli.get_save_path(),
                             )
                         },
-                        |collection| collection,
+                        |collection| collection.to_legacy(),
                     );
-                    merkle_tree_collection = Some(
+                    merkle_tree_collection = Some(GeneratedMerkleTreeCollection::from_legacy(
                         legacy_tip_router_operator_cli::create_merkle_tree_collection(
                             cli.operator_address.clone(),
                             tip_router_program_id,
@@ -276,12 +276,11 @@ pub async fn loop_stages(
                             epoch_to_process,
                             ncn_address,
                             protocol_fee_bps,
-                            fees.priority_fee_distribution_fee_bps(),
                             &cli.get_save_path(),
                             save_stages,
                             &cli.cluster,
                         ),
-                    );
+                    ));
                 } else {
                     let some_stake_meta_collection = stake_meta_collection.to_owned().map_or_else(
                         || read_stake_meta_collection(epoch_to_process, &cli.get_save_path()),
@@ -318,7 +317,7 @@ pub async fn loop_stages(
                                     &cli.get_save_path(),
                                 )
                             },
-                            |collection| collection,
+                            |collection| collection.to_legacy(&tip_distribution_program_id),
                         );
                     let merkle_tree = legacy_tip_router_operator_cli::create_meta_merkle_tree(
                         cli.operator_address.clone(),

--- a/tip-router-operator-cli/src/process_epoch.rs
+++ b/tip-router-operator-cli/src/process_epoch.rs
@@ -111,6 +111,7 @@ pub async fn loop_stages(
     ncn_address: &Pubkey,
     enable_snapshots: bool,
     save_stages: bool,
+    current_epoch_info: EpochInfo,
 ) -> Result<()> {
     let keypair = read_keypair_file(&cli.keypair_path).expect("Failed to read keypair file");
     let mut current_epoch_info = rpc_client.get_epoch_info().await?;
@@ -156,11 +157,21 @@ pub async fn loop_stages(
                 wait_for_optimal_incremental_snapshot(incremental_snapshots_path, slot_to_process)
                     .await?;
 
-                bank = Some(load_bank_from_snapshot(
-                    cli.clone(),
-                    slot_to_process,
-                    enable_snapshots,
-                ));
+                if current_epoch_info.epoch
+                    < legacy_tip_router_operator_cli::PRIORITY_FEE_MERKLE_TREE_START_EPOCH
+                {
+                    bank = Some(legacy_tip_router_operator_cli::load_bank_from_snapshot(
+                        cli.as_legacy(),
+                        slot_to_process,
+                        enable_snapshots,
+                    ));
+                } else {
+                    bank = Some(load_bank_from_snapshot(
+                        cli.clone(),
+                        slot_to_process,
+                        enable_snapshots,
+                    ));
+                }
                 // Transition to the next stage
                 stage = OperatorState::CreateStakeMeta;
             }
@@ -201,27 +212,40 @@ pub async fn loop_stages(
                         }
                     }
                 }
-                stake_meta_collection = Some(create_stake_meta(
-                    operator_address.clone(),
-                    epoch_to_process,
-                    bank.as_ref().expect("Bank was not set"),
-                    tip_distribution_program_id,
-                    priority_fee_distribution_program_id,
-                    tip_payment_program_id,
-                    &cli.get_save_path(),
-                    save_stages,
-                    &cli.cluster,
-                ));
+                if current_epoch_info.epoch
+                    < legacy_tip_router_operator_cli::PRIORITY_FEE_MERKLE_TREE_START_EPOCH
+                {
+                    stake_meta_collection =
+                        Some(legacy_tip_router_operator_cli::create_stake_meta(
+                            operator_address.clone(),
+                            epoch_to_process,
+                            bank.as_ref().expect("Bank was not set"),
+                            tip_distribution_program_id,
+                            priority_fee_distribution_program_id,
+                            tip_payment_program_id,
+                            &cli.get_save_path(),
+                            save_stages,
+                            &cli.cluster,
+                        ));
+                } else {
+                    stake_meta_collection = Some(create_stake_meta(
+                        operator_address.clone(),
+                        epoch_to_process,
+                        bank.as_ref().expect("Bank was not set"),
+                        tip_distribution_program_id,
+                        priority_fee_distribution_program_id,
+                        tip_payment_program_id,
+                        &cli.get_save_path(),
+                        save_stages,
+                        &cli.cluster,
+                    ));
+                }
                 // we should be able to safely drop the bank in this loop
                 bank = None;
                 // Transition to the next stage
                 stage = OperatorState::CreateMerkleTreeCollection;
             }
             OperatorState::CreateMerkleTreeCollection => {
-                let some_stake_meta_collection = stake_meta_collection.to_owned().map_or_else(
-                    || read_stake_meta_collection(epoch_to_process, &cli.get_save_path()),
-                    |collection| collection,
-                );
                 let config =
                     get_ncn_config(&rpc_client, tip_router_program_id, ncn_address).await?;
                 // Tip Router looks backwards in time (typically current_epoch - 1) to calculated
@@ -232,39 +256,100 @@ pub async fn loop_stages(
                 let protocol_fee_bps = config.fee_config.adjusted_total_fees_bps(ballot_epoch)?;
 
                 // Generate the merkle tree collection
-                merkle_tree_collection = Some(create_merkle_tree_collection(
-                    cli.operator_address.clone(),
-                    tip_router_program_id,
-                    some_stake_meta_collection,
-                    epoch_to_process,
-                    ncn_address,
-                    protocol_fee_bps,
-                    fees.priority_fee_distribution_fee_bps(),
-                    &cli.get_save_path(),
-                    save_stages,
-                    &cli.cluster,
-                ));
+                if current_epoch_info.epoch
+                    < legacy_tip_router_operator_cli::PRIORITY_FEE_MERKLE_TREE_START_EPOCH
+                {
+                    let some_stake_meta_collection = stake_meta_collection.to_owned().map_or_else(
+                        || {
+                            legacy_tip_router_operator_cli::read_stake_meta_collection(
+                                epoch_to_process,
+                                &cli.get_save_path(),
+                            )
+                        },
+                        |collection| collection,
+                    );
+                    merkle_tree_collection = Some(
+                        legacy_tip_router_operator_cli::create_merkle_tree_collection(
+                            cli.operator_address.clone(),
+                            tip_router_program_id,
+                            some_stake_meta_collection,
+                            epoch_to_process,
+                            ncn_address,
+                            protocol_fee_bps,
+                            fees.priority_fee_distribution_fee_bps(),
+                            &cli.get_save_path(),
+                            save_stages,
+                            &cli.cluster,
+                        ),
+                    );
+                } else {
+                    let some_stake_meta_collection = stake_meta_collection.to_owned().map_or_else(
+                        || read_stake_meta_collection(epoch_to_process, &cli.get_save_path()),
+                        |collection| collection,
+                    );
+                    merkle_tree_collection = Some(create_merkle_tree_collection(
+                        cli.operator_address.clone(),
+                        tip_router_program_id,
+                        some_stake_meta_collection,
+                        epoch_to_process,
+                        ncn_address,
+                        protocol_fee_bps,
+                        fees.priority_fee_distribution_fee_bps(),
+                        &cli.get_save_path(),
+                        save_stages,
+                        &cli.cluster,
+                    ));
+                }
 
                 stake_meta_collection = None;
                 // Transition to the next stage
                 stage = OperatorState::CreateMetaMerkleTree;
             }
             OperatorState::CreateMetaMerkleTree => {
-                let some_merkle_tree_collection = merkle_tree_collection.to_owned().map_or_else(
-                    || read_merkle_tree_collection(epoch_to_process, &cli.get_save_path()),
-                    |collection| collection,
-                );
+                let mut merkle_root = [0u8; 32];
+                if current_epoch_info.epoch
+                    < legacy_tip_router_operator_cli::PRIORITY_FEE_MERKLE_TREE_START_EPOCH
+                {
+                    let some_merkle_tree_collection =
+                        merkle_tree_collection.to_owned().map_or_else(
+                            || {
+                                legacy_tip_router_operator_cli::read_merkle_tree_collection(
+                                    epoch_to_process,
+                                    &cli.get_save_path(),
+                                )
+                            },
+                            |collection| collection,
+                        );
+                    let merkle_tree = legacy_tip_router_operator_cli::create_meta_merkle_tree(
+                        cli.operator_address.clone(),
+                        some_merkle_tree_collection,
+                        epoch_to_process,
+                        &cli.get_save_path(),
+                        // This is defaulted to true because the output file is required by the
+                        //  task that sets TipDistributionAccounts' merkle roots
+                        true,
+                        &cli.cluster,
+                    );
+                    merkle_root = merkle_tree.merkle_root;
+                } else {
+                    let some_merkle_tree_collection =
+                        merkle_tree_collection.to_owned().map_or_else(
+                            || read_merkle_tree_collection(epoch_to_process, &cli.get_save_path()),
+                            |collection| collection,
+                        );
+                    let merkle_tree = create_meta_merkle_tree(
+                        cli.operator_address.clone(),
+                        some_merkle_tree_collection,
+                        epoch_to_process,
+                        &cli.get_save_path(),
+                        // This is defaulted to true because the output file is required by the
+                        //  task that sets TipDistributionAccounts' merkle roots
+                        true,
+                        &cli.cluster,
+                    );
+                    merkle_root = merkle_tree.merkle_root;
+                }
 
-                let merkle_tree = create_meta_merkle_tree(
-                    cli.operator_address.clone(),
-                    some_merkle_tree_collection,
-                    epoch_to_process,
-                    &cli.get_save_path(),
-                    // This is defaulted to true because the output file is required by the
-                    //  task that sets TipDistributionAccounts' merkle roots
-                    true,
-                    &cli.cluster,
-                );
                 datapoint_info!(
                     "tip_router_cli.process_epoch",
                     ("operator_address", operator_address, String),
@@ -273,7 +358,7 @@ pub async fn loop_stages(
                     ("state", "epoch_processing_completed", String),
                     (
                         "meta_merkle_root",
-                        format!("{:?}", merkle_tree.merkle_root),
+                        format!("{:?}", merkle_root),
                         String
                     ),
                     ("version", Version::default().to_string(), String),

--- a/tip-router-operator-cli/src/process_epoch.rs
+++ b/tip-router-operator-cli/src/process_epoch.rs
@@ -111,7 +111,6 @@ pub async fn loop_stages(
     ncn_address: &Pubkey,
     enable_snapshots: bool,
     save_stages: bool,
-    current_epoch_info: EpochInfo,
 ) -> Result<()> {
     let keypair = read_keypair_file(&cli.keypair_path).expect("Failed to read keypair file");
     let mut current_epoch_info = rpc_client.get_epoch_info().await?;
@@ -317,7 +316,7 @@ pub async fn loop_stages(
                                     &cli.get_save_path(),
                                 )
                             },
-                            |collection| collection.to_legacy(&tip_distribution_program_id),
+                            |collection| collection.to_legacy(),
                         );
                     let merkle_tree = legacy_tip_router_operator_cli::create_meta_merkle_tree(
                         cli.operator_address.clone(),


### PR DESCRIPTION
**Problem**

Go-live epoch conditional fallback logic was removed in a recent merge into priority-fee-distribution-support

**Solution**

- Re-introduce loop_stages legacy fallback logic to be executed before the go-live epoch
- Use branch v.1.3.0-legacy for the legacy_tip_router_operator_cli submodule