### PR TITLE
CI/CD: Change to `big-runner-1`

### DIFF
--- a/.github/workflows/build-container-images.yaml
+++ b/.github/workflows/build-container-images.yaml
@@ -17,7 +17,7 @@ env:
 
 jobs:
   build-container:
-    runs-on: ubuntu-latest
+    runs-on: big-runner-1
     
     steps:
     - name: Checkout repository


### PR DESCRIPTION
### Problem

- Took time to build and publish image of ncn-keeper

### Solution

- Changes the runner from `ubuntu-latest` to `big-runner-1` for the build-container job