### PR TITLE
operator: improve error handling in critical path

### DIFF
--- a/tip-router-operator-cli/src/process_epoch.rs
+++ b/tip-router-operator-cli/src/process_epoch.rs
@@ -119,6 +119,13 @@ pub async fn loop_stages(
                 Ok(info) => break info,
                 Err(e) => {
                     error!("Error getting epoch info from RPC. Retrying...");
+                    datapoint_error!(
+                        "tip_router_cli.get_epoch_info",
+                        ("operator_address", cli.operator_address.clone(), String),
+                        ("status", "error", String),
+                        ("error", e.to_string(), String),
+                        "cluster" => &cli.cluster,
+                    );
                     tokio::time::sleep(Duration::from_secs(5)).await;
                 }
             }
@@ -131,6 +138,13 @@ pub async fn loop_stages(
                 Ok(schedule) => break schedule,
                 Err(e) => {
                     error!("Error getting epoch schedule from RPC. Retrying...");
+                    datapoint_error!(
+                        "tip_router_cli.get_epoch_schedule",
+                        ("operator_address", cli.operator_address.clone(), String),
+                        ("status", "error", String),
+                        ("error", e.to_string(), String),
+                        "cluster" => &cli.cluster,
+                    );
                     tokio::time::sleep(Duration::from_secs(5)).await;
                 }
             }
@@ -332,6 +346,15 @@ pub async fn loop_stages(
                     error!(
                         "Failed to submit epoch {} to NCN: {:?}",
                         epoch_to_process, e
+                    );
+                    datapoint_error!(
+                        "tip_router_cli.cast_vote",
+                        ("operator_address", operator_address.to_string(), String),
+                        ("epoch", epoch_to_process, i64),
+                        ("status", "error", String),
+                        ("error", e.to_string(), String),
+                        ("state", "cast_vote", String),
+                        "cluster" => &cli.cluster,
                     );
                 }
                 stage = OperatorState::WaitForNextEpoch;


### PR DESCRIPTION
**Problem:** Internal and external operators have seen transient errors crashing tip router operator. These errors are generally related to a timed out RPC request. Upon examining loop_stages I have found errors that perhaps are not handled in the way we would like.

**Solution:** 
- Wait for epoch info and schedule rpc requests to come back, log failures, this state is required to do anything useful with the operator. A failed request should be handled gracefully, this action is periodic.
- We should not handle submit_to_ncn in CastVote with `?`, log an error here, this gives the operator a chance to vote again and recover from any potential RPC issues that were responsible for the failure.