### PR TITLE
CLI: Check epoch completion before loading merkle tree

### DIFF
--- a/tip-router-operator-cli/src/claim.rs
+++ b/tip-router-operator-cli/src/claim.rs
@@ -89,6 +89,17 @@ pub async fn emit_claim_mev_tips_metrics(
     file_path: &PathBuf,
     file_mutex: &Arc<Mutex<()>>,
 ) -> Result<(), anyhow::Error> {
+    let rpc_url = cli.rpc_url.clone();
+    let rpc_client = RpcClient::new_with_timeout_and_commitment(
+        rpc_url,
+        Duration::from_secs(1800),
+        CommitmentConfig::confirmed(),
+    );
+    let current_epoch = rpc_client.get_epoch_info().await?.epoch;
+    if is_epoch_completed(epoch, current_epoch, file_path, file_mutex).await? {
+        return Ok(());
+    }
+
     let meta_merkle_tree_dir = cli.get_save_path().clone();
 
     let merkle_tree_path = meta_merkle_tree_dir.join(merkle_tree_collection_file_name(epoch));
@@ -111,19 +122,6 @@ pub async fn emit_claim_mev_tips_metrics(
         GeneratedMerkleTreeCollection::new_from_file_wincode(&merkle_tree_wincode_path)
             .map_err(|e| anyhow::anyhow!(e))?
     };
-
-    let rpc_url = cli.rpc_url.clone();
-    let rpc_client = RpcClient::new_with_timeout_and_commitment(
-        rpc_url,
-        Duration::from_secs(1800),
-        CommitmentConfig::confirmed(),
-    );
-
-    let epoch = merkle_trees.epoch;
-    let current_epoch = rpc_client.get_epoch_info().await?.epoch;
-    if is_epoch_completed(epoch, current_epoch, file_path, file_mutex).await? {
-        return Ok(());
-    }
 
     let (claims_to_process, validators_processed) = get_claim_transactions_for_valid_unclaimed(
         &rpc_client,
@@ -211,6 +209,18 @@ pub async fn handle_claim_mev_tips(
     keypair: &Arc<Keypair>,
     rpc_url: String,
 ) -> Result<(), anyhow::Error> {
+    let rpc_client = RpcClient::new_with_timeout_and_commitment(
+        rpc_url.clone(),
+        Duration::from_secs(1800),
+        CommitmentConfig::confirmed(),
+    );
+    let rpc_sender_client = RpcClient::new(rpc_url.clone());
+
+    let current_epoch = rpc_client.get_epoch_info().await?.epoch;
+    if is_epoch_completed(epoch, current_epoch, file_path, file_mutex).await? {
+        return Ok(());
+    }
+
     let meta_merkle_tree_dir = cli.get_save_path().clone();
     let merkle_tree_path = meta_merkle_tree_dir.join(merkle_tree_collection_file_name(epoch));
     let merkle_tree_wincode_path =
@@ -256,8 +266,9 @@ pub async fn handle_claim_mev_tips(
 
     match claim_mev_tips(
         &merkle_tree_coll,
-        rpc_url.clone(),
-        rpc_url.clone(),
+        &rpc_client,
+        &rpc_sender_client,
+        current_epoch,
         tip_distribution_program_id,
         priority_fee_distribution_program_id,
         tip_router_program_id,
@@ -330,8 +341,9 @@ pub async fn get_claimer_balance(
 #[allow(clippy::too_many_arguments)]
 pub async fn claim_mev_tips(
     merkle_trees: &GeneratedMerkleTreeCollection,
-    rpc_url: String,
-    rpc_sender_url: String,
+    rpc_client: &RpcClient,
+    rpc_sender_client: &RpcClient,
+    current_epoch: u64,
     tip_distribution_program_id: Pubkey,
     priority_fee_distribution_program_id: Pubkey,
     tip_router_program_id: Pubkey,
@@ -345,20 +357,9 @@ pub async fn claim_mev_tips(
     operator_address: &String,
     cluster: &str,
 ) -> Result<(), ClaimMevError> {
-    let rpc_client = RpcClient::new_with_timeout_and_commitment(
-        rpc_url,
-        Duration::from_secs(1800),
-        CommitmentConfig::confirmed(),
-    );
-    let rpc_sender_client = RpcClient::new(rpc_sender_url);
-
     let epoch = merkle_trees.epoch;
-    let current_epoch = rpc_client.get_epoch_info().await?.epoch;
-    if is_epoch_completed(epoch, current_epoch, file_path, file_mutex).await? {
-        return Ok(());
-    }
-
     let start = Instant::now();
+
     while start.elapsed() <= max_loop_duration {
         let (mut claims_to_process, validators_processed) =
             get_claim_transactions_for_valid_unclaimed(

--- a/tip-router-operator-cli/src/claim.rs
+++ b/tip-router-operator-cli/src/claim.rs
@@ -363,7 +363,7 @@ pub async fn claim_mev_tips(
     while start.elapsed() <= max_loop_duration {
         let (mut claims_to_process, validators_processed) =
             get_claim_transactions_for_valid_unclaimed(
-                &rpc_client,
+                rpc_client,
                 merkle_trees,
                 tip_distribution_program_id,
                 priority_fee_distribution_program_id,
@@ -378,7 +378,7 @@ pub async fn claim_mev_tips(
             .await?;
 
         if validators_processed {
-            match get_epoch_percentage(&rpc_client).await {
+            match get_epoch_percentage(rpc_client).await {
                 Ok(epoch_percentage) => {
                     datapoint_info!(
                         "tip_router_cli.claim_mev_tips-send_summary",
@@ -406,7 +406,7 @@ pub async fn claim_mev_tips(
             let transactions: Vec<_> = transactions.to_vec();
             // only check balance for the ones we need to currently send since reclaim rent running in parallel
             if let Some((start_balance, desired_balance, sol_to_deposit)) =
-                is_sufficient_balance(&keypair.pubkey(), &rpc_client, transactions.len() as u64)
+                is_sufficient_balance(&keypair.pubkey(), rpc_client, transactions.len() as u64)
                     .await
             {
                 return Err(ClaimMevError::InsufficientBalance {
@@ -419,8 +419,8 @@ pub async fn claim_mev_tips(
 
             let blockhash = rpc_client.get_latest_blockhash().await?;
             if let Err(e) = send_until_blockhash_expires(
-                &rpc_client,
-                &rpc_sender_client,
+                rpc_client,
+                rpc_sender_client,
                 transactions,
                 blockhash,
                 keypair,
@@ -433,7 +433,7 @@ pub async fn claim_mev_tips(
     }
 
     let (transactions, validators_processed) = get_claim_transactions_for_valid_unclaimed(
-        &rpc_client,
+        rpc_client,
         merkle_trees,
         tip_distribution_program_id,
         priority_fee_distribution_program_id,


### PR DESCRIPTION
## Summary
- Move `is_epoch_completed` check to the top of `emit_claim_mev_tips_metrics` and `handle_claim_mev_tips`, before any merkle tree file I/O
- Refactor `claim_mev_tips` to accept `rpc_client`, `rpc_sender_client`, and `current_epoch` as parameters, eliminating a redundant `get_epoch_info` RPC call

## Motivation
Previously, completed epochs (where the merkle tree file no longer exists) would produce a noisy error log:

```bash
May 04 19:32:34 singapore-mainnet-tip-router-1 tip-router-operator-cli[1084596]: [2026-05-04T19:32:34Z ERROR tip_router_operator_cli] Error emitting claim metrics for epoch 963: Failed to load merkle tree: No such file or directory (os error 2)

...

May 04 19:33:08 singapore-mainnet-tip-router-1 tip-router-operator-cli[1084596]: [2026-05-04T19:33:08Z ERROR tip_router_operator_cli] Error claiming tips for epoch 963: Failed to load merkle tree: No such file or directory (os error 2)
```

## Solution

The epoch completion check happened after the file load, so a missing file caused an error instead of a clean early exit. Now the check runs first — if the epoch is already done, the function returns immediately without touching the filesystem.
