### PR TITLE
Operator: Fix claim metrics sleep outside epoch offset loop

### DIFF
--- a/tip-router-operator-cli/src/main.rs
+++ b/tip-router-operator-cli/src/main.rs
@@ -292,9 +292,10 @@ async fn main() -> Result<()> {
                                 }
                             }
 
-                            info!("Sleeping for 30 minutes before next emit claim cycle");
-                            sleep(Duration::from_secs(1800)).await;
                         }
+
+                        info!("Sleeping for 30 minutes before next emit claim cycle");
+                        sleep(Duration::from_secs(1800)).await;
                     }
                 });
             }

--- a/tip-router-operator-cli/src/main.rs
+++ b/tip-router-operator-cli/src/main.rs
@@ -291,7 +291,6 @@ async fn main() -> Result<()> {
                                     );
                                 }
                             }
-
                         }
 
                         info!("Sleeping for 30 minutes before next emit claim cycle");


### PR DESCRIPTION
## Summary

- The 30-minute sleep in the `claim_tips_metrics` task was incorrectly placed **inside** the `for epoch_offset` loop, causing metrics to be emitted only once per 90 minutes (with default `claim_tips_epoch_lookback = 3`) and older epoch offsets often producing no datapoints at all
- Moved the sleep **outside** the loop so all epoch offsets are emitted in a single cycle, then the task sleeps 30 minutes before the next full cycle — matching the original intended behavior

We changed sleep schedule accidentally in this PR
https://github.com/jito-foundation/jito-tip-router/pull/171/changes

## Test plan

- [ ] Confirm Grafana shows `claim_transactions_left` datapoints every ~30 minutes instead of every ~90 minutes
- [ ] Confirm all epoch offsets (0, 1, 2) emit within the same cycle before the sleep

