### PR TITLE
keeper: modify keypair path / config logic for containerized builds

### DIFF
--- a/cli/src/handler.rs
+++ b/cli/src/handler.rs
@@ -89,7 +89,7 @@ impl CliHandler {
                 match Config::load(config_file) {
                     Ok(config) => read_keypair_file(config.keypair_path.as_str())
                         .map_err(|e| anyhow!("Failed to read keypair path: {e:?}"))?,
-                    Err(_) => read_keypair_file(&args.keypair_path.clone().unwrap())
+                    Err(_) => read_keypair_file(args.keypair_path.clone().unwrap())
                         .map_err(|e| anyhow!("Failed to read keypair path: {e:?}"))?,
                 }
             }

--- a/cli/src/handler.rs
+++ b/cli/src/handler.rs
@@ -86,13 +86,12 @@ impl CliHandler {
                 let config_file = solana_cli_config::CONFIG_FILE
                     .as_ref()
                     .ok_or_else(|| anyhow!("unable to get config file path"))?;
-                let config = Config::load(config_file)?;
-                let keypair_path = match &args.keypair_path {
-                    Some(path) => path.as_str(),
-                    None => config.keypair_path.as_str(),
-                };
-                read_keypair_file(keypair_path)
-                    .map_err(|e| anyhow!("Failed to read keypair path: {e:?}"))?
+                match Config::load(config_file) {
+                    Ok(config) => read_keypair_file(config.keypair_path.as_str())
+                        .map_err(|e| anyhow!("Failed to read keypair path: {e:?}"))?,
+                    Err(_) => read_keypair_file(&args.keypair_path.clone().unwrap())
+                        .map_err(|e| anyhow!("Failed to read keypair path: {e:?}"))?,
+                }
             }
         };
 


### PR DESCRIPTION
**Problem**
- Keypair path logic fails in our current tip-router-cli keeper dockerized build due to lack of solana config within container
- Keypair path argument is never read if there is no Solana config at the expected default path

**Solution**
- If Solana config file exists: use keypair path
- If Solana config does not exist: use keypair path argument