### PR TITLE
Allow bank replay w/o block cost limits

### DIFF
--- a/tip-router-operator-cli/src/ledger_utils.rs
+++ b/tip-router-operator-cli/src/ledger_utils.rs
@@ -202,6 +202,7 @@ pub fn get_bank_from_ledger(
 
     let process_options = ProcessOptions {
         halt_at_slot: Some(desired_slot.to_owned()),
+        no_block_cost_limits: true,
         ..Default::default()
     };
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Disable block cost limits in ledger replay by setting `ProcessOptions.no_block_cost_limits = true`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6172b6982899730f0e8905d2efddb443736efede. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->