### PR TITLE
fix: claims logic when total_fees are greater than total_tips

### DIFF
--- a/meta_merkle_tree/src/generated_merkle_tree.rs
+++ b/meta_merkle_tree/src/generated_merkle_tree.rs
@@ -1593,35 +1593,5 @@ mod tests {
                     });
                 assert_eq!(expected_gmt.merkle_root, actual_gmt.merkle_root);
             });
-
-        let epoch = 761;
-        let merkle_tree_collection = GeneratedMerkleTreeCollection::new_from_stake_meta_collection(
-            stake_meta_collection.clone(),
-            &ncn_address,
-            epoch,
-            300,
-            150,
-            &tip_router_program_id,
-        )
-        .unwrap();
-        merkle_tree_collection
-            .generated_merkle_trees
-            .iter()
-            .for_each(|gmt| {
-                // Ensure that validator vote account exists as a claimant in the new merkle tree collection
-                // and does not contain identity account as claimant.
-                assert!(gmt
-                    .tree_nodes
-                    .iter()
-                    .any(|node| node.claimant == validator_vote_account_0
-                        || node.claimant == validator_vote_account_1));
-                assert!(
-                    !(gmt
-                        .tree_nodes
-                        .iter()
-                        .any(|node| node.claimant == validator_id_0
-                            || node.claimant == validator_id_1))
-                );
-            });
     }
 }

--- a/meta_merkle_tree/src/generated_merkle_tree.rs
+++ b/meta_merkle_tree/src/generated_merkle_tree.rs
@@ -25,6 +25,8 @@ use thiserror::Error;
 
 use crate::{merkle_tree::MerkleTree, utils::get_proof};
 
+pub const VOTE_ACCOUNT_CLAIM_CALCULATION_UPDATE_EPOCH: u64 = 815;
+
 pub fn mul_div(a: u64, b: u64, q: u64) -> Result<u64, MerkleRootGeneratorError> {
     (a as u128)
         .checked_mul(b as u128)
@@ -355,9 +357,9 @@ impl TreeNode {
 
         // For Priority Fee Distributions, there is no validator amount, 0 is passed in for
         // validator_fee_bps
-        let validator_amount = mul_div(total_tips, validator_fee_bps as u64, MAX_BPS as u64)?;
+        let mut validator_amount = mul_div(total_tips, validator_fee_bps as u64, MAX_BPS as u64)?;
 
-        let (validator_amount, remaining_total_rewards) = validator_amount
+        let (updated_validator_amount, remaining_total_rewards) = validator_amount
             .checked_add(protocol_fee_amount)
             .map_or((validator_amount, None), |total_fees| {
                 if total_fees > total_tips {
@@ -376,6 +378,12 @@ impl TreeNode {
                     )
                 }
             });
+
+        if epoch < VOTE_ACCOUNT_CLAIM_CALCULATION_UPDATE_EPOCH {
+            // Do nothing, old logic is used
+        } else {
+            validator_amount = updated_validator_amount;
+        }
 
         let remaining_total_rewards =
             remaining_total_rewards.ok_or(MerkleRootGeneratorError::CheckedMathError)?;
@@ -1358,7 +1366,7 @@ mod tests {
     }
 
     #[test]
-    fn test_new_from_stake_meta_collection_total_fees_greater_than_total_tips() {
+    fn test_new_from_stake_meta_collection_legacy_full_commission_claim() {
         let merkle_root_upload_authority = Pubkey::new_unique();
         let tip_distribution_program_id = TIP_DISTRIBUTION_ID;
         let priority_fee_distribution_program_id = PRIORITY_FEE_DISTRIBUTION_ID;
@@ -1377,6 +1385,220 @@ mod tests {
         let validator_id_0 = Pubkey::new_unique();
         let ncn_address = Pubkey::new_unique();
         let epoch = 737;
+
+        let stake_meta_collection = StakeMetaCollection {
+            stake_metas: vec![StakeMeta {
+                validator_vote_account: validator_vote_account_0,
+                validator_node_pubkey: validator_id_0,
+                maybe_tip_distribution_meta: Some(TipDistributionMeta {
+                    merkle_root_upload_authority,
+                    tip_distribution_pubkey: tda_0,
+                    total_tips: 1_900_122_111_000,
+                    validator_fee_bps: 10_000,
+                }),
+                delegations: vec![
+                    Delegation {
+                        stake_account_pubkey: stake_account_0,
+                        staker_pubkey: staker_account_0,
+                        withdrawer_pubkey: staker_account_0,
+                        lamports_delegated: 123_999_123_555,
+                    },
+                    Delegation {
+                        stake_account_pubkey: stake_account_1,
+                        staker_pubkey: staker_account_1,
+                        withdrawer_pubkey: staker_account_1,
+                        lamports_delegated: 144_555_444_556,
+                    },
+                ],
+                total_delegated: 1_555_123_000_333_454_000,
+                commission: 100,
+                maybe_priority_fee_distribution_meta: Some(PriorityFeeDistributionMeta {
+                    merkle_root_upload_authority,
+                    priority_fee_distribution_pubkey: pf_tda_0,
+                    total_tips: 2_546_000_000,
+                    validator_fee_bps: 10_000,
+                }),
+            }],
+            tip_distribution_program_id,
+            priority_fee_distribution_program_id,
+            bank_hash: Hash::new_unique().to_string(),
+            epoch: 100,
+            slot: 2_000_000,
+        };
+
+        let merkle_tree_collection = GeneratedMerkleTreeCollection::new_from_stake_meta_collection(
+            stake_meta_collection.clone(),
+            &ncn_address,
+            epoch,
+            300,
+            150,
+            &tip_router_program_id,
+        )
+        .unwrap();
+
+        assert_eq!(stake_meta_collection.epoch, merkle_tree_collection.epoch);
+        assert_eq!(
+            stake_meta_collection.bank_hash,
+            merkle_tree_collection.bank_hash
+        );
+        assert_eq!(stake_meta_collection.slot, merkle_tree_collection.slot);
+        assert_eq!(
+            stake_meta_collection.stake_metas.len() * 2,
+            merkle_tree_collection.generated_merkle_trees.len()
+        );
+
+        let protocol_fee_recipient = Pubkey::find_program_address(
+            &[
+                b"base_reward_receiver",
+                &ncn_address.to_bytes(),
+                &(epoch + 1).to_le_bytes(),
+            ],
+            &tip_router_program_id,
+        )
+        .0;
+
+        let claim_statuses = &[
+            (protocol_fee_recipient, tda_0),
+            (validator_vote_account_0, tda_0),
+            (stake_account_0, tda_0),
+            (stake_account_1, tda_0),
+            (protocol_fee_recipient, tda_1),
+            (validator_vote_account_1, tda_1),
+            (stake_account_2, tda_1),
+            (stake_account_3, tda_1),
+        ]
+        .iter()
+        .map(|(claimant, tda)| {
+            Pubkey::find_program_address(
+                &[CLAIM_STATUS_SEED, &claimant.to_bytes(), &tda.to_bytes()],
+                &TIP_DISTRIBUTION_ID,
+            )
+        })
+        .collect::<Vec<(Pubkey, u8)>>();
+
+        let tree_nodes = vec![
+            TreeNode {
+                claimant: protocol_fee_recipient,
+                claim_status_pubkey: claim_statuses[0].0,
+                claim_status_bump: claim_statuses[0].1,
+                staker_pubkey: Pubkey::default(),
+                withdrawer_pubkey: Pubkey::default(),
+                amount: 57_003_663_330, // 3% of 1_900_122_111_000
+                proof: None,
+            },
+            TreeNode {
+                claimant: validator_vote_account_0,
+                claim_status_pubkey: claim_statuses[1].0,
+                claim_status_bump: claim_statuses[1].1,
+                staker_pubkey: Pubkey::default(),
+                withdrawer_pubkey: Pubkey::default(),
+                amount: 1_900_122_111_000, // 100% of total tips
+                proof: None,
+            },
+            TreeNode {
+                claimant: stake_account_0,
+                claim_status_pubkey: claim_statuses[2].0,
+                claim_status_bump: claim_statuses[2].1,
+                staker_pubkey: staker_account_0,
+                withdrawer_pubkey: staker_account_0,
+                amount: 0,
+                proof: None,
+            },
+            TreeNode {
+                claimant: stake_account_1,
+                claim_status_pubkey: claim_statuses[3].0,
+                claim_status_bump: claim_statuses[3].1,
+                staker_pubkey: staker_account_1,
+                withdrawer_pubkey: staker_account_1,
+                amount: 0,
+                proof: None,
+            },
+        ];
+
+        let hashed_nodes: Vec<[u8; 32]> = tree_nodes.iter().map(|n| n.hash().to_bytes()).collect();
+        let merkle_tree = MerkleTree::new(&hashed_nodes[..], true);
+        let gmt_0 = GeneratedMerkleTree {
+            distribution_program: TIP_DISTRIBUTION_ID,
+            distribution_account: tda_0,
+            merkle_root_upload_authority,
+            merkle_root: *merkle_tree.get_root().unwrap(),
+            tree_nodes,
+            max_total_claim: stake_meta_collection.stake_metas[0]
+                .clone()
+                .maybe_tip_distribution_meta
+                .unwrap()
+                .total_tips,
+            max_num_nodes: 4,
+        };
+
+        let expected_generated_merkle_trees = vec![gmt_0];
+        let actual_generated_merkle_trees = merkle_tree_collection.generated_merkle_trees;
+        expected_generated_merkle_trees
+            .iter()
+            .for_each(|expected_gmt| {
+                let actual_gmt = actual_generated_merkle_trees
+                    .iter()
+                    .find(|gmt| {
+                        gmt.distribution_account == expected_gmt.distribution_account
+                            && gmt.distribution_program == expected_gmt.distribution_program
+                    })
+                    .unwrap();
+                assert_eq!(expected_gmt.max_num_nodes, actual_gmt.max_num_nodes);
+                assert_eq!(expected_gmt.max_total_claim, actual_gmt.max_total_claim);
+                assert_eq!(
+                    expected_gmt.distribution_account,
+                    actual_gmt.distribution_account
+                );
+                assert_eq!(expected_gmt.tree_nodes.len(), actual_gmt.tree_nodes.len());
+                expected_gmt
+                    .tree_nodes
+                    .iter()
+                    .for_each(|expected_tree_node| {
+                        let actual_tree_node = actual_gmt
+                            .tree_nodes
+                            .iter()
+                            .find(|tree_node| tree_node.claimant == expected_tree_node.claimant)
+                            .unwrap();
+                        if expected_tree_node.claimant == validator_vote_account_0 {
+                            let expected_amount = expected_gmt.max_total_claim;
+                            let actual_amount = actual_tree_node.amount;
+                            assert_eq!(
+                                expected_amount, actual_amount,
+                                "Expected amount: {}, Actual amount: {}",
+                                expected_amount, actual_amount
+                            );
+                        } else {
+                            assert_eq!(
+                                expected_tree_node.amount, actual_tree_node.amount,
+                                "Expected amount: {}, Actual amount: {}",
+                                expected_tree_node.amount, actual_tree_node.amount
+                            );
+                        }
+                    });
+                assert_eq!(expected_gmt.merkle_root, actual_gmt.merkle_root);
+            });
+    }
+
+    #[test]
+    fn test_new_from_stake_meta_collection_updated_full_commission_claim() {
+        let merkle_root_upload_authority = Pubkey::new_unique();
+        let tip_distribution_program_id = TIP_DISTRIBUTION_ID;
+        let priority_fee_distribution_program_id = PRIORITY_FEE_DISTRIBUTION_ID;
+        let tip_router_program_id = Pubkey::new_unique();
+        let (tda_0, tda_1) = (Pubkey::new_unique(), Pubkey::new_unique());
+        let pf_tda_0 = Pubkey::new_unique();
+        let stake_account_0 = Pubkey::new_unique();
+        let stake_account_1 = Pubkey::new_unique();
+        let stake_account_2 = Pubkey::new_unique();
+        let stake_account_3 = Pubkey::new_unique();
+        let staker_account_0 = Pubkey::new_unique();
+        let staker_account_1 = Pubkey::new_unique();
+
+        let validator_vote_account_0 = Pubkey::new_unique();
+        let validator_vote_account_1 = Pubkey::new_unique();
+        let validator_id_0 = Pubkey::new_unique();
+        let ncn_address = Pubkey::new_unique();
+        let epoch = 815;
 
         let stake_meta_collection = StakeMetaCollection {
             stake_metas: vec![StakeMeta {

--- a/meta_merkle_tree/src/generated_merkle_tree.rs
+++ b/meta_merkle_tree/src/generated_merkle_tree.rs
@@ -1364,7 +1364,7 @@ mod tests {
         let priority_fee_distribution_program_id = PRIORITY_FEE_DISTRIBUTION_ID;
         let tip_router_program_id = Pubkey::new_unique();
         let (tda_0, tda_1) = (Pubkey::new_unique(), Pubkey::new_unique());
-        let (pf_tda_0, pf_tda_1) = (Pubkey::new_unique(), Pubkey::new_unique());
+        let pf_tda_0 = Pubkey::new_unique();
         let stake_account_0 = Pubkey::new_unique();
         let stake_account_1 = Pubkey::new_unique();
         let stake_account_2 = Pubkey::new_unique();

--- a/meta_merkle_tree/src/generated_merkle_tree.rs
+++ b/meta_merkle_tree/src/generated_merkle_tree.rs
@@ -1371,12 +1371,10 @@ mod tests {
         let stake_account_3 = Pubkey::new_unique();
         let staker_account_0 = Pubkey::new_unique();
         let staker_account_1 = Pubkey::new_unique();
-        let staker_account_2 = Pubkey::new_unique();
-        let staker_account_3 = Pubkey::new_unique();
+
         let validator_vote_account_0 = Pubkey::new_unique();
         let validator_vote_account_1 = Pubkey::new_unique();
         let validator_id_0 = Pubkey::new_unique();
-        let validator_id_1 = Pubkey::new_unique();
         let ncn_address = Pubkey::new_unique();
         let epoch = 737;
 
@@ -1470,25 +1468,6 @@ mod tests {
         })
         .collect::<Vec<(Pubkey, u8)>>();
 
-        let pf_claim_statuses = &[
-            (protocol_fee_recipient, pf_tda_0),
-            (validator_vote_account_0, pf_tda_0),
-            (stake_account_0, pf_tda_0),
-            (stake_account_1, pf_tda_0),
-            (protocol_fee_recipient, pf_tda_1),
-            (validator_vote_account_1, pf_tda_1),
-            (stake_account_2, pf_tda_1),
-            (stake_account_3, pf_tda_1),
-        ]
-        .iter()
-        .map(|(claimant, tda)| {
-            Pubkey::find_program_address(
-                &[CLAIM_STATUS_SEED, &claimant.to_bytes(), &tda.to_bytes()],
-                &PRIORITY_FEE_DISTRIBUTION_ID,
-            )
-        })
-        .collect::<Vec<(Pubkey, u8)>>();
-
         let tree_nodes = vec![
             TreeNode {
                 claimant: protocol_fee_recipient,
@@ -1505,7 +1484,7 @@ mod tests {
                 claim_status_bump: claim_statuses[1].1,
                 staker_pubkey: Pubkey::default(),
                 withdrawer_pubkey: Pubkey::default(),
-                amount: (1_900_122_111_000i128 - 57_003_663_330i128) as u64,
+                amount: (1_900_122_111_000i128 - 57_003_663_330i128) as u64, // 97% of total tips
                 proof: None,
             },
             TreeNode {
@@ -1514,7 +1493,7 @@ mod tests {
                 claim_status_bump: claim_statuses[2].1,
                 staker_pubkey: staker_account_0,
                 withdrawer_pubkey: staker_account_0,
-                amount: 0, // Update to match actual amount
+                amount: 0,
                 proof: None,
             },
             TreeNode {
@@ -1523,7 +1502,7 @@ mod tests {
                 claim_status_bump: claim_statuses[3].1,
                 staker_pubkey: staker_account_1,
                 withdrawer_pubkey: staker_account_1,
-                amount: 0, // Update to match actual amount
+                amount: 0,
                 proof: None,
             },
         ];

--- a/tip-router-operator-cli/src/claim.rs
+++ b/tip-router-operator-cli/src/claim.rs
@@ -105,7 +105,7 @@ pub async fn emit_claim_mev_tips_metrics(
         return Ok(());
     }
 
-    let (_claims_to_process, num_total_unprocessed) = get_claim_transactions_for_valid_unclaimed(
+    let all_claim_transactions = get_claim_transactions_for_valid_unclaimed(
         &rpc_client,
         &merkle_trees,
         tip_distribution_program_id,
@@ -121,12 +121,12 @@ pub async fn emit_claim_mev_tips_metrics(
 
     datapoint_info!(
         "tip_router_cli.claim_mev_tips-send_summary",
-        ("claim_transactions_left", num_total_unprocessed, i64),
+        ("claim_transactions_left", all_claim_transactions.len(), i64),
         ("epoch", epoch, i64),
         "cluster" => &cli.cluster,
     );
 
-    if num_total_unprocessed == 0 {
+    if all_claim_transactions.is_empty() {
         add_completed_epoch(epoch, current_epoch, file_path, file_mutex).await?;
     }
 
@@ -424,37 +424,36 @@ pub async fn claim_mev_tips(
 
     let start = Instant::now();
     while start.elapsed() <= max_loop_duration {
-        let (mut claims_to_process, num_total_unprocessed_claims) =
-            get_claim_transactions_for_valid_unclaimed(
-                &rpc_client,
-                merkle_trees,
-                tip_distribution_program_id,
-                priority_fee_distribution_program_id,
-                tip_router_program_id,
-                ncn,
-                micro_lamports,
-                keypair.pubkey(),
-                operator_address,
-                cluster,
-            )
-            .await?;
+        let mut all_claim_transactions = get_claim_transactions_for_valid_unclaimed(
+            &rpc_client,
+            merkle_trees,
+            tip_distribution_program_id,
+            priority_fee_distribution_program_id,
+            tip_router_program_id,
+            ncn,
+            micro_lamports,
+            keypair.pubkey(),
+            operator_address,
+            cluster,
+        )
+        .await?;
 
         datapoint_info!(
             "tip_router_cli.claim_mev_tips-send_summary",
-            ("claim_transactions_left", num_total_unprocessed_claims, i64),
+            ("claim_transactions_left", all_claim_transactions.len(), i64),
             ("epoch", epoch, i64),
             ("operator", operator_address, String),
             "cluster" => cluster,
         );
 
-        if num_total_unprocessed_claims == 0 {
+        if all_claim_transactions.is_empty() {
             add_completed_epoch(epoch, current_epoch, file_path, file_mutex).await?;
             return Ok(());
         }
 
-        claims_to_process.shuffle(&mut thread_rng());
+        all_claim_transactions.shuffle(&mut thread_rng());
 
-        for transactions in claims_to_process.chunks(2_000) {
+        for transactions in all_claim_transactions.chunks(2_000) {
             let transactions: Vec<_> = transactions.to_vec();
             // only check balance for the ones we need to currently send since reclaim rent running in parallel
             if let Some((start_balance, desired_balance, sol_to_deposit)) =
@@ -484,7 +483,7 @@ pub async fn claim_mev_tips(
         }
     }
 
-    let (transactions, num_total_unprocessed_claims) = get_claim_transactions_for_valid_unclaimed(
+    let transactions = get_claim_transactions_for_valid_unclaimed(
         &rpc_client,
         merkle_trees,
         tip_distribution_program_id,
@@ -497,7 +496,7 @@ pub async fn claim_mev_tips(
         cluster,
     )
     .await?;
-    if num_total_unprocessed_claims == 0 {
+    if transactions.is_empty() {
         add_completed_epoch(epoch, current_epoch, file_path, file_mutex).await?;
         return Ok(());
     }
@@ -562,11 +561,11 @@ pub async fn get_claim_transactions_for_valid_unclaimed(
     payer_pubkey: Pubkey,
     operator_address: &String,
     cluster: &str,
-) -> Result<(Vec<Transaction>, usize), ClaimMevError> {
+) -> Result<Vec<Transaction>, ClaimMevError> {
     let epoch = merkle_trees.epoch;
     let tip_router_config_address = Config::find_program_address(&tip_router_program_id, &ncn).0;
 
-    let all_tree_nodes = merkle_trees
+    let tree_nodes = merkle_trees
         .generated_merkle_trees
         .iter()
         .filter_map(|tree| {
@@ -579,28 +578,9 @@ pub async fn get_claim_transactions_for_valid_unclaimed(
         .flatten()
         .collect_vec();
 
-    let validator_tree_nodes = merkle_trees
-        .generated_merkle_trees
-        .iter()
-        .filter_map(|tree| {
-            if tree.merkle_root_upload_authority != tip_router_config_address {
-                return None;
-            }
-
-            Some(vec![&tree.tree_nodes[1]])
-        })
-        .flatten()
-        .collect_vec();
-
-    let tree_nodes = if validator_tree_nodes.is_empty() {
-        all_tree_nodes.to_owned()
-    } else {
-        validator_tree_nodes.to_owned()
-    };
-
     info!(
         "reading {} tip distribution related accounts for epoch {}",
-        all_tree_nodes.len(),
+        tree_nodes.len(),
         epoch
     );
 
@@ -671,7 +651,7 @@ pub async fn get_claim_transactions_for_valid_unclaimed(
         cluster,
     );
 
-    Ok((transactions, all_tree_nodes.len()))
+    Ok(transactions)
 }
 
 /// Returns a list of claim transactions for valid, unclaimed MEV tips


### PR DESCRIPTION
**Problem**
The amount to pay out to vote account claimants is not calculated correctly when total_fees exceed total_tips. This scenario manifests when validator commission bps on tip distributions is set to 10_000.

**Solution**
- Subtract protocol fees from vote account claimant payouts when total fees exceed total tips
- Test case for 10_000 bps commission on tip distribution
- Test case for legacy calculation (feature gated at epoch 815)