### PR TITLE
Operator: Use wincode

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -15,6 +15,7 @@ ignore = [
     "RUSTSEC-2026-0068", # tar - PAX size headers
     "RUSTSEC-2026-0098", # rustls-webpki - URI name constraints
     "RUSTSEC-2026-0099", # rustls-webpki - wildcard name constraints
+    "RUSTSEC-2026-0104", # rustls-webpki
     # Unmaintained/unsound (transitive deps)
     "RUSTSEC-2020-0016", # net2 - deprecated
     "RUSTSEC-2021-0139", # ansi_term - unmaintained

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -63,7 +63,7 @@ jobs:
         uses: baptiste0928/cargo-install@v3
         with:
           crate: cargo-sort
-          version: 2.1.1
+          version: 2.1.3
       - run: cargo sort --workspace --check
       - run: cargo fmt --all --check
       - run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -181,6 +181,7 @@ jobs:
       - run: cargo nextest run --all-features -E 'not test(ledger_utils::tests)'
         env:
           SBPF_OUT_DIR: ${{ github.workspace }}/integration_tests/tests/fixtures
+          PROTOC: /usr/bin/protoc
 
   # create_release:
   #   name: Create Release

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,7 +75,7 @@ dependencies = [
  "solana-bls-signatures",
  "solana-signer-store",
  "thiserror 2.0.18",
- "wincode",
+ "wincode 0.4.9",
 ]
 
 [[package]]
@@ -356,7 +356,7 @@ dependencies = [
  "solana-vote",
  "solana-vote-program",
  "thiserror 2.0.18",
- "wincode",
+ "wincode 0.4.9",
 ]
 
 [[package]]
@@ -375,7 +375,7 @@ dependencies = [
  "solana-pubkey 4.1.0",
  "solana-signer-store",
  "thiserror 2.0.18",
- "wincode",
+ "wincode 0.4.9",
 ]
 
 [[package]]
@@ -5067,6 +5067,7 @@ dependencies = [
  "spl-math",
  "spl-token-interface",
  "thiserror 2.0.18",
+ "wincode 0.5.2",
 ]
 
 [[package]]
@@ -6863,7 +6864,7 @@ dependencies = [
  "once_cell",
  "ring 0.17.14",
  "rustls-pki-types",
- "rustls-webpki 0.103.10",
+ "rustls-webpki 0.103.13",
  "subtle",
  "zeroize",
 ]
@@ -6913,7 +6914,7 @@ dependencies = [
  "rustls 0.23.37",
  "rustls-native-certs",
  "rustls-platform-verifier-android",
- "rustls-webpki 0.103.10",
+ "rustls-webpki 0.103.13",
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
@@ -6938,9 +6939,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring 0.17.14",
  "rustls-pki-types",
@@ -7748,7 +7749,7 @@ dependencies = [
  "solana-program-error 3.0.1",
  "solana-sanitize 3.0.1",
  "solana-sha256-hasher 3.1.0",
- "wincode",
+ "wincode 0.4.9",
 ]
 
 [[package]]
@@ -8603,7 +8604,7 @@ dependencies = [
  "tonic",
  "tonic-build",
  "trees",
- "wincode",
+ "wincode 0.4.9",
 ]
 
 [[package]]
@@ -8809,7 +8810,7 @@ dependencies = [
  "solana-transaction 4.0.0",
  "solana-transaction-error 3.1.0",
  "thiserror 2.0.18",
- "wincode",
+ "wincode 0.4.9",
 ]
 
 [[package]]
@@ -9346,7 +9347,7 @@ dependencies = [
  "serde_derive",
  "solana-atomic-u64 3.0.1",
  "solana-sanitize 3.0.1",
- "wincode",
+ "wincode 0.4.9",
 ]
 
 [[package]]
@@ -9401,7 +9402,7 @@ dependencies = [
  "solana-define-syscall 5.0.0",
  "solana-instruction-error",
  "solana-pubkey 4.1.0",
- "wincode",
+ "wincode 0.4.9",
 ]
 
 [[package]]
@@ -9657,7 +9658,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "trees",
- "wincode",
+ "wincode 0.4.9",
 ]
 
 [[package]]
@@ -9856,7 +9857,7 @@ dependencies = [
  "solana-sdk-ids 3.1.0",
  "solana-short-vec 3.2.0",
  "solana-transaction-error 3.1.0",
- "wincode",
+ "wincode 0.4.9",
 ]
 
 [[package]]
@@ -10300,7 +10301,6 @@ dependencies = [
  "solana-account-info 3.1.1",
  "solana-big-mod-exp 3.0.0",
  "solana-blake3-hasher 3.1.0",
- "solana-borsh 3.0.2",
  "solana-clock 3.0.1",
  "solana-cpi 3.1.0",
  "solana-define-syscall 3.0.0",
@@ -11149,7 +11149,7 @@ dependencies = [
  "symlink",
  "tempfile",
  "thiserror 2.0.18",
- "wincode",
+ "wincode 0.4.9",
 ]
 
 [[package]]
@@ -11657,7 +11657,7 @@ dependencies = [
  "serde-big-array",
  "serde_derive",
  "solana-sanitize 3.0.1",
- "wincode",
+ "wincode 0.4.9",
 ]
 
 [[package]]
@@ -12051,7 +12051,7 @@ dependencies = [
  "solana-instruction 3.3.0",
  "solana-msg 3.1.0",
  "solana-program-error 3.0.1",
- "wincode",
+ "wincode 0.4.9",
 ]
 
 [[package]]
@@ -12359,7 +12359,7 @@ dependencies = [
  "solana-signature 3.3.0",
  "solana-signer 3.0.0",
  "solana-transaction-error 3.1.0",
- "wincode",
+ "wincode 0.4.9",
 ]
 
 [[package]]
@@ -12525,7 +12525,7 @@ dependencies = [
  "solana-time-utils 3.0.0",
  "solana-transaction-error 3.1.0",
  "thiserror 2.0.18",
- "wincode",
+ "wincode 0.4.9",
 ]
 
 [[package]]
@@ -13182,7 +13182,7 @@ dependencies = [
  "sha2 0.10.9",
  "solana-account-decoder",
  "solana-client",
- "solana-program 3.0.0",
+ "solana-program 4.0.0",
  "solana-sdk 2.3.1",
  "solana-sdk 4.0.1",
  "switchboard-protos",
@@ -14543,6 +14543,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "solana-short-vec 3.2.0",
+ "thiserror 2.0.18",
+ "wincode-derive",
+]
+
+[[package]]
+name = "wincode"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2f42dd20febad683d07044c5f543e57f822512ebebaf2c827705c99a0ad4575"
+dependencies = [
+ "pastey",
+ "proc-macro2",
+ "quote",
  "thiserror 2.0.18",
  "wincode-derive",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "core",
     "gcp_uploader",
     "integration_tests",
+    "meta_merkle_tree",
     "priority_fee_distribution_sdk",
     "program",
     "shank_cli",
@@ -127,6 +128,7 @@ spl-token-interface = { version = "2.0.0" }
 syn = "2.0.72"
 thiserror = "2.0.16"
 tokio = { version = "1.47.1", features = ["full"] }
+wincode = { version = "0.5", features = ["derive"] }
 
 [profile.release]
 overflow-checks = true

--- a/meta_merkle_tree/Cargo.toml
+++ b/meta_merkle_tree/Cargo.toml
@@ -30,6 +30,7 @@ spl-associated-token-account-interface = { workspace = true }
 spl-math = { workspace = true }
 spl-token-interface = { workspace = true }
 thiserror = { workspace = true }
+wincode = { workspace = true }
 
 [dev-dependencies]
 solana-sdk = { workspace = true }

--- a/meta_merkle_tree/src/generated_merkle_tree.rs
+++ b/meta_merkle_tree/src/generated_merkle_tree.rs
@@ -1,4 +1,9 @@
-use crate::{merkle_tree::MerkleTree, utils::get_proof};
+use std::{
+    fs::File,
+    io::{BufReader, BufWriter, Write},
+    path::PathBuf,
+};
+
 use jito_vault_core::MAX_BPS;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use solana_program::{
@@ -7,12 +12,10 @@ use solana_program::{
     hash::Hash,
     pubkey::Pubkey,
 };
-use std::{
-    fs::File,
-    io::{BufReader, Write},
-    path::PathBuf,
-};
 use thiserror::Error;
+use wincode::io::Writer;
+
+use crate::{merkle_tree::MerkleTree, utils::get_proof, wincode_schema::CollectionW};
 
 pub const CLAIM_STATUS_SEED: &[u8] = b"CLAIM_STATUS";
 
@@ -42,6 +45,15 @@ pub enum MerkleRootGeneratorError {
     CheckedMathError,
     #[error("Distribution program not known")]
     UnknownDistributionProgram,
+
+    #[error(transparent)]
+    WincodeWriteError(#[from] wincode::WriteError),
+
+    #[error(transparent)]
+    WincodeReadError(#[from] wincode::ReadError),
+
+    #[error(transparent)]
+    WincodeIoWriteError(#[from] wincode::io::WriteError),
 }
 
 #[derive(Clone, Deserialize, Serialize, Debug)]
@@ -240,6 +252,30 @@ impl GeneratedMerkleTreeCollection {
         let serialized = serde_json::to_string_pretty(&self)?;
         let mut file = File::create(path)?;
         file.write_all(serialized.as_bytes())?;
+        Ok(())
+    }
+
+    /// Load from a wincode file (bincode 1.x-compatible wire format, zero-copy friendly).
+    pub fn new_from_file_wincode(path: &PathBuf) -> Result<Self, MerkleRootGeneratorError> {
+        let bytes = std::fs::read(path)?;
+        let config = wincode::config::Configuration::default().disable_preallocation_size_limit();
+        let collection =
+            <CollectionW as wincode::config::Deserialize<'_, _>>::deserialize(&bytes, config)?;
+        Ok(collection)
+    }
+
+    /// Write the collection out as a wincode file.
+    pub fn write_wincode_to_file(&self, path: &PathBuf) -> Result<(), MerkleRootGeneratorError> {
+        let config = wincode::config::Configuration::default().disable_preallocation_size_limit();
+        let tmp_path = path.with_extension("wincode.tmp");
+        let file = File::create(&tmp_path)?;
+        let writer = BufWriter::new(file);
+        let mut adapter = wincode::io::std_write::WriteAdapter::new(writer);
+        <CollectionW as wincode::config::Serialize<_>>::serialize_into(&mut adapter, self, config)?;
+
+        adapter.finish()?;
+        std::fs::rename(&tmp_path, path)?;
+
         Ok(())
     }
 }

--- a/meta_merkle_tree/src/lib.rs
+++ b/meta_merkle_tree/src/lib.rs
@@ -6,3 +6,4 @@ pub mod meta_merkle_tree;
 pub mod tree_node;
 pub mod utils;
 pub mod verify;
+pub mod wincode_schema;

--- a/meta_merkle_tree/src/wincode_schema.rs
+++ b/meta_merkle_tree/src/wincode_schema.rs
@@ -1,0 +1,40 @@
+use solana_program::{hash::Hash, pubkey::Pubkey};
+use wincode::{SchemaRead, SchemaWrite};
+
+wincode::pod_wrapper! {
+    unsafe struct PodPubkey(Pubkey);
+    unsafe struct PodHash(Hash);
+}
+
+#[derive(SchemaWrite, SchemaRead)]
+#[wincode(from = "crate::generated_merkle_tree::GeneratedMerkleTreeCollection")]
+pub struct CollectionW {
+    generated_merkle_trees: Vec<TreeW>,
+    bank_hash: String,
+    epoch: u64,
+    slot: u64,
+}
+
+#[derive(SchemaWrite, SchemaRead)]
+#[wincode(from = "crate::generated_merkle_tree::GeneratedMerkleTree")]
+pub struct TreeW {
+    distribution_program: PodPubkey,
+    distribution_account: PodPubkey,
+    merkle_root_upload_authority: PodPubkey,
+    merkle_root: PodHash,
+    tree_nodes: Vec<NodeW>,
+    max_total_claim: u64,
+    max_num_nodes: u64,
+}
+
+#[derive(SchemaWrite, SchemaRead)]
+#[wincode(from = "crate::generated_merkle_tree::TreeNode")]
+pub struct NodeW {
+    claimant: PodPubkey,
+    claim_status_pubkey: PodPubkey,
+    claim_status_bump: u8,
+    staker_pubkey: PodPubkey,
+    withdrawer_pubkey: PodPubkey,
+    amount: u64,
+    proof: Option<Vec<[u8; 32]>>,
+}

--- a/tip-router-operator-cli/src/backup_snapshots.rs
+++ b/tip-router-operator-cli/src/backup_snapshots.rs
@@ -6,8 +6,10 @@ use std::path::{Path, PathBuf};
 use std::time::Duration;
 use tokio::time;
 
-use crate::process_epoch::get_previous_epoch_last_slot;
-use crate::{merkle_tree_collection_file_name, meta_merkle_tree_file_name, stake_meta_file_name};
+use crate::{
+    merkle_tree_collection_file_name, merkle_tree_collection_wincode_file_name,
+    meta_merkle_tree_file_name, process_epoch::get_previous_epoch_last_slot, stake_meta_file_name,
+};
 
 const MAXIMUM_BACKUP_INCREMENTAL_SNAPSHOTS_PER_EPOCH: usize = 3;
 
@@ -67,6 +69,9 @@ pub struct SavedTipRouterFile {
 
 impl SavedTipRouterFile {
     /// Try to parse a TipRouter saved filename with epoch information
+    ///
+    /// NOTE: If you add a new TipRouter file type (new *_file_name() fn in lib.rs),
+    /// add it here or files of that type will never be evicted.
     pub fn from_path(path: PathBuf) -> Option<Self> {
         let file_name = path.file_name()?.to_str()?;
 
@@ -77,6 +82,7 @@ impl SavedTipRouterFile {
         let is_tip_router_file = [
             stake_meta_file_name(epoch),
             merkle_tree_collection_file_name(epoch),
+            merkle_tree_collection_wincode_file_name(epoch),
             meta_merkle_tree_file_name(epoch),
         ]
         .iter()
@@ -535,13 +541,19 @@ mod tests {
         for i in first_epoch..current_epoch {
             File::create(&monitor.save_path.join(stake_meta_file_name(i))).unwrap();
             File::create(&monitor.save_path.join(merkle_tree_collection_file_name(i))).unwrap();
+            File::create(
+                &monitor
+                    .save_path
+                    .join(merkle_tree_collection_wincode_file_name(i)),
+            )
+            .unwrap();
             File::create(&monitor.save_path.join(meta_merkle_tree_file_name(i))).unwrap();
         }
         let dir_entries: Vec<PathBuf> = std::fs::read_dir(&monitor.save_path)
             .unwrap()
             .map(|x| x.unwrap().path())
             .collect();
-        assert_eq!(dir_entries.len(), 5 * 3);
+        assert_eq!(dir_entries.len(), 5 * 4);
 
         monitor
             .evict_saved_files(current_epoch - monitor.num_monitored_epochs)
@@ -550,7 +562,7 @@ mod tests {
             .unwrap()
             .map(|x| x.unwrap().path())
             .collect();
-        assert_eq!(dir_entries.len(), 6);
+        assert_eq!(dir_entries.len(), 8);
 
         // test not evicting some other similar file in the same directory
         let file_path = monitor

--- a/tip-router-operator-cli/src/claim.rs
+++ b/tip-router-operator-cli/src/claim.rs
@@ -40,7 +40,8 @@ use tokio::io::BufReader;
 use tokio::sync::Mutex;
 
 use crate::{
-    get_epoch_percentage, merkle_tree_collection_file_name, priority_fees,
+    get_epoch_percentage, merkle_tree_collection_file_name,
+    merkle_tree_collection_wincode_file_name, priority_fees,
     rpc_utils::{get_batched_accounts, send_until_blockhash_expires},
     Cli,
 };
@@ -89,9 +90,27 @@ pub async fn emit_claim_mev_tips_metrics(
     file_mutex: &Arc<Mutex<()>>,
 ) -> Result<(), anyhow::Error> {
     let meta_merkle_tree_dir = cli.get_save_path().clone();
-    let merkle_tree_coll_path = meta_merkle_tree_dir.join(merkle_tree_collection_file_name(epoch));
-    let merkle_trees = GeneratedMerkleTreeCollection::new_from_file(&merkle_tree_coll_path)
-        .map_err(|e| anyhow::anyhow!(e))?;
+
+    let merkle_tree_path = meta_merkle_tree_dir.join(merkle_tree_collection_file_name(epoch));
+    let merkle_tree_wincode_path =
+        meta_merkle_tree_dir.join(merkle_tree_collection_wincode_file_name(epoch));
+    let merkle_trees = {
+        let _file_guard = file_mutex.lock().await;
+
+        if !merkle_tree_wincode_path.exists() {
+            let merkle_trees = GeneratedMerkleTreeCollection::new_from_file(&merkle_tree_path)
+                .map_err(|e| anyhow::anyhow!("Failed to load merkle tree: {e}"))?;
+            let wincode_path =
+                meta_merkle_tree_dir.join(merkle_tree_collection_wincode_file_name(epoch));
+            merkle_trees
+                .write_wincode_to_file(&wincode_path)
+                .map_err(|e| anyhow::anyhow!("Failed to write wincode: {e}"))?;
+            info!("Wrote wincode to {}", wincode_path.display());
+        };
+
+        GeneratedMerkleTreeCollection::new_from_file_wincode(&merkle_tree_wincode_path)
+            .map_err(|e| anyhow::anyhow!(e))?
+    };
 
     let rpc_url = cli.rpc_url.clone();
     let rpc_client = RpcClient::new_with_timeout_and_commitment(
@@ -193,9 +212,27 @@ pub async fn handle_claim_mev_tips(
     rpc_url: String,
 ) -> Result<(), anyhow::Error> {
     let meta_merkle_tree_dir = cli.get_save_path().clone();
-    let merkle_tree_coll_path = meta_merkle_tree_dir.join(merkle_tree_collection_file_name(epoch));
-    let mut merkle_tree_coll = GeneratedMerkleTreeCollection::new_from_file(&merkle_tree_coll_path)
-        .map_err(|e| anyhow::anyhow!(e))?;
+    let merkle_tree_path = meta_merkle_tree_dir.join(merkle_tree_collection_file_name(epoch));
+    let merkle_tree_wincode_path =
+        meta_merkle_tree_dir.join(merkle_tree_collection_wincode_file_name(epoch));
+
+    let mut merkle_tree_coll = {
+        let _file_lock = file_mutex.lock().await;
+
+        if !merkle_tree_wincode_path.exists() {
+            let merkle_trees = GeneratedMerkleTreeCollection::new_from_file(&merkle_tree_path)
+                .map_err(|e| anyhow::anyhow!("Failed to load merkle tree: {e}"))?;
+            let wincode_path =
+                meta_merkle_tree_dir.join(merkle_tree_collection_wincode_file_name(epoch));
+            merkle_trees
+                .write_wincode_to_file(&wincode_path)
+                .map_err(|e| anyhow::anyhow!("Failed to write wincode: {e}"))?;
+            info!("Wrote wincode to {}", wincode_path.display());
+        };
+
+        GeneratedMerkleTreeCollection::new_from_file_wincode(&merkle_tree_wincode_path)
+            .map_err(|e| anyhow::anyhow!(e))?
+    };
 
     let tip_router_config_address = Config::find_program_address(&tip_router_program_id, &ncn).0;
 

--- a/tip-router-operator-cli/src/lib.rs
+++ b/tip-router-operator-cli/src/lib.rs
@@ -132,7 +132,7 @@ pub fn merkle_tree_collection_file_name(epoch: u64) -> String {
 }
 
 pub fn merkle_tree_collection_wincode_file_name(epoch: u64) -> String {
-    format!("{}_merkle_tree_collection.wincode", epoch)
+    format!("{epoch}_merkle_tree_collection.wincode")
 }
 
 fn merkle_tree_collection_file_candidates(epoch: u64) -> [String; 2] {

--- a/tip-router-operator-cli/src/lib.rs
+++ b/tip-router-operator-cli/src/lib.rs
@@ -131,6 +131,10 @@ pub fn merkle_tree_collection_file_name(epoch: u64) -> String {
     format!("{}_merkle_tree_collection.json", epoch)
 }
 
+pub fn merkle_tree_collection_wincode_file_name(epoch: u64) -> String {
+    format!("{}_merkle_tree_collection.wincode", epoch)
+}
+
 fn merkle_tree_collection_file_candidates(epoch: u64) -> [String; 2] {
     [
         format!("{}_merkle_tree_collection.json", epoch),


### PR DESCRIPTION
#### Problem 

- Slow to read + generate `GeneratedMerkleTreeCollection` from json file

#### Solution

- Use wincode to serialize + deserialize `GeneratedMerkleTreeCollection`

```bash
Benchmark 1: serde_json
  Time (mean ± σ):     27.910 s ±  0.337 s    [User: 26.572 s, System: 1.325 s]
  Range (min … max):   27.502 s … 28.525 s    20 runs

Benchmark 2: serde_json_slice
  Time (mean ± σ):     10.257 s ±  0.184 s    [User: 9.045 s, System: 1.203 s]
  Range (min … max):   10.052 s … 10.571 s    20 runs

Benchmark 3: bincode
  Time (mean ± σ):      1.806 s ±  0.013 s    [User: 1.658 s, System: 0.144 s]
  Range (min … max):    1.792 s …  1.836 s    20 runs

Benchmark 4: wincode
  Time (mean ± σ):     165.3 ms ±   2.1 ms    [User: 52.5 ms, System: 108.7 ms]
  Range (min … max):   162.6 ms … 171.3 ms    20 runs

Summary
  wincode ran
   10.93 ± 0.16 times faster than bincode
   62.04 ± 1.37 times faster than serde_json_slice
  168.82 ± 2.98 times faster than serde_json

File size
json file: 12 GB
wincode file: 0.8 GB
```