### PR TITLE
Operator: Fix key name

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,29 @@
+[advisories]
+ignore = [
+    # Vulnerabilities (transitive deps from jito-solana/switchboard)
+    "RUSTSEC-2022-0093", # ed25519-dalek - double public key signing
+    "RUSTSEC-2024-0344", # curve25519-dalek - timing variability
+    "RUSTSEC-2024-0375", # atty - potential unaligned read
+    "RUSTSEC-2024-0421", # idna - IDNA 2003 compatibility
+    "RUSTSEC-2025-0009", # ring 0.16 - vulnerability
+    "RUSTSEC-2026-0001", # rkyv - unsound
+    "RUSTSEC-2026-0007", # bytes - vulnerability
+    "RUSTSEC-2026-0009", # time - vulnerability
+    "RUSTSEC-2026-0037", # quinn-proto - vulnerability
+    "RUSTSEC-2026-0049", # rustls-webpki - CRL matching
+    "RUSTSEC-2026-0067", # tar - symlink chmod
+    "RUSTSEC-2026-0068", # tar - PAX size headers
+    # Unmaintained/unsound (transitive deps)
+    "RUSTSEC-2020-0016", # net2 - deprecated
+    "RUSTSEC-2021-0139", # ansi_term - unmaintained
+    "RUSTSEC-2021-0141", # dotenv - unmaintained
+    "RUSTSEC-2021-0145", # atty - unsound
+    "RUSTSEC-2024-0384", # instant - unmaintained
+    "RUSTSEC-2024-0388", # derivative - unmaintained
+    "RUSTSEC-2024-0436", # paste - unmaintained
+    "RUSTSEC-2025-0010", # ring 0.16 - unmaintained
+    "RUSTSEC-2025-0012", # backoff - unmaintained
+    "RUSTSEC-2025-0134", # rustls-pemfile - unmaintained
+    "RUSTSEC-2025-0141", # bincode - unmaintained
+    "RUSTSEC-2026-0012", # keccak - unsound ARMv8 backend
+]

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,7 +24,7 @@ jobs:
         with:
           crate: cargo-audit
       - run: |
-          cargo audit --ignore RUSTSEC-2022-0093 --ignore RUSTSEC-2024-0344 --ignore RUSTSEC-2024-0421 --ignore RUSTSEC-2024-0375 --ignore RUSTSEC-2025-0009 --ignore RUSTSEC-2025-0022 --ignore RUSTSEC-2026-0001 --ignore RUSTSEC-2026-0007 --ignore RUSTSEC-2026-0009 --ignore RUSTSEC-2026-0037
+          cargo audit
 
   code_gen:
     name: code generation

--- a/tip-router-operator-cli/src/claim.rs
+++ b/tip-router-operator-cli/src/claim.rs
@@ -122,7 +122,7 @@ pub async fn emit_claim_mev_tips_metrics(
         match get_epoch_percentage(&rpc_client).await {
             Ok(epoch_percentage) => {
                 datapoint_info!(
-                    "tip_router_cli.claim_mev_tips-send_summary",
+                    "tip_router_cli.claim_mev_tips-metrics_only",
                     ("claim_transactions_left", claims_to_process.len(), i64),
                     ("epoch", epoch, i64),
                     ("epoch_percentage", epoch_percentage, f64),
@@ -130,7 +130,7 @@ pub async fn emit_claim_mev_tips_metrics(
                 );
             }
             Err(e) => {
-                warn!("Failed to fetch epoch percentage for claims: {:?}", e);
+                warn!("Failed to fetch epoch percentage for claims: {e:?}");
             }
         }
     }


### PR DESCRIPTION
- Rename metrics-only datapoint
 `emit_claim_mev_tips_metrics` now emits to `tip_router_cli.claim_mev_tips-metrics_only` instead of sharing the same key as the claim path, preventing false alarm triggers.

https://github.com/jito-foundation/jito-tip-router/blob/8fe8d5e2cc7ea442c7576dbae3c016b69c5041c4/tip-router-operator-cli/src/claim.rs#L339-L346



```bash
cargo zigbuild --release --target x86_64-unknown-linux-musl -p tip-router-operator-cli
```