### PR TITLE
Program: Verify vault_operator_delegation PDA when account is empty

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -100,36 +100,37 @@ jobs:
         env:
           TIP_ROUTER_PROGRAM_ID: ${{ env.TIP_ROUTER_PROGRAM_ID }}
           SBF_OUT_PATH: ${{ github.workspace }}/target/sbpf-solana-solana/release
-      - name: Upload MEV Tip Distribution NCN program
+      # - name: Upload MEV Tip Distribution NCN program
+      #   uses: actions/upload-artifact@v4
+      #   with:
+      #     name: jito_tip_router_program.so
+      #     path: ${{ github.workspace }}/target/sbpf-solana-solana/release/jito_tip_router_program.so
+      #     if-no-files-found: error
+
+  verified_build:
+    name: verified_build
+    runs-on: big-runner-1
+    # Keep this job pinned to solanafoundation/solana-verifiable-build:3.1.9 for now.
+    # Upgrading to a 4.0.x verifiable-build image is still blocked until solana-verify
+    # supports Cargo.lock format version 4
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y libudev-dev
+      - run: docker pull --platform linux/amd64 solanafoundation/solana-verifiable-build:3.1.9
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
+      - name: Install solana-verify from crates.io
+        uses: baptiste0928/cargo-install@v3
+        with:
+          crate: solana-verify
+      - run: solana-verify build --library-name jito_tip_router_program --base-image solanafoundation/solana-verifiable-build:3.1.9
+      - name: Upload jito_tip_router_program.so
         uses: actions/upload-artifact@v4
         with:
           name: jito_tip_router_program.so
-          path: ${{ github.workspace }}/target/sbpf-solana-solana/release/jito_tip_router_program.so
-          if-no-files-found: error
-
-  # verified_build:
-  #   name: verified_build
-  #   runs-on: big-runner-1
-  #   # TODO: Re-enable once solanafoundation/solana-verifiable-build publishes a 4.0.x Docker image
-  #   #       and solana-verify supports Cargo.lock format version 4.
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #     - name: Install system dependencies
-  #       run: sudo apt-get update && sudo apt-get install -y libudev-dev
-  #     - run: docker pull --platform linux/amd64 solanafoundation/solana-verifiable-build:4.0.0
-  #     - uses: actions-rust-lang/setup-rust-toolchain@v1
-  #       with:
-  #         toolchain: ${{ env.RUST_VERSION }}
-  #     - name: Install solana-verify from crates.io
-  #       uses: baptiste0928/cargo-install@v3
-  #       with:
-  #         crate: solana-verify
-  #     - run: solana-verify build --library-name jito_tip_router_program --base-image solanafoundation/solana-verifiable-build:4.0.0
-  #     - name: Upload jito_tip_router_program.so
-  #       uses: actions/upload-artifact@v4
-  #       with:
-  #         name: jito_restaking_program.so
-  #         path: target/deploy/jito_tip_router_program.so
+          path: target/deploy/jito_tip_router_program.so
 
   # coverage:
   #   name: coverage
@@ -158,6 +159,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - build
+      - verified_build
     steps:
       - uses: actions/checkout@v4
       - uses: aarcangeli/load-dotenv@v1.0.0
@@ -181,7 +183,6 @@ jobs:
       - run: cargo nextest run --all-features -E 'not test(ledger_utils::tests)'
         env:
           SBPF_OUT_DIR: ${{ github.workspace }}/integration_tests/tests/fixtures
-          PROTOC: /usr/bin/protoc
 
   # create_release:
   #   name: Create Release

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4343,7 +4343,7 @@ dependencies = [
 
 [[package]]
 name = "jito-tip-router-program"
-version = "0.0.1"
+version = "0.1.1"
 dependencies = [
  "assert_matches",
  "borsh 1.6.1",
@@ -13564,7 +13564,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tip-router-operator-cli"
-version = "4.0.0"
+version = "4.0.1"
 dependencies = [
  "agave-snapshots",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ jito-tip-distribution-sdk = { path = "./tip_distribution_sdk", version = "=0.0.1
 jito-tip-payment-sdk = { path = "./tip_payment_sdk", version = "=0.0.1" }
 jito-tip-router-client = { path = "./clients/rust/jito_tip_router", version = "0.0.1" }
 jito-tip-router-core = { path = "./core", version = "=0.0.1" }
-jito-tip-router-program = { path = "./program", version = "=0.0.1" }
+jito-tip-router-program = { path = "./program", version = "=0.1.1" }
 jito-tip-router-shank-cli = { path = "./shank_cli", version = "=0.0.1" }
 jito-vault-client = { package = "jito-vault-client", git = "https://github.com/jito-foundation/restaking", rev = "58df1582c474e9c5f534a7dcb0388b82437aa78e" }
 jito-vault-core = { package = "jito-vault-core", git = "https://github.com/jito-foundation/restaking", rev = "58df1582c474e9c5f534a7dcb0388b82437aa78e" }

--- a/idl/jito_tip_router.json
+++ b/idl/jito_tip_router.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.1",
+  "version": "0.1.1",
   "name": "jito_tip_router",
   "instructions": [
     {

--- a/integration_tests/tests/fixtures/tip_router_client.rs
+++ b/integration_tests/tests/fixtures/tip_router_client.rs
@@ -1129,6 +1129,30 @@ impl TipRouterClient {
         ncn: Pubkey,
         epoch: u64,
     ) -> TestResult<()> {
+        let vault_operator_delegation = VaultOperatorDelegation::find_program_address(
+            &jito_vault_program::id(),
+            &vault,
+            &operator,
+        )
+        .0;
+        self.snapshot_vault_operator_delegation_with_override(
+            vault,
+            operator,
+            ncn,
+            epoch,
+            vault_operator_delegation,
+        )
+        .await
+    }
+
+    pub async fn snapshot_vault_operator_delegation_with_override(
+        &mut self,
+        vault: Pubkey,
+        operator: Pubkey,
+        ncn: Pubkey,
+        epoch: u64,
+        vault_operator_delegation: Pubkey,
+    ) -> TestResult<()> {
         let epoch_state =
             EpochState::find_program_address(&jito_tip_router_program::id(), &ncn, epoch).0;
         let restaking_config = Config::find_program_address(&jito_restaking_program::id()).0;
@@ -1150,13 +1174,6 @@ impl TipRouterClient {
 
         let ncn_vault_ticket =
             NcnVaultTicket::find_program_address(&jito_restaking_program::id(), &ncn, &vault).0;
-
-        let vault_operator_delegation = VaultOperatorDelegation::find_program_address(
-            &jito_vault_program::id(),
-            &vault,
-            &operator,
-        )
-        .0;
 
         let weight_table =
             WeightTable::find_program_address(&jito_tip_router_program::id(), &ncn, epoch).0;

--- a/integration_tests/tests/tip_router/snapshot_vault_operator_delegation.rs
+++ b/integration_tests/tests/tip_router/snapshot_vault_operator_delegation.rs
@@ -1,7 +1,10 @@
 #[cfg(test)]
 mod tests {
+    use jito_vault_core::vault_operator_delegation::VaultOperatorDelegation;
+    use solana_program::instruction::InstructionError;
+    use solana_sdk::pubkey::Pubkey;
 
-    use crate::fixtures::{test_builder::TestBuilder, TestResult};
+    use crate::fixtures::{assert_ix_error, test_builder::TestBuilder, TestResult};
 
     #[tokio::test]
     async fn test_snapshot_vault_operator_delegation() -> TestResult<()> {
@@ -48,5 +51,197 @@ mod tests {
             .await?;
 
         Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_snapshot_vault_operator_delegation_wrong_pda() {
+        let mut fixture = TestBuilder::new().await;
+        let mut vault_client = fixture.vault_program_client();
+        let mut tip_router_client = fixture.tip_router_client();
+
+        let test_ncn = fixture.create_initial_test_ncn(1, 1, None).await.unwrap();
+        fixture
+            .add_epoch_state_for_test_ncn(&test_ncn)
+            .await
+            .unwrap();
+
+        fixture.warp_slot_incremental(1000).await.unwrap();
+
+        let epoch = fixture.clock().await.epoch;
+
+        tip_router_client
+            .do_full_initialize_weight_table(test_ncn.ncn_root.ncn_pubkey, epoch)
+            .await
+            .unwrap();
+
+        let ncn = test_ncn.ncn_root.ncn_pubkey;
+
+        let vault_root = test_ncn.vaults[0].clone();
+        let vault_address = vault_root.vault_pubkey;
+        let vault = vault_client.get_vault(&vault_address).await.unwrap();
+
+        let mint = vault.supported_mint;
+        let weight = 100;
+
+        tip_router_client
+            .do_admin_set_weight(ncn, epoch, mint, weight)
+            .await
+            .unwrap();
+
+        tip_router_client
+            .do_initialize_epoch_snapshot(ncn, epoch)
+            .await
+            .unwrap();
+
+        let operator = test_ncn.operators[0].operator_pubkey;
+
+        tip_router_client
+            .do_full_initialize_operator_snapshot(operator, ncn, epoch)
+            .await
+            .unwrap();
+
+        // Pass a random pubkey that is empty and does not match the expected PDA.
+        // The new guard must reject this with InvalidAccountData.
+        let wrong_delegation = Pubkey::new_unique();
+        let result = tip_router_client
+            .snapshot_vault_operator_delegation_with_override(
+                vault_address,
+                operator,
+                ncn,
+                epoch,
+                wrong_delegation,
+            )
+            .await;
+
+        assert_ix_error(result, InstructionError::InvalidAccountData);
+    }
+
+    // Operator added after vault setup has no VaultOperatorDelegation, so the
+    // correct PDA exists on-chain as an empty (uninitialized) account.
+    // The instruction should succeed, recording zero stake weight.
+    #[tokio::test]
+    async fn test_snapshot_vault_operator_delegation_correct_pda_empty() {
+        let mut fixture = TestBuilder::new().await;
+        let mut vault_client = fixture.vault_program_client();
+        let mut tip_router_client = fixture.tip_router_client();
+
+        // Build the NCN manually so we can add operator[1] after vault setup.
+        // add_vault_registry_to_test_ncn must run first because it calls
+        // do_full_vault_update, which cranks VaultOperatorDelegation for every
+        // operator in the list — an account that won't exist for operator[1].
+        let mut test_ncn = fixture.create_test_ncn().await.unwrap();
+        fixture
+            .add_operators_to_test_ncn(&mut test_ncn, 1, None)
+            .await
+            .unwrap();
+        fixture
+            .add_vaults_to_test_ncn(&mut test_ncn, 1, None)
+            .await
+            .unwrap();
+        fixture
+            .add_delegation_in_test_ncn(&test_ncn, 100)
+            .await
+            .unwrap();
+        // This internally warps epoch_length * 2, activating operator[0].
+        fixture
+            .add_vault_registry_to_test_ncn(&test_ncn)
+            .await
+            .unwrap();
+
+        // operator[1] added after vault_registry: no VaultOperatorDelegation is
+        // ever created for it, so its PDA will be empty on-chain.
+        fixture
+            .add_operators_to_test_ncn(&mut test_ncn, 1, None)
+            .await
+            .unwrap();
+
+        // Warp a full epoch so operator[1]'s warmup period completes and
+        // realloc_operator_snapshot initialises it as is_active=true.
+        // Also re-crank the vault update (only for operator[0], since operator[1]
+        // has no VaultOperatorDelegation) because the vault becomes stale after
+        // the large slot warp.
+        {
+            let mut restaking_client = fixture.restaking_program_client();
+            let config_address = jito_restaking_core::config::Config::find_program_address(
+                &jito_restaking_program::id(),
+            )
+            .0;
+            let restaking_config = restaking_client.get_config(&config_address).await.unwrap();
+            fixture
+                .warp_slot_incremental(restaking_config.epoch_length() * 2)
+                .await
+                .unwrap();
+        }
+
+        // Update the vault so it is current for the new epoch; pass only
+        // operator[0] because operator[1] has no VaultOperatorDelegation.
+        vault_client
+            .do_full_vault_update(
+                &test_ncn.vaults[0].vault_pubkey,
+                &[test_ncn.operators[0].operator_pubkey],
+            )
+            .await
+            .unwrap();
+
+        fixture
+            .add_epoch_state_for_test_ncn(&test_ncn)
+            .await
+            .unwrap();
+        fixture.warp_slot_incremental(1000).await.unwrap();
+
+        let epoch = fixture.clock().await.epoch;
+        let ncn = test_ncn.ncn_root.ncn_pubkey;
+
+        tip_router_client
+            .do_full_initialize_weight_table(ncn, epoch)
+            .await
+            .unwrap();
+
+        let vault_root = test_ncn.vaults[0].clone();
+        let vault_address = vault_root.vault_pubkey;
+        let vault = vault_client.get_vault(&vault_address).await.unwrap();
+
+        tip_router_client
+            .do_admin_set_weight(ncn, epoch, vault.supported_mint, 100)
+            .await
+            .unwrap();
+
+        tip_router_client
+            .do_initialize_epoch_snapshot(ncn, epoch)
+            .await
+            .unwrap();
+
+        let operator = test_ncn.operators[1].operator_pubkey;
+        tip_router_client
+            .do_full_initialize_operator_snapshot(operator, ncn, epoch)
+            .await
+            .unwrap();
+
+        // Correct PDA — but the account is empty because the delegation was never created.
+        let correct_empty_pda = VaultOperatorDelegation::find_program_address(
+            &jito_vault_program::id(),
+            &vault_address,
+            &operator,
+        )
+        .0;
+
+        // Should succeed: PDA matches, data is empty → is_active=false, stake_weight=0.
+        tip_router_client
+            .snapshot_vault_operator_delegation_with_override(
+                vault_address,
+                operator,
+                ncn,
+                epoch,
+                correct_empty_pda,
+            )
+            .await
+            .unwrap();
+
+        let snapshot = tip_router_client
+            .get_operator_snapshot(operator, ncn, epoch)
+            .await
+            .unwrap();
+        assert_eq!(snapshot.stake_weights().stake_weight(), 0);
+        assert_eq!(snapshot.valid_operator_vault_delegations(), 0);
     }
 }

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "jito-tip-router-program"
 description = "Jito's MEV Tip Distribution NCN Program"
-version = { workspace = true }
+version = "0.1.1"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/program/src/snapshot_vault_operator_delegation.rs
+++ b/program/src/snapshot_vault_operator_delegation.rs
@@ -56,7 +56,17 @@ pub fn process_snapshot_vault_operator_delegation(
         )?;
     }
 
-    if !vault_operator_delegation.data_is_empty() {
+    if vault_operator_delegation.data_is_empty() {
+        let expected = VaultOperatorDelegation::find_program_address(
+            &jito_vault_program::id(),
+            vault.key,
+            operator.key,
+        )
+        .0;
+        if vault_operator_delegation.key.ne(&expected) {
+            return Err(ProgramError::InvalidAccountData);
+        }
+    } else {
         VaultOperatorDelegation::load(
             &jito_vault_program::id(),
             vault_operator_delegation,

--- a/tip-router-operator-cli/Cargo.toml
+++ b/tip-router-operator-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tip-router-operator-cli"
-version = "4.0.0"
+version = "4.0.1"
 edition = "2021"
 description = "CLI for Jito Tip Router"
 


### PR DESCRIPTION
## Summary

- Fixed inverted condition in `process_snapshot_vault_operator_delegation`: the PDA check was only running when the account was non-empty, but it should run when the account is empty (i.e., not yet initialized).
- When `vault_operator_delegation` is empty, the account's key is now validated against the expected PDA derived from the vault and operator keys, returning `InvalidAccountData` if they don't match.
- This prevents a caller from passing an arbitrary empty account in place of the expected `VaultOperatorDelegation` PDA.

## Test plan

- [x] Verify that passing a valid but empty `VaultOperatorDelegation` PDA succeeds
- [x] Verify that passing an unrelated empty account returns `InvalidAccountData`
- [x] Verify that passing a populated `VaultOperatorDelegation` account still loads correctly via `VaultOperatorDelegation::load`

https://solscan.io/tx/65cjSnMGkpYAhBTEYFsyFDXaEdoa19vKg4KrYVN9uHd4P2Wj5S6PfYmvm6zXjsgNpXyf97LijbbvmvGm1RbXgeMS