### PR TITLE
Operator: Retry on transient blockstore open error instead of panicking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13564,7 +13564,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tip-router-operator-cli"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "agave-snapshots",
  "anyhow",

--- a/tip-router-operator-cli/Cargo.toml
+++ b/tip-router-operator-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tip-router-operator-cli"
-version = "4.0.1"
+version = "4.0.2"
 edition = "2021"
 description = "CLI for Jito Tip Router"
 

--- a/tip-router-operator-cli/src/ledger_utils.rs
+++ b/tip-router-operator-cli/src/ledger_utils.rs
@@ -39,7 +39,7 @@ pub enum LedgerUtilsError {
     #[error("Missing snapshot at slot {0}")]
     MissingSnapshotAtSlot(u64),
 
-    #[error("BankFromSnapshot error: {0}")]
+    #[error(transparent)]
     OpenGenesisConfigError(#[from] OpenGenesisConfigError),
 
     #[error("{0}")]

--- a/tip-router-operator-cli/src/ledger_utils.rs
+++ b/tip-router-operator-cli/src/ledger_utils.rs
@@ -35,13 +35,32 @@ use crate::{arg_matches, load_and_process_ledger, Version};
 pub enum LedgerUtilsError {
     #[error("BankFromSnapshot error: {0}")]
     BankFromSnapshotError(#[from] SnapshotError),
+
     #[error("Missing snapshot at slot {0}")]
     MissingSnapshotAtSlot(u64),
+
     #[error("BankFromSnapshot error: {0}")]
     OpenGenesisConfigError(#[from] OpenGenesisConfigError),
+
+    #[error("{0}")]
+    GenesisConfigError(String),
+
+    #[error("{0}")]
+    BlockstoreOpenError(String),
+
+    #[error("{0}")]
+    BlockstoreRangeError(String),
+
+    #[error("{0}")]
+    LoadBankForksError(String),
+
+    #[error("{0}")]
+    SnapshotCreationError(String),
+
+    #[error("Expected bank at slot {expected}, found {found}")]
+    BankSlotMismatch { expected: u64, found: u64 },
 }
 
-// TODO: Use Result and propagate errors more gracefully
 /// Create the Bank for a desired slot for given file paths.
 #[allow(clippy::cognitive_complexity, clippy::too_many_arguments)]
 pub fn get_bank_from_ledger(
@@ -54,7 +73,7 @@ pub fn get_bank_from_ledger(
     save_snapshot: bool,
     snapshot_save_path: PathBuf,
     cluster: &str,
-) -> Arc<Bank> {
+) -> Result<Arc<Bank>, LedgerUtilsError> {
     let start_time = Instant::now();
 
     // Start validation
@@ -82,16 +101,17 @@ pub fn get_bank_from_ledger(
     let genesis_config = match open_genesis_config(ledger_path, MAX_GENESIS_ARCHIVE_UNPACKED_SIZE) {
         Ok(genesis_config) => genesis_config,
         Err(e) => {
+            let error_str = format!("Failed to load genesis config: {}", e);
             datapoint_error!(
                 "tip_router_cli.get_bank",
                 ("operator", operator_address, String),
                 ("status", "error", String),
                 ("state", "load_genesis", String),
                 ("step", 1, i64),
-                ("error", format!("{:?}", e), String),
+                ("error", error_str, String),
                 "cluster" => cluster,
             );
-            panic!("Failed to load genesis config: {}", e); // TODO should panic here?
+            return Err(LedgerUtilsError::GenesisConfigError(error_str));
         }
     };
 
@@ -153,7 +173,7 @@ pub fn get_bank_from_ledger(
                 ("duration_ms", start_time.elapsed().as_millis() as i64, i64),
                 "cluster" => cluster,
             );
-            panic!("{}", error_str);
+            return Err(LedgerUtilsError::BlockstoreOpenError(error_str));
         }
         Err(err) => {
             let error_str = format!("Failed to open blockstore at {ledger_path:?}: {err:?}");
@@ -167,7 +187,7 @@ pub fn get_bank_from_ledger(
                 ("duration_ms", start_time.elapsed().as_millis() as i64, i64),
                 "cluster" => cluster,
             );
-            panic!("{}", error_str);
+            return Err(LedgerUtilsError::BlockstoreOpenError(error_str));
         }
     };
 
@@ -244,7 +264,7 @@ pub fn get_bank_from_ledger(
                     ("duration_ms", start_time.elapsed().as_millis() as i64, i64),
                     "cluster" => cluster,
                 );
-                panic!("{}", error_str);
+                return Err(LedgerUtilsError::BlockstoreRangeError(error_str));
             }
             // Check if we have the slot data necessary to replay from starting_slot to >= halt_slot.
             if !blockstore.slot_range_connected(starting_slot, halt_slot) {
@@ -260,7 +280,7 @@ pub fn get_bank_from_ledger(
                     ("duration_ms", start_time.elapsed().as_millis() as i64, i64),
                     "cluster" => cluster,
                 );
-                panic!("{}", error_str);
+                return Err(LedgerUtilsError::BlockstoreRangeError(error_str));
             }
         }
     }
@@ -288,17 +308,18 @@ pub fn get_bank_from_ledger(
         ) {
             Ok(res) => res,
             Err(e) => {
+                let error_str = format!("Failed to load bank forks: {}", e);
                 datapoint_error!(
                     "tip_router_cli.get_bank",
                     ("operator", operator_address, String),
                     ("state", "load_bank_forks", String),
                     ("status", "error", String),
                     ("step", 4, i64),
-                    ("error", format!("{:?}", e), String),
+                    ("error", error_str, String),
                     ("duration_ms", start_time.elapsed().as_millis() as i64, i64),
                     "cluster" => cluster,
                 );
-                panic!("Failed to load bank forks: {}", e);
+                return Err(LedgerUtilsError::LoadBankForksError(error_str));
             }
         };
 
@@ -398,17 +419,18 @@ pub fn get_bank_from_ledger(
         ) {
             Ok(res) => res,
             Err(e) => {
+                let error_str = format!("Failed to create snapshot: {}", e);
                 datapoint_error!(
                     "tip_router_cli.get_bank",
                     ("operator", operator_address, String),
                     ("status", "error", String),
                     ("state", "bank_to_full_snapshot_archive", String),
                     ("step", 6, i64),
-                    ("error", format!("{:?}", e), String),
+                    ("error", error_str, String),
                     ("duration_ms", start_time.elapsed().as_millis() as i64, i64),
                     "cluster" => cluster,
                 );
-                panic!("Failed to create snapshot: {}", e);
+                return Err(LedgerUtilsError::SnapshotCreationError(error_str));
             }
         };
 
@@ -421,13 +443,12 @@ pub fn get_bank_from_ledger(
     }
     // STEP 6: Complete //
 
-    assert_eq!(
-        working_bank.slot(),
-        *desired_slot,
-        "expected working bank slot {}, found {}",
-        desired_slot,
-        working_bank.slot()
-    );
+    if working_bank.slot() != *desired_slot {
+        return Err(LedgerUtilsError::BankSlotMismatch {
+            expected: *desired_slot,
+            found: working_bank.slot(),
+        });
+    }
 
     datapoint_info!(
         "tip_router_cli.get_bank",
@@ -437,7 +458,7 @@ pub fn get_bank_from_ledger(
         ("duration_ms", start_time.elapsed().as_millis() as i64, i64),
         "cluster" => cluster,
     );
-    working_bank
+    Ok(working_bank)
 }
 
 /// Loads the bank from the snapshot at the exact slot. If the snapshot doesn't exist, result is

--- a/tip-router-operator-cli/src/lib.rs
+++ b/tip-router-operator-cli/src/lib.rs
@@ -35,7 +35,7 @@ use jito_tip_payment_sdk::{
     TIP_ACCOUNT_SEED_3, TIP_ACCOUNT_SEED_4, TIP_ACCOUNT_SEED_5, TIP_ACCOUNT_SEED_6,
     TIP_ACCOUNT_SEED_7,
 };
-use ledger_utils::get_bank_from_ledger;
+use ledger_utils::{get_bank_from_ledger, LedgerUtilsError};
 use log::info;
 use meta_merkle_tree::generated_merkle_tree::StakeMetaCollection;
 use meta_merkle_tree::{
@@ -205,7 +205,11 @@ pub fn meta_merkle_tree_path(epoch: u64, save_path: &Path) -> PathBuf {
 }
 
 // STAGE 1 LoadBankFromSnapshot
-pub fn load_bank_from_snapshot(cli: Cli, slot: u64, save_snapshot: bool) -> Arc<Bank> {
+pub fn load_bank_from_snapshot(
+    cli: Cli,
+    slot: u64,
+    save_snapshot: bool,
+) -> Result<Arc<Bank>, LedgerUtilsError> {
     let SnapshotPaths {
         ledger_path,
         account_paths,

--- a/tip-router-operator-cli/src/main.rs
+++ b/tip-router-operator-cli/src/main.rs
@@ -395,7 +395,7 @@ async fn main() -> Result<()> {
         Commands::SnapshotSlot { slot } => {
             info!("Snapshotting slot...");
 
-            load_bank_from_snapshot(cli, slot, true);
+            load_bank_from_snapshot(cli, slot, true)?;
         }
         Commands::SubmitEpoch {
             ncn_address,

--- a/tip-router-operator-cli/src/process_epoch.rs
+++ b/tip-router-operator-cli/src/process_epoch.rs
@@ -7,13 +7,14 @@ use std::{
 
 use crate::{
     backup_snapshots::SnapshotInfo, cli::SnapshotPaths, create_merkle_tree_collection,
-    create_meta_merkle_tree, create_stake_meta, ledger_utils::get_bank_from_snapshot_at_slot,
+    create_meta_merkle_tree, create_stake_meta,
+    ledger_utils::{get_bank_from_snapshot_at_slot, LedgerUtilsError},
     load_bank_from_snapshot, meta_merkle_tree_path, read_merkle_tree_collection,
     read_stake_meta_collection, submit::submit_to_ncn, tip_router::get_ncn_config, Cli,
     OperatorState, Version,
 };
 use anyhow::Result;
-use log::{error, info};
+use log::{error, info, warn};
 use meta_merkle_tree::generated_merkle_tree::{GeneratedMerkleTreeCollection, StakeMetaCollection};
 use solana_metrics::{datapoint_error, datapoint_info};
 use solana_rpc_client::nonblocking::rpc_client::RpcClient;
@@ -23,6 +24,8 @@ use tokio::time;
 
 const MAX_WAIT_FOR_INCREMENTAL_SNAPSHOT_TICKS: u64 = 1200; // Experimentally determined
 const OPTIMAL_INCREMENTAL_SNAPSHOT_SLOT_RANGE: u64 = 800; // Experimentally determined
+const MAX_BLOCKSTORE_OPEN_RETRIES: u32 = 5;
+const BLOCKSTORE_RETRY_DELAY_SECS: u64 = 10;
 
 pub async fn wait_for_next_epoch(rpc_client: &RpcClient, current_epoch: u64) -> EpochInfo {
     loop {
@@ -154,6 +157,7 @@ pub async fn loop_stages(
     // Track runs that are starting right at the beginning of a new epoch
     let operator_address = cli.operator_address.clone();
     let mut stage = starting_stage;
+    let mut blockstore_retries: u32 = 0;
     let mut bank: Option<Arc<Bank>> = None;
     let mut stake_meta_collection: Option<StakeMetaCollection> = None;
     let mut merkle_tree_collection: Option<GeneratedMerkleTreeCollection> = None;
@@ -191,13 +195,38 @@ pub async fn loop_stages(
                 wait_for_optimal_incremental_snapshot(incremental_snapshots_path, slot_to_process)
                     .await?;
 
-                bank = Some(load_bank_from_snapshot(
-                    cli.clone(),
-                    slot_to_process,
-                    enable_snapshots,
-                ));
-                // Transition to the next stage
-                stage = OperatorState::CreateStakeMeta;
+                match load_bank_from_snapshot(cli.clone(), slot_to_process, enable_snapshots) {
+                    Ok(loaded_bank) => {
+                        blockstore_retries = 0;
+                        bank = Some(loaded_bank);
+                        stage = OperatorState::CreateStakeMeta;
+                    }
+                    Err(LedgerUtilsError::BlockstoreOpenError(ref e))
+                        if blockstore_retries < MAX_BLOCKSTORE_OPEN_RETRIES =>
+                    {
+                        blockstore_retries += 1;
+                        warn!(
+                            "Transient blockstore error (retry {}/{}), retrying in {}s: {}",
+                            blockstore_retries,
+                            MAX_BLOCKSTORE_OPEN_RETRIES,
+                            BLOCKSTORE_RETRY_DELAY_SECS,
+                            e
+                        );
+                        datapoint_error!(
+                            "tip_router_cli.load_bank_from_snapshot",
+                            ("operator_address", operator_address, String),
+                            ("epoch", epoch_to_process, i64),
+                            ("status", "error", String),
+                            ("error", e.to_string(), String),
+                            ("state", "blockstore_open_retry", String),
+                            ("retry", blockstore_retries, i64),
+                            "cluster" => &cli.cluster,
+                        );
+                        tokio::time::sleep(Duration::from_secs(BLOCKSTORE_RETRY_DELAY_SECS)).await;
+                        // stay in LoadBankFromSnapshot stage
+                    }
+                    Err(e) => return Err(e.into()),
+                }
             }
             OperatorState::CreateStakeMeta => {
                 let start = Instant::now();

--- a/tip-router-operator-cli/src/process_epoch.rs
+++ b/tip-router-operator-cli/src/process_epoch.rs
@@ -6,12 +6,15 @@ use std::{
 };
 
 use crate::{
-    backup_snapshots::SnapshotInfo, cli::SnapshotPaths, create_merkle_tree_collection,
-    create_meta_merkle_tree, create_stake_meta,
+    backup_snapshots::SnapshotInfo,
+    cli::SnapshotPaths,
+    create_merkle_tree_collection, create_meta_merkle_tree, create_stake_meta,
     ledger_utils::{get_bank_from_snapshot_at_slot, LedgerUtilsError},
     load_bank_from_snapshot, meta_merkle_tree_path, read_merkle_tree_collection,
-    read_stake_meta_collection, submit::submit_to_ncn, tip_router::get_ncn_config, Cli,
-    OperatorState, Version,
+    read_stake_meta_collection,
+    submit::submit_to_ncn,
+    tip_router::get_ncn_config,
+    Cli, OperatorState, Version,
 };
 use anyhow::Result;
 use log::{error, info, warn};

--- a/tip-router-operator-cli/src/process_epoch.rs
+++ b/tip-router-operator-cli/src/process_epoch.rs
@@ -208,13 +208,7 @@ pub async fn loop_stages(
                         if blockstore_retries < MAX_BLOCKSTORE_OPEN_RETRIES =>
                     {
                         blockstore_retries += 1;
-                        warn!(
-                            "Transient blockstore error (retry {}/{}), retrying in {}s: {}",
-                            blockstore_retries,
-                            MAX_BLOCKSTORE_OPEN_RETRIES,
-                            BLOCKSTORE_RETRY_DELAY_SECS,
-                            e
-                        );
+                        warn!("Transient blockstore error (retry {blockstore_retries}/{MAX_BLOCKSTORE_OPEN_RETRIES}), retrying in {BLOCKSTORE_RETRY_DELAY_SECS}s: {e}");
                         datapoint_error!(
                             "tip_router_cli.load_bank_from_snapshot",
                             ("operator_address", operator_address, String),
@@ -226,7 +220,6 @@ pub async fn loop_stages(
                             "cluster" => &cli.cluster,
                         );
                         tokio::time::sleep(Duration::from_secs(BLOCKSTORE_RETRY_DELAY_SECS)).await;
-                        // stay in LoadBankFromSnapshot stage
                     }
                     Err(e) => return Err(e.into()),
                 }


### PR DESCRIPTION
## Summary

- Converts `get_bank_from_ledger` from returning `Arc<Bank>` (with `panic!` on all errors) to returning `Result<Arc<Bank>, LedgerUtilsError>`, propagating all error paths cleanly
- Changes `load_bank_from_snapshot` in `lib.rs` to return `Result<Arc<Bank>, LedgerUtilsError>` accordingly
- In `process_epoch.rs`, adds retry logic (up to 5 retries, 10s apart) specifically for `BlockstoreOpenError` — all other error types remain fatal and propagate immediately

## Root cause

When the validator's RocksDB blockstore is mid-compaction, the MANIFEST may reference an SST file that hasn't been fully synced to disk yet. The CLI opens the blockstore in ReadOnly mode at that exact moment, sees a missing SST (`5707921.sst`), and the `Corruption: IO error: No such file or directory` error previously triggered an immediate `panic!`, causing systemd to restart the entire process.

This is a transient race condition — by the time the process restarts, the compaction has already completed and the file reference is gone. The fix avoids the full restart by retrying after a short sleep.

```bash
May 05 11:54:24 singapore-mainnet-tip-router-1 tip-router-operator-cli[1084596]: [2026-05-05T11:54:24Z INFO  tip_router_operator_cli::backup_snapshots] New target slot: 418175999
May 05 11:54:26 singapore-mainnet-tip-router-1 tip-router-operator-cli[1084596]: thread 'main' (1084596) panicked at tip-router-operator-cli/src/ledger_utils.rs:156:13:
May 05 11:54:26 singapore-mainnet-tip-router-1 tip-router-operator-cli[1084596]: Failed to open blockstore at "/solana/ledger": Error { message: "Corruption: Corruption: IO error: No such file or directory: While open a file for random read: /solana/ledger/rocksdb/5707921.sst: No such file or directory  The file /solana/ledger/rocksdb/MANIFEST-4547530 may be corrupted." }
May 05 11:54:26 singapore-mainnet-tip-router-1 tip-router-operator-cli[1084596]: note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
May 05 11:54:26 singapore-mainnet-tip-router-1 tip-router-operator-cli[1084596]: [2026-05-05T11:54:26Z ERROR solana_metrics::metrics] datapoint: tip_router_cli.get_bank,cluster=mainnet operator="GmWQyzNGzMGQySvNCADu9pynAQfUjQm6tJL9cuN5Y3D6" status="error" state="load_blockstore" step=2i error="Failed to open blockstore at \"/solana/ledger\": Error { message: \"Corruption: Corruption: IO error: No such file or directory: While open a file for random read: /solana/ledger/rocksdb/5707921.sst: No such file or directory  The file /solana/ledger/rocksdb/MANIFEST-4547530 may be corrupted.\" }" duration_ms=3334i
```

## Behavior change

Before: any blockstore open failure → `panic!` → systemd restart (~30s recovery, full epoch reprocessing restarts from scratch)

After: `BlockstoreOpenError` → sleep 10s → retry, up to 5 times → if all retries exhausted, propagate error to systemd (same as before). All other errors (genesis config missing, bank forks failure, etc.) remain fatal immediately.

## Test plan

- [x] Build passes: `cargo build -p tip-router-operator-cli`
- [ ] Confirm service no longer panics when blockstore is mid-compaction at epoch boundary
- [ ] Confirm other fatal errors (e.g. wrong ledger path) still terminate the process promptly