### PR TITLE
CI/CD: Add procps

### DIFF
--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -25,6 +25,7 @@ FROM debian:bullseye-slim as jito-tip-router-ncn-keeper
 RUN apt-get update && apt-get install -y \
     ca-certificates \
     libssl1.1 \
+    procps \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /usr/src/app/target/release/jito-tip-router-cli /usr/local/bin/jito-tip-router-cli


### PR DESCRIPTION
- To do health check of NCN Keeper on remote machine, we need to install `procps` library