### PR TITLE
Operator: Pin jito-solana blockstore compatibility backport

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13564,7 +13564,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tip-router-operator-cli"
-version = "4.0.2"
+version = "4.0.3"
 dependencies = [
  "agave-snapshots",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,7 +57,7 @@ dependencies = [
 [[package]]
 name = "agave-banking-stage-ingress-types"
 version = "4.1.0-alpha.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=0ecd70f3bdaed01d6b2b371422d3ec874c87486f#0ecd70f3bdaed01d6b2b371422d3ec874c87486f"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=623eceb50d7200f418d38a04926e6b47037214e6#623eceb50d7200f418d38a04926e6b47037214e6"
 dependencies = [
  "crossbeam-channel",
  "solana-perf",
@@ -66,7 +66,7 @@ dependencies = [
 [[package]]
 name = "agave-bls-cert-verify"
 version = "4.1.0-alpha.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=0ecd70f3bdaed01d6b2b371422d3ec874c87486f#0ecd70f3bdaed01d6b2b371422d3ec874c87486f"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=623eceb50d7200f418d38a04926e6b47037214e6#623eceb50d7200f418d38a04926e6b47037214e6"
 dependencies = [
  "agave-votor-messages",
  "bitvec",
@@ -81,7 +81,7 @@ dependencies = [
 [[package]]
 name = "agave-bls12-381"
 version = "4.1.0-alpha.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=0ecd70f3bdaed01d6b2b371422d3ec874c87486f#0ecd70f3bdaed01d6b2b371422d3ec874c87486f"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=623eceb50d7200f418d38a04926e6b47037214e6#623eceb50d7200f418d38a04926e6b47037214e6"
 dependencies = [
  "blst",
  "blstrs",
@@ -94,7 +94,7 @@ dependencies = [
 [[package]]
 name = "agave-feature-set"
 version = "4.1.0-alpha.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=0ecd70f3bdaed01d6b2b371422d3ec874c87486f#0ecd70f3bdaed01d6b2b371422d3ec874c87486f"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=623eceb50d7200f418d38a04926e6b47037214e6#623eceb50d7200f418d38a04926e6b47037214e6"
 dependencies = [
  "ahash 0.8.12",
  "solana-epoch-schedule 3.0.0",
@@ -108,7 +108,7 @@ dependencies = [
 [[package]]
 name = "agave-fs"
 version = "4.1.0-alpha.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=0ecd70f3bdaed01d6b2b371422d3ec874c87486f#0ecd70f3bdaed01d6b2b371422d3ec874c87486f"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=623eceb50d7200f418d38a04926e6b47037214e6#623eceb50d7200f418d38a04926e6b47037214e6"
 dependencies = [
  "agave-io-uring",
  "io-uring",
@@ -122,7 +122,7 @@ dependencies = [
 [[package]]
 name = "agave-geyser-plugin-interface"
 version = "4.1.0-alpha.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=0ecd70f3bdaed01d6b2b371422d3ec874c87486f#0ecd70f3bdaed01d6b2b371422d3ec874c87486f"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=623eceb50d7200f418d38a04926e6b47037214e6#623eceb50d7200f418d38a04926e6b47037214e6"
 dependencies = [
  "log",
  "solana-clock 3.0.1",
@@ -136,7 +136,7 @@ dependencies = [
 [[package]]
 name = "agave-io-uring"
 version = "4.1.0-alpha.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=0ecd70f3bdaed01d6b2b371422d3ec874c87486f#0ecd70f3bdaed01d6b2b371422d3ec874c87486f"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=623eceb50d7200f418d38a04926e6b47037214e6#623eceb50d7200f418d38a04926e6b47037214e6"
 dependencies = [
  "io-uring",
  "libc",
@@ -148,7 +148,7 @@ dependencies = [
 [[package]]
 name = "agave-logger"
 version = "4.1.0-alpha.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=0ecd70f3bdaed01d6b2b371422d3ec874c87486f#0ecd70f3bdaed01d6b2b371422d3ec874c87486f"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=623eceb50d7200f418d38a04926e6b47037214e6#623eceb50d7200f418d38a04926e6b47037214e6"
 dependencies = [
  "env_logger 0.11.10",
  "libc",
@@ -159,7 +159,7 @@ dependencies = [
 [[package]]
 name = "agave-math-utils"
 version = "4.1.0-alpha.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=0ecd70f3bdaed01d6b2b371422d3ec874c87486f#0ecd70f3bdaed01d6b2b371422d3ec874c87486f"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=623eceb50d7200f418d38a04926e6b47037214e6#623eceb50d7200f418d38a04926e6b47037214e6"
 dependencies = [
  "num-traits",
 ]
@@ -167,7 +167,7 @@ dependencies = [
 [[package]]
 name = "agave-precompiles"
 version = "4.1.0-alpha.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=0ecd70f3bdaed01d6b2b371422d3ec874c87486f#0ecd70f3bdaed01d6b2b371422d3ec874c87486f"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=623eceb50d7200f418d38a04926e6b47037214e6#623eceb50d7200f418d38a04926e6b47037214e6"
 dependencies = [
  "agave-feature-set",
  "bincode",
@@ -188,7 +188,7 @@ dependencies = [
 [[package]]
 name = "agave-random"
 version = "4.1.0-alpha.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=0ecd70f3bdaed01d6b2b371422d3ec874c87486f#0ecd70f3bdaed01d6b2b371422d3ec874c87486f"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=623eceb50d7200f418d38a04926e6b47037214e6#623eceb50d7200f418d38a04926e6b47037214e6"
 dependencies = [
  "rand 0.9.2",
 ]
@@ -196,7 +196,7 @@ dependencies = [
 [[package]]
 name = "agave-reserved-account-keys"
 version = "4.1.0-alpha.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=0ecd70f3bdaed01d6b2b371422d3ec874c87486f#0ecd70f3bdaed01d6b2b371422d3ec874c87486f"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=623eceb50d7200f418d38a04926e6b47037214e6#623eceb50d7200f418d38a04926e6b47037214e6"
 dependencies = [
  "agave-feature-set",
  "solana-pubkey 4.1.0",
@@ -206,12 +206,12 @@ dependencies = [
 [[package]]
 name = "agave-scheduler-bindings"
 version = "4.1.0-alpha.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=0ecd70f3bdaed01d6b2b371422d3ec874c87486f#0ecd70f3bdaed01d6b2b371422d3ec874c87486f"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=623eceb50d7200f418d38a04926e6b47037214e6#623eceb50d7200f418d38a04926e6b47037214e6"
 
 [[package]]
 name = "agave-scheduling-utils"
 version = "4.1.0-alpha.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=0ecd70f3bdaed01d6b2b371422d3ec874c87486f#0ecd70f3bdaed01d6b2b371422d3ec874c87486f"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=623eceb50d7200f418d38a04926e6b47037214e6#623eceb50d7200f418d38a04926e6b47037214e6"
 dependencies = [
  "agave-scheduler-bindings",
  "agave-transaction-view",
@@ -228,7 +228,7 @@ dependencies = [
 [[package]]
 name = "agave-snapshots"
 version = "4.1.0-alpha.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=0ecd70f3bdaed01d6b2b371422d3ec874c87486f#0ecd70f3bdaed01d6b2b371422d3ec874c87486f"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=623eceb50d7200f418d38a04926e6b47037214e6#623eceb50d7200f418d38a04926e6b47037214e6"
 dependencies = [
  "agave-fs",
  "bincode",
@@ -257,7 +257,7 @@ dependencies = [
 [[package]]
 name = "agave-syscalls"
 version = "4.1.0-alpha.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=0ecd70f3bdaed01d6b2b371422d3ec874c87486f#0ecd70f3bdaed01d6b2b371422d3ec874c87486f"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=623eceb50d7200f418d38a04926e6b47037214e6#623eceb50d7200f418d38a04926e6b47037214e6"
 dependencies = [
  "agave-bls12-381",
  "bincode",
@@ -300,7 +300,7 @@ dependencies = [
 [[package]]
 name = "agave-transaction-view"
 version = "4.1.0-alpha.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=0ecd70f3bdaed01d6b2b371422d3ec874c87486f#0ecd70f3bdaed01d6b2b371422d3ec874c87486f"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=623eceb50d7200f418d38a04926e6b47037214e6#623eceb50d7200f418d38a04926e6b47037214e6"
 dependencies = [
  "solana-hash 4.2.0",
  "solana-message 4.0.0",
@@ -316,7 +316,7 @@ dependencies = [
 [[package]]
 name = "agave-votor"
 version = "4.1.0-alpha.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=0ecd70f3bdaed01d6b2b371422d3ec874c87486f#0ecd70f3bdaed01d6b2b371422d3ec874c87486f"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=623eceb50d7200f418d38a04926e6b47037214e6#623eceb50d7200f418d38a04926e6b47037214e6"
 dependencies = [
  "agave-logger",
  "agave-math-utils",
@@ -362,7 +362,7 @@ dependencies = [
 [[package]]
 name = "agave-votor-messages"
 version = "4.1.0-alpha.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=0ecd70f3bdaed01d6b2b371422d3ec874c87486f#0ecd70f3bdaed01d6b2b371422d3ec874c87486f"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=623eceb50d7200f418d38a04926e6b47037214e6#623eceb50d7200f418d38a04926e6b47037214e6"
 dependencies = [
  "agave-feature-set",
  "log",
@@ -381,7 +381,7 @@ dependencies = [
 [[package]]
 name = "agave-xdp"
 version = "4.1.0-alpha.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=0ecd70f3bdaed01d6b2b371422d3ec874c87486f#0ecd70f3bdaed01d6b2b371422d3ec874c87486f"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=623eceb50d7200f418d38a04926e6b47037214e6#623eceb50d7200f418d38a04926e6b47037214e6"
 dependencies = [
  "agave-xdp-ebpf",
  "arc-swap",
@@ -398,7 +398,7 @@ dependencies = [
 [[package]]
 name = "agave-xdp-ebpf"
 version = "4.1.0-alpha.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=0ecd70f3bdaed01d6b2b371422d3ec874c87486f#0ecd70f3bdaed01d6b2b371422d3ec874c87486f"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=623eceb50d7200f418d38a04926e6b47037214e6#623eceb50d7200f418d38a04926e6b47037214e6"
 dependencies = [
  "aya",
  "aya-ebpf",
@@ -1302,7 +1302,7 @@ dependencies = [
  "bitflags 2.11.0",
  "cexpr",
  "clang-sys",
- "itertools 0.12.1",
+ "itertools 0.11.0",
  "lazy_static",
  "lazycell",
  "proc-macro2",
@@ -4098,7 +4098,7 @@ dependencies = [
 [[package]]
 name = "jito-protos"
 version = "4.1.0-alpha.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=0ecd70f3bdaed01d6b2b371422d3ec874c87486f#0ecd70f3bdaed01d6b2b371422d3ec874c87486f"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=623eceb50d7200f418d38a04926e6b47037214e6#623eceb50d7200f418d38a04926e6b47037214e6"
 dependencies = [
  "bytes",
  "prost 0.14.3",
@@ -5934,7 +5934,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck 0.5.0",
- "itertools 0.14.0",
+ "itertools 0.11.0",
  "log",
  "multimap",
  "once_cell",
@@ -5954,7 +5954,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
  "heck 0.5.0",
- "itertools 0.14.0",
+ "itertools 0.11.0",
  "log",
  "multimap",
  "petgraph 0.8.3",
@@ -5975,7 +5975,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.11.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -5988,7 +5988,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.11.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -6001,7 +6001,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.11.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -7583,7 +7583,7 @@ dependencies = [
 [[package]]
 name = "solana-account-decoder"
 version = "4.1.0-alpha.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=0ecd70f3bdaed01d6b2b371422d3ec874c87486f#0ecd70f3bdaed01d6b2b371422d3ec874c87486f"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=623eceb50d7200f418d38a04926e6b47037214e6#623eceb50d7200f418d38a04926e6b47037214e6"
 dependencies = [
  "Inflector",
  "base64 0.22.1",
@@ -7624,7 +7624,7 @@ dependencies = [
 [[package]]
 name = "solana-account-decoder-client-types"
 version = "4.1.0-alpha.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=0ecd70f3bdaed01d6b2b371422d3ec874c87486f#0ecd70f3bdaed01d6b2b371422d3ec874c87486f"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=623eceb50d7200f418d38a04926e6b47037214e6#623eceb50d7200f418d38a04926e6b47037214e6"
 dependencies = [
  "base64 0.22.1",
  "bs58 0.5.1",
@@ -7664,7 +7664,7 @@ dependencies = [
 [[package]]
 name = "solana-accounts-db"
 version = "4.1.0-alpha.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=0ecd70f3bdaed01d6b2b371422d3ec874c87486f#0ecd70f3bdaed01d6b2b371422d3ec874c87486f"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=623eceb50d7200f418d38a04926e6b47037214e6#623eceb50d7200f418d38a04926e6b47037214e6"
 dependencies = [
  "agave-fs",
  "ahash 0.8.12",
@@ -7808,7 +7808,7 @@ dependencies = [
 [[package]]
 name = "solana-banks-client"
 version = "4.1.0-alpha.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=0ecd70f3bdaed01d6b2b371422d3ec874c87486f#0ecd70f3bdaed01d6b2b371422d3ec874c87486f"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=623eceb50d7200f418d38a04926e6b47037214e6#623eceb50d7200f418d38a04926e6b47037214e6"
 dependencies = [
  "borsh 1.6.1",
  "futures 0.3.32",
@@ -7835,7 +7835,7 @@ dependencies = [
 [[package]]
 name = "solana-banks-interface"
 version = "4.1.0-alpha.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=0ecd70f3bdaed01d6b2b371422d3ec874c87486f#0ecd70f3bdaed01d6b2b371422d3ec874c87486f"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=623eceb50d7200f418d38a04926e6b47037214e6#623eceb50d7200f418d38a04926e6b47037214e6"
 dependencies = [
  "serde",
  "solana-account 4.1.0",
@@ -7854,7 +7854,7 @@ dependencies = [
 [[package]]
 name = "solana-banks-server"
 version = "4.1.0-alpha.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=0ecd70f3bdaed01d6b2b371422d3ec874c87486f#0ecd70f3bdaed01d6b2b371422d3ec874c87486f"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=623eceb50d7200f418d38a04926e6b47037214e6#623eceb50d7200f418d38a04926e6b47037214e6"
 dependencies = [
  "agave-feature-set",
  "bincode",
@@ -7951,7 +7951,7 @@ dependencies = [
 [[package]]
 name = "solana-bloom"
 version = "4.1.0-alpha.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=0ecd70f3bdaed01d6b2b371422d3ec874c87486f#0ecd70f3bdaed01d6b2b371422d3ec874c87486f"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=623eceb50d7200f418d38a04926e6b47037214e6#623eceb50d7200f418d38a04926e6b47037214e6"
 dependencies = [
  "bv",
  "fnv",
@@ -8038,7 +8038,7 @@ dependencies = [
 [[package]]
 name = "solana-bpf-loader-program"
 version = "4.1.0-alpha.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=0ecd70f3bdaed01d6b2b371422d3ec874c87486f#0ecd70f3bdaed01d6b2b371422d3ec874c87486f"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=623eceb50d7200f418d38a04926e6b47037214e6#623eceb50d7200f418d38a04926e6b47037214e6"
 dependencies = [
  "agave-syscalls",
  "bincode",
@@ -8065,7 +8065,7 @@ dependencies = [
 [[package]]
 name = "solana-bucket-map"
 version = "4.1.0-alpha.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=0ecd70f3bdaed01d6b2b371422d3ec874c87486f#0ecd70f3bdaed01d6b2b371422d3ec874c87486f"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=623eceb50d7200f418d38a04926e6b47037214e6#623eceb50d7200f418d38a04926e6b47037214e6"
 dependencies = [
  "ahash 0.8.12",
  "bv",
@@ -8084,7 +8084,7 @@ dependencies = [
 [[package]]
 name = "solana-builtins"
 version = "4.1.0-alpha.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=0ecd70f3bdaed01d6b2b371422d3ec874c87486f#0ecd70f3bdaed01d6b2b371422d3ec874c87486f"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=623eceb50d7200f418d38a04926e6b47037214e6#623eceb50d7200f418d38a04926e6b47037214e6"
 dependencies = [
  "agave-feature-set",
  "solana-bpf-loader-program",
@@ -8103,7 +8103,7 @@ dependencies = [
 [[package]]
 name = "solana-builtins-default-costs"
 version = "4.1.0-alpha.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=0ecd70f3bdaed01d6b2b371422d3ec874c87486f#0ecd70f3bdaed01d6b2b371422d3ec874c87486f"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=623eceb50d7200f418d38a04926e6b47037214e6#623eceb50d7200f418d38a04926e6b47037214e6"
 dependencies = [
  "agave-feature-set",
  "ahash 0.8.12",
@@ -8120,7 +8120,7 @@ dependencies = [
 [[package]]
 name = "solana-bundle"
 version = "4.1.0-alpha.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=0ecd70f3bdaed01d6b2b371422d3ec874c87486f#0ecd70f3bdaed01d6b2b371422d3ec874c87486f"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=623eceb50d7200f418d38a04926e6b47037214e6#623eceb50d7200f418d38a04926e6b47037214e6"
 dependencies = [
  "itertools 0.14.0",
  "sha2 0.10.9",
@@ -8130,7 +8130,7 @@ dependencies = [
 [[package]]
 name = "solana-clap-utils"
 version = "4.1.0-alpha.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=0ecd70f3bdaed01d6b2b371422d3ec874c87486f#0ecd70f3bdaed01d6b2b371422d3ec874c87486f"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=623eceb50d7200f418d38a04926e6b47037214e6#623eceb50d7200f418d38a04926e6b47037214e6"
 dependencies = [
  "chrono",
  "clap 2.34.0",
@@ -8159,7 +8159,7 @@ dependencies = [
 [[package]]
 name = "solana-cli-config"
 version = "4.1.0-alpha.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=0ecd70f3bdaed01d6b2b371422d3ec874c87486f#0ecd70f3bdaed01d6b2b371422d3ec874c87486f"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=623eceb50d7200f418d38a04926e6b47037214e6#623eceb50d7200f418d38a04926e6b47037214e6"
 dependencies = [
  "dirs-next",
  "serde",
@@ -8172,7 +8172,7 @@ dependencies = [
 [[package]]
 name = "solana-cli-output"
 version = "4.1.0-alpha.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=0ecd70f3bdaed01d6b2b371422d3ec874c87486f#0ecd70f3bdaed01d6b2b371422d3ec874c87486f"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=623eceb50d7200f418d38a04926e6b47037214e6#623eceb50d7200f418d38a04926e6b47037214e6"
 dependencies = [
  "Inflector",
  "agave-reserved-account-keys",
@@ -8212,7 +8212,7 @@ dependencies = [
 [[package]]
 name = "solana-client"
 version = "4.1.0-alpha.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=0ecd70f3bdaed01d6b2b371422d3ec874c87486f#0ecd70f3bdaed01d6b2b371422d3ec874c87486f"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=623eceb50d7200f418d38a04926e6b47037214e6#623eceb50d7200f418d38a04926e6b47037214e6"
 dependencies = [
  "async-trait",
  "bincode",
@@ -8358,7 +8358,7 @@ dependencies = [
 [[package]]
 name = "solana-compute-budget"
 version = "4.1.0-alpha.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=0ecd70f3bdaed01d6b2b371422d3ec874c87486f#0ecd70f3bdaed01d6b2b371422d3ec874c87486f"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=623eceb50d7200f418d38a04926e6b47037214e6#623eceb50d7200f418d38a04926e6b47037214e6"
 dependencies = [
  "solana-fee-structure 3.0.0",
  "solana-program-runtime",
@@ -8367,7 +8367,7 @@ dependencies = [
 [[package]]
 name = "solana-compute-budget-instruction"
 version = "4.1.0-alpha.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=0ecd70f3bdaed01d6b2b371422d3ec874c87486f#0ecd70f3bdaed01d6b2b371422d3ec874c87486f"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=623eceb50d7200f418d38a04926e6b47037214e6#623eceb50d7200f418d38a04926e6b47037214e6"
 dependencies = [
  "agave-feature-set",
  "solana-borsh 3.0.2",
@@ -8409,7 +8409,7 @@ dependencies = [
 [[package]]
 name = "solana-compute-budget-program"
 version = "4.1.0-alpha.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=0ecd70f3bdaed01d6b2b371422d3ec874c87486f#0ecd70f3bdaed01d6b2b371422d3ec874c87486f"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=623eceb50d7200f418d38a04926e6b47037214e6#623eceb50d7200f418d38a04926e6b47037214e6"
 dependencies = [
  "solana-program-runtime",
 ]
@@ -8434,7 +8434,7 @@ dependencies = [
 [[package]]
 name = "solana-connection-cache"
 version = "4.1.0-alpha.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=0ecd70f3bdaed01d6b2b371422d3ec874c87486f#0ecd70f3bdaed01d6b2b371422d3ec874c87486f"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=623eceb50d7200f418d38a04926e6b47037214e6#623eceb50d7200f418d38a04926e6b47037214e6"
 dependencies = [
  "async-trait",
  "crossbeam-channel",
@@ -8452,7 +8452,7 @@ dependencies = [
 [[package]]
 name = "solana-core"
 version = "4.1.0-alpha.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=0ecd70f3bdaed01d6b2b371422d3ec874c87486f#0ecd70f3bdaed01d6b2b371422d3ec874c87486f"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=623eceb50d7200f418d38a04926e6b47037214e6#623eceb50d7200f418d38a04926e6b47037214e6"
 dependencies = [
  "agave-banking-stage-ingress-types",
  "agave-bls-cert-verify",
@@ -8610,7 +8610,7 @@ dependencies = [
 [[package]]
 name = "solana-cost-model"
 version = "4.1.0-alpha.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=0ecd70f3bdaed01d6b2b371422d3ec874c87486f#0ecd70f3bdaed01d6b2b371422d3ec874c87486f"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=623eceb50d7200f418d38a04926e6b47037214e6#623eceb50d7200f418d38a04926e6b47037214e6"
 dependencies = [
  "agave-feature-set",
  "ahash 0.8.12",
@@ -8746,7 +8746,7 @@ dependencies = [
 [[package]]
 name = "solana-download-utils"
 version = "4.1.0-alpha.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=0ecd70f3bdaed01d6b2b371422d3ec874c87486f#0ecd70f3bdaed01d6b2b371422d3ec874c87486f"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=623eceb50d7200f418d38a04926e6b47037214e6#623eceb50d7200f418d38a04926e6b47037214e6"
 dependencies = [
  "agave-snapshots",
  "log",
@@ -8786,7 +8786,7 @@ dependencies = [
 [[package]]
 name = "solana-entry"
 version = "4.1.0-alpha.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=0ecd70f3bdaed01d6b2b371422d3ec874c87486f#0ecd70f3bdaed01d6b2b371422d3ec874c87486f"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=623eceb50d7200f418d38a04926e6b47037214e6#623eceb50d7200f418d38a04926e6b47037214e6"
 dependencies = [
  "agave-votor-messages",
  "crossbeam-channel",
@@ -8981,7 +8981,7 @@ dependencies = [
 [[package]]
 name = "solana-faucet"
 version = "4.1.0-alpha.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=0ecd70f3bdaed01d6b2b371422d3ec874c87486f#0ecd70f3bdaed01d6b2b371422d3ec874c87486f"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=623eceb50d7200f418d38a04926e6b47037214e6#623eceb50d7200f418d38a04926e6b47037214e6"
 dependencies = [
  "bincode",
  "crossbeam-channel",
@@ -9060,7 +9060,7 @@ dependencies = [
 [[package]]
 name = "solana-fee"
 version = "4.1.0-alpha.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=0ecd70f3bdaed01d6b2b371422d3ec874c87486f#0ecd70f3bdaed01d6b2b371422d3ec874c87486f"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=623eceb50d7200f418d38a04926e6b47037214e6#623eceb50d7200f418d38a04926e6b47037214e6"
 dependencies = [
  "agave-feature-set",
  "solana-fee-structure 3.0.0",
@@ -9185,7 +9185,7 @@ dependencies = [
 [[package]]
 name = "solana-genesis-utils"
 version = "4.1.0-alpha.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=0ecd70f3bdaed01d6b2b371422d3ec874c87486f#0ecd70f3bdaed01d6b2b371422d3ec874c87486f"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=623eceb50d7200f418d38a04926e6b47037214e6#623eceb50d7200f418d38a04926e6b47037214e6"
 dependencies = [
  "agave-snapshots",
  "log",
@@ -9199,7 +9199,7 @@ dependencies = [
 [[package]]
 name = "solana-geyser-plugin-manager"
 version = "4.1.0-alpha.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=0ecd70f3bdaed01d6b2b371422d3ec874c87486f#0ecd70f3bdaed01d6b2b371422d3ec874c87486f"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=623eceb50d7200f418d38a04926e6b47037214e6#623eceb50d7200f418d38a04926e6b47037214e6"
 dependencies = [
  "agave-geyser-plugin-interface",
  "arc-swap",
@@ -9229,7 +9229,7 @@ dependencies = [
 [[package]]
 name = "solana-gossip"
 version = "4.1.0-alpha.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=0ecd70f3bdaed01d6b2b371422d3ec874c87486f#0ecd70f3bdaed01d6b2b371422d3ec874c87486f"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=623eceb50d7200f418d38a04926e6b47037214e6#623eceb50d7200f418d38a04926e6b47037214e6"
 dependencies = [
  "agave-logger",
  "agave-random",
@@ -9543,7 +9543,7 @@ dependencies = [
 [[package]]
 name = "solana-lattice-hash"
 version = "4.1.0-alpha.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=0ecd70f3bdaed01d6b2b371422d3ec874c87486f#0ecd70f3bdaed01d6b2b371422d3ec874c87486f"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=623eceb50d7200f418d38a04926e6b47037214e6#623eceb50d7200f418d38a04926e6b47037214e6"
 dependencies = [
  "base64 0.22.1",
  "blake3",
@@ -9554,7 +9554,7 @@ dependencies = [
 [[package]]
 name = "solana-leader-schedule"
 version = "4.1.0-alpha.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=0ecd70f3bdaed01d6b2b371422d3ec874c87486f#0ecd70f3bdaed01d6b2b371422d3ec874c87486f"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=623eceb50d7200f418d38a04926e6b47037214e6#623eceb50d7200f418d38a04926e6b47037214e6"
 dependencies = [
  "agave-random",
  "itertools 0.14.0",
@@ -9567,7 +9567,7 @@ dependencies = [
 [[package]]
 name = "solana-ledger"
 version = "4.1.0-alpha.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=0ecd70f3bdaed01d6b2b371422d3ec874c87486f#0ecd70f3bdaed01d6b2b371422d3ec874c87486f"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=623eceb50d7200f418d38a04926e6b47037214e6#623eceb50d7200f418d38a04926e6b47037214e6"
 dependencies = [
  "agave-feature-set",
  "agave-reserved-account-keys",
@@ -9752,7 +9752,7 @@ dependencies = [
 [[package]]
 name = "solana-loader-v4-program"
 version = "4.1.0-alpha.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=0ecd70f3bdaed01d6b2b371422d3ec874c87486f#0ecd70f3bdaed01d6b2b371422d3ec874c87486f"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=623eceb50d7200f418d38a04926e6b47037214e6#623eceb50d7200f418d38a04926e6b47037214e6"
 dependencies = [
  "solana-account 4.1.0",
  "solana-bincode 3.1.0",
@@ -9787,12 +9787,12 @@ dependencies = [
 [[package]]
 name = "solana-measure"
 version = "4.1.0-alpha.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=0ecd70f3bdaed01d6b2b371422d3ec874c87486f#0ecd70f3bdaed01d6b2b371422d3ec874c87486f"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=623eceb50d7200f418d38a04926e6b47037214e6#623eceb50d7200f418d38a04926e6b47037214e6"
 
 [[package]]
 name = "solana-merkle-tree"
 version = "4.1.0-alpha.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=0ecd70f3bdaed01d6b2b371422d3ec874c87486f#0ecd70f3bdaed01d6b2b371422d3ec874c87486f"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=623eceb50d7200f418d38a04926e6b47037214e6#623eceb50d7200f418d38a04926e6b47037214e6"
 dependencies = [
  "fast-math",
  "solana-hash 4.2.0",
@@ -9863,7 +9863,7 @@ dependencies = [
 [[package]]
 name = "solana-metrics"
 version = "4.1.0-alpha.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=0ecd70f3bdaed01d6b2b371422d3ec874c87486f#0ecd70f3bdaed01d6b2b371422d3ec874c87486f"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=623eceb50d7200f418d38a04926e6b47037214e6#623eceb50d7200f418d38a04926e6b47037214e6"
 dependencies = [
  "crossbeam-channel",
  "gethostname",
@@ -9908,7 +9908,7 @@ checksum = "ae8dd4c280dca9d046139eb5b7a5ac9ad10403fbd64964c7d7571214950d758f"
 [[package]]
 name = "solana-net-utils"
 version = "4.1.0-alpha.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=0ecd70f3bdaed01d6b2b371422d3ec874c87486f#0ecd70f3bdaed01d6b2b371422d3ec874c87486f"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=623eceb50d7200f418d38a04926e6b47037214e6#623eceb50d7200f418d38a04926e6b47037214e6"
 dependencies = [
  "anyhow",
  "bincode",
@@ -10067,7 +10067,7 @@ dependencies = [
 [[package]]
 name = "solana-perf"
 version = "4.1.0-alpha.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=0ecd70f3bdaed01d6b2b371422d3ec874c87486f#0ecd70f3bdaed01d6b2b371422d3ec874c87486f"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=623eceb50d7200f418d38a04926e6b47037214e6#623eceb50d7200f418d38a04926e6b47037214e6"
 dependencies = [
  "ahash 0.8.12",
  "bincode",
@@ -10095,7 +10095,7 @@ dependencies = [
 [[package]]
 name = "solana-poh"
 version = "4.1.0-alpha.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=0ecd70f3bdaed01d6b2b371422d3ec874c87486f#0ecd70f3bdaed01d6b2b371422d3ec874c87486f"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=623eceb50d7200f418d38a04926e6b47037214e6#623eceb50d7200f418d38a04926e6b47037214e6"
 dependencies = [
  "agave-votor-messages",
  "arc-swap",
@@ -10388,7 +10388,7 @@ dependencies = [
 [[package]]
 name = "solana-program-binaries"
 version = "4.1.0-alpha.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=0ecd70f3bdaed01d6b2b371422d3ec874c87486f#0ecd70f3bdaed01d6b2b371422d3ec874c87486f"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=623eceb50d7200f418d38a04926e6b47037214e6#623eceb50d7200f418d38a04926e6b47037214e6"
 dependencies = [
  "bincode",
  "solana-account 4.1.0",
@@ -10501,7 +10501,7 @@ dependencies = [
 [[package]]
 name = "solana-program-runtime"
 version = "4.1.0-alpha.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=0ecd70f3bdaed01d6b2b371422d3ec874c87486f#0ecd70f3bdaed01d6b2b371422d3ec874c87486f"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=623eceb50d7200f418d38a04926e6b47037214e6#623eceb50d7200f418d38a04926e6b47037214e6"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -10547,7 +10547,7 @@ dependencies = [
 [[package]]
 name = "solana-program-test"
 version = "4.1.0-alpha.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=0ecd70f3bdaed01d6b2b371422d3ec874c87486f#0ecd70f3bdaed01d6b2b371422d3ec874c87486f"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=623eceb50d7200f418d38a04926e6b47037214e6#623eceb50d7200f418d38a04926e6b47037214e6"
 dependencies = [
  "agave-feature-set",
  "agave-logger",
@@ -10654,7 +10654,7 @@ dependencies = [
 [[package]]
 name = "solana-pubsub-client"
 version = "4.1.0-alpha.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=0ecd70f3bdaed01d6b2b371422d3ec874c87486f#0ecd70f3bdaed01d6b2b371422d3ec874c87486f"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=623eceb50d7200f418d38a04926e6b47037214e6#623eceb50d7200f418d38a04926e6b47037214e6"
 dependencies = [
  "crossbeam-channel",
  "futures-util",
@@ -10677,7 +10677,7 @@ dependencies = [
 [[package]]
 name = "solana-quic-client"
 version = "4.1.0-alpha.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=0ecd70f3bdaed01d6b2b371422d3ec874c87486f#0ecd70f3bdaed01d6b2b371422d3ec874c87486f"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=623eceb50d7200f418d38a04926e6b47037214e6#623eceb50d7200f418d38a04926e6b47037214e6"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -10711,7 +10711,7 @@ dependencies = [
 [[package]]
 name = "solana-rayon-threadlimit"
 version = "4.1.0-alpha.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=0ecd70f3bdaed01d6b2b371422d3ec874c87486f#0ecd70f3bdaed01d6b2b371422d3ec874c87486f"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=623eceb50d7200f418d38a04926e6b47037214e6#623eceb50d7200f418d38a04926e6b47037214e6"
 dependencies = [
  "log",
  "num_cpus",
@@ -10720,7 +10720,7 @@ dependencies = [
 [[package]]
 name = "solana-remote-wallet"
 version = "4.1.0-alpha.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=0ecd70f3bdaed01d6b2b371422d3ec874c87486f#0ecd70f3bdaed01d6b2b371422d3ec874c87486f"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=623eceb50d7200f418d38a04926e6b47037214e6#623eceb50d7200f418d38a04926e6b47037214e6"
 dependencies = [
  "console 0.16.3",
  "dialoguer",
@@ -10840,7 +10840,7 @@ dependencies = [
 [[package]]
 name = "solana-rpc"
 version = "4.1.0-alpha.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=0ecd70f3bdaed01d6b2b371422d3ec874c87486f#0ecd70f3bdaed01d6b2b371422d3ec874c87486f"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=623eceb50d7200f418d38a04926e6b47037214e6#623eceb50d7200f418d38a04926e6b47037214e6"
 dependencies = [
  "agave-feature-set",
  "agave-snapshots",
@@ -10923,7 +10923,7 @@ dependencies = [
 [[package]]
 name = "solana-rpc-client"
 version = "4.1.0-alpha.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=0ecd70f3bdaed01d6b2b371422d3ec874c87486f#0ecd70f3bdaed01d6b2b371422d3ec874c87486f"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=623eceb50d7200f418d38a04926e6b47037214e6#623eceb50d7200f418d38a04926e6b47037214e6"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -10962,7 +10962,7 @@ dependencies = [
 [[package]]
 name = "solana-rpc-client-api"
 version = "4.1.0-alpha.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=0ecd70f3bdaed01d6b2b371422d3ec874c87486f#0ecd70f3bdaed01d6b2b371422d3ec874c87486f"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=623eceb50d7200f418d38a04926e6b47037214e6#623eceb50d7200f418d38a04926e6b47037214e6"
 dependencies = [
  "anyhow",
  "jsonrpc-core",
@@ -10985,7 +10985,7 @@ dependencies = [
 [[package]]
 name = "solana-rpc-client-nonce-utils"
 version = "4.1.0-alpha.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=0ecd70f3bdaed01d6b2b371422d3ec874c87486f#0ecd70f3bdaed01d6b2b371422d3ec874c87486f"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=623eceb50d7200f418d38a04926e6b47037214e6#623eceb50d7200f418d38a04926e6b47037214e6"
 dependencies = [
  "solana-account 4.1.0",
  "solana-commitment-config 3.1.1",
@@ -11001,7 +11001,7 @@ dependencies = [
 [[package]]
 name = "solana-rpc-client-types"
 version = "4.1.0-alpha.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=0ecd70f3bdaed01d6b2b371422d3ec874c87486f#0ecd70f3bdaed01d6b2b371422d3ec874c87486f"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=623eceb50d7200f418d38a04926e6b47037214e6#623eceb50d7200f418d38a04926e6b47037214e6"
 dependencies = [
  "base64 0.22.1",
  "bs58 0.5.1",
@@ -11025,7 +11025,7 @@ dependencies = [
 [[package]]
 name = "solana-runtime"
 version = "4.1.0-alpha.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=0ecd70f3bdaed01d6b2b371422d3ec874c87486f#0ecd70f3bdaed01d6b2b371422d3ec874c87486f"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=623eceb50d7200f418d38a04926e6b47037214e6#623eceb50d7200f418d38a04926e6b47037214e6"
 dependencies = [
  "agave-bls-cert-verify",
  "agave-feature-set",
@@ -11155,7 +11155,7 @@ dependencies = [
 [[package]]
 name = "solana-runtime-transaction"
 version = "4.1.0-alpha.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=0ecd70f3bdaed01d6b2b371422d3ec874c87486f#0ecd70f3bdaed01d6b2b371422d3ec874c87486f"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=623eceb50d7200f418d38a04926e6b47037214e6#623eceb50d7200f418d38a04926e6b47037214e6"
 dependencies = [
  "agave-transaction-view",
  "solana-compute-budget-instruction",
@@ -11484,7 +11484,7 @@ dependencies = [
 [[package]]
 name = "solana-send-transaction-service"
 version = "4.1.0-alpha.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=0ecd70f3bdaed01d6b2b371422d3ec874c87486f#0ecd70f3bdaed01d6b2b371422d3ec874c87486f"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=623eceb50d7200f418d38a04926e6b47037214e6#623eceb50d7200f418d38a04926e6b47037214e6"
 dependencies = [
  "async-trait",
  "crossbeam-channel",
@@ -11808,7 +11808,7 @@ dependencies = [
 [[package]]
 name = "solana-storage-bigtable"
 version = "4.1.0-alpha.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=0ecd70f3bdaed01d6b2b371422d3ec874c87486f#0ecd70f3bdaed01d6b2b371422d3ec874c87486f"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=623eceb50d7200f418d38a04926e6b47037214e6#623eceb50d7200f418d38a04926e6b47037214e6"
 dependencies = [
  "agave-reserved-account-keys",
  "base64 0.22.1",
@@ -11846,7 +11846,7 @@ dependencies = [
 [[package]]
 name = "solana-storage-proto"
 version = "4.1.0-alpha.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=0ecd70f3bdaed01d6b2b371422d3ec874c87486f#0ecd70f3bdaed01d6b2b371422d3ec874c87486f"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=623eceb50d7200f418d38a04926e6b47037214e6#623eceb50d7200f418d38a04926e6b47037214e6"
 dependencies = [
  "bincode",
  "bs58 0.5.1",
@@ -11870,7 +11870,7 @@ dependencies = [
 [[package]]
 name = "solana-streamer"
 version = "4.1.0-alpha.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=0ecd70f3bdaed01d6b2b371422d3ec874c87486f#0ecd70f3bdaed01d6b2b371422d3ec874c87486f"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=623eceb50d7200f418d38a04926e6b47037214e6#623eceb50d7200f418d38a04926e6b47037214e6"
 dependencies = [
  "agave-xdp",
  "bytes",
@@ -11907,7 +11907,7 @@ dependencies = [
 [[package]]
 name = "solana-svm"
 version = "4.1.0-alpha.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=0ecd70f3bdaed01d6b2b371422d3ec874c87486f#0ecd70f3bdaed01d6b2b371422d3ec874c87486f"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=623eceb50d7200f418d38a04926e6b47037214e6#623eceb50d7200f418d38a04926e6b47037214e6"
 dependencies = [
  "ahash 0.8.12",
  "log",
@@ -11950,7 +11950,7 @@ dependencies = [
 [[package]]
 name = "solana-svm-callback"
 version = "4.1.0-alpha.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=0ecd70f3bdaed01d6b2b371422d3ec874c87486f#0ecd70f3bdaed01d6b2b371422d3ec874c87486f"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=623eceb50d7200f418d38a04926e6b47037214e6#623eceb50d7200f418d38a04926e6b47037214e6"
 dependencies = [
  "solana-account 4.1.0",
  "solana-clock 3.0.1",
@@ -11961,12 +11961,12 @@ dependencies = [
 [[package]]
 name = "solana-svm-feature-set"
 version = "4.1.0-alpha.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=0ecd70f3bdaed01d6b2b371422d3ec874c87486f#0ecd70f3bdaed01d6b2b371422d3ec874c87486f"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=623eceb50d7200f418d38a04926e6b47037214e6#623eceb50d7200f418d38a04926e6b47037214e6"
 
 [[package]]
 name = "solana-svm-log-collector"
 version = "4.1.0-alpha.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=0ecd70f3bdaed01d6b2b371422d3ec874c87486f#0ecd70f3bdaed01d6b2b371422d3ec874c87486f"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=623eceb50d7200f418d38a04926e6b47037214e6#623eceb50d7200f418d38a04926e6b47037214e6"
 dependencies = [
  "log",
 ]
@@ -11974,12 +11974,12 @@ dependencies = [
 [[package]]
 name = "solana-svm-measure"
 version = "4.1.0-alpha.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=0ecd70f3bdaed01d6b2b371422d3ec874c87486f#0ecd70f3bdaed01d6b2b371422d3ec874c87486f"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=623eceb50d7200f418d38a04926e6b47037214e6#623eceb50d7200f418d38a04926e6b47037214e6"
 
 [[package]]
 name = "solana-svm-timings"
 version = "4.1.0-alpha.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=0ecd70f3bdaed01d6b2b371422d3ec874c87486f#0ecd70f3bdaed01d6b2b371422d3ec874c87486f"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=623eceb50d7200f418d38a04926e6b47037214e6#623eceb50d7200f418d38a04926e6b47037214e6"
 dependencies = [
  "eager",
  "enum-iterator",
@@ -11989,7 +11989,7 @@ dependencies = [
 [[package]]
 name = "solana-svm-transaction"
 version = "4.1.0-alpha.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=0ecd70f3bdaed01d6b2b371422d3ec874c87486f#0ecd70f3bdaed01d6b2b371422d3ec874c87486f"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=623eceb50d7200f418d38a04926e6b47037214e6#623eceb50d7200f418d38a04926e6b47037214e6"
 dependencies = [
  "solana-hash 4.2.0",
  "solana-message 4.0.0",
@@ -12002,7 +12002,7 @@ dependencies = [
 [[package]]
 name = "solana-svm-type-overrides"
 version = "4.1.0-alpha.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=0ecd70f3bdaed01d6b2b371422d3ec874c87486f#0ecd70f3bdaed01d6b2b371422d3ec874c87486f"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=623eceb50d7200f418d38a04926e6b47037214e6#623eceb50d7200f418d38a04926e6b47037214e6"
 dependencies = [
  "rand 0.9.2",
 ]
@@ -12057,7 +12057,7 @@ dependencies = [
 [[package]]
 name = "solana-system-program"
 version = "4.1.0-alpha.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=0ecd70f3bdaed01d6b2b371422d3ec874c87486f#0ecd70f3bdaed01d6b2b371422d3ec874c87486f"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=623eceb50d7200f418d38a04926e6b47037214e6#623eceb50d7200f418d38a04926e6b47037214e6"
 dependencies = [
  "bincode",
  "log",
@@ -12247,7 +12247,7 @@ checksum = "0ced92c60aa76ec4780a9d93f3bd64dfa916e1b998eacc6f1c110f3f444f02c9"
 [[package]]
 name = "solana-tls-utils"
 version = "4.1.0-alpha.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=0ecd70f3bdaed01d6b2b371422d3ec874c87486f#0ecd70f3bdaed01d6b2b371422d3ec874c87486f"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=623eceb50d7200f418d38a04926e6b47037214e6#623eceb50d7200f418d38a04926e6b47037214e6"
 dependencies = [
  "rustls 0.23.37",
  "solana-keypair 3.1.2",
@@ -12259,7 +12259,7 @@ dependencies = [
 [[package]]
 name = "solana-tpu-client"
 version = "4.1.0-alpha.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=0ecd70f3bdaed01d6b2b371422d3ec874c87486f#0ecd70f3bdaed01d6b2b371422d3ec874c87486f"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=623eceb50d7200f418d38a04926e6b47037214e6#623eceb50d7200f418d38a04926e6b47037214e6"
 dependencies = [
  "bincode",
  "futures-util",
@@ -12287,7 +12287,7 @@ dependencies = [
 [[package]]
 name = "solana-tpu-client-next"
 version = "4.1.0-alpha.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=0ecd70f3bdaed01d6b2b371422d3ec874c87486f#0ecd70f3bdaed01d6b2b371422d3ec874c87486f"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=623eceb50d7200f418d38a04926e6b47037214e6#623eceb50d7200f418d38a04926e6b47037214e6"
 dependencies = [
  "async-trait",
  "futures 0.3.32",
@@ -12382,7 +12382,7 @@ dependencies = [
 [[package]]
 name = "solana-transaction-context"
 version = "4.1.0-alpha.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=0ecd70f3bdaed01d6b2b371422d3ec874c87486f#0ecd70f3bdaed01d6b2b371422d3ec874c87486f"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=623eceb50d7200f418d38a04926e6b47037214e6#623eceb50d7200f418d38a04926e6b47037214e6"
 dependencies = [
  "bincode",
  "serde",
@@ -12422,7 +12422,7 @@ dependencies = [
 [[package]]
 name = "solana-transaction-status"
 version = "4.1.0-alpha.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=0ecd70f3bdaed01d6b2b371422d3ec874c87486f#0ecd70f3bdaed01d6b2b371422d3ec874c87486f"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=623eceb50d7200f418d38a04926e6b47037214e6#623eceb50d7200f418d38a04926e6b47037214e6"
 dependencies = [
  "Inflector",
  "agave-reserved-account-keys",
@@ -12463,7 +12463,7 @@ dependencies = [
 [[package]]
 name = "solana-transaction-status-client-types"
 version = "4.1.0-alpha.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=0ecd70f3bdaed01d6b2b371422d3ec874c87486f#0ecd70f3bdaed01d6b2b371422d3ec874c87486f"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=623eceb50d7200f418d38a04926e6b47037214e6#623eceb50d7200f418d38a04926e6b47037214e6"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -12485,7 +12485,7 @@ dependencies = [
 [[package]]
 name = "solana-turbine"
 version = "4.1.0-alpha.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=0ecd70f3bdaed01d6b2b371422d3ec874c87486f#0ecd70f3bdaed01d6b2b371422d3ec874c87486f"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=623eceb50d7200f418d38a04926e6b47037214e6#623eceb50d7200f418d38a04926e6b47037214e6"
 dependencies = [
  "agave-feature-set",
  "agave-votor",
@@ -12531,7 +12531,7 @@ dependencies = [
 [[package]]
 name = "solana-udp-client"
 version = "4.1.0-alpha.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=0ecd70f3bdaed01d6b2b371422d3ec874c87486f#0ecd70f3bdaed01d6b2b371422d3ec874c87486f"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=623eceb50d7200f418d38a04926e6b47037214e6#623eceb50d7200f418d38a04926e6b47037214e6"
 dependencies = [
  "async-trait",
  "solana-connection-cache",
@@ -12544,7 +12544,7 @@ dependencies = [
 [[package]]
 name = "solana-unified-scheduler-logic"
 version = "4.1.0-alpha.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=0ecd70f3bdaed01d6b2b371422d3ec874c87486f#0ecd70f3bdaed01d6b2b371422d3ec874c87486f"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=623eceb50d7200f418d38a04926e6b47037214e6#623eceb50d7200f418d38a04926e6b47037214e6"
 dependencies = [
  "assert_matches",
  "solana-clock 3.0.1",
@@ -12559,7 +12559,7 @@ dependencies = [
 [[package]]
 name = "solana-unified-scheduler-pool"
 version = "4.1.0-alpha.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=0ecd70f3bdaed01d6b2b371422d3ec874c87486f#0ecd70f3bdaed01d6b2b371422d3ec874c87486f"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=623eceb50d7200f418d38a04926e6b47037214e6#623eceb50d7200f418d38a04926e6b47037214e6"
 dependencies = [
  "agave-banking-stage-ingress-types",
  "aquamarine",
@@ -12604,7 +12604,7 @@ checksum = "c5d2face763df5afeaa9509b9019968860e69cc1531ec8b4a2e6c7b702204d5a"
 [[package]]
 name = "solana-version"
 version = "4.1.0-alpha.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=0ecd70f3bdaed01d6b2b371422d3ec874c87486f#0ecd70f3bdaed01d6b2b371422d3ec874c87486f"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=623eceb50d7200f418d38a04926e6b47037214e6#623eceb50d7200f418d38a04926e6b47037214e6"
 dependencies = [
  "agave-feature-set",
  "rand 0.9.2",
@@ -12617,7 +12617,7 @@ dependencies = [
 [[package]]
 name = "solana-vote"
 version = "4.1.0-alpha.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=0ecd70f3bdaed01d6b2b371422d3ec874c87486f#0ecd70f3bdaed01d6b2b371422d3ec874c87486f"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=623eceb50d7200f418d38a04926e6b47037214e6#623eceb50d7200f418d38a04926e6b47037214e6"
 dependencies = [
  "bincode",
  "log",
@@ -12694,7 +12694,7 @@ dependencies = [
 [[package]]
 name = "solana-vote-program"
 version = "4.1.0-alpha.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=0ecd70f3bdaed01d6b2b371422d3ec874c87486f#0ecd70f3bdaed01d6b2b371422d3ec874c87486f"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=623eceb50d7200f418d38a04926e6b47037214e6#623eceb50d7200f418d38a04926e6b47037214e6"
 dependencies = [
  "agave-feature-set",
  "bincode",
@@ -12730,7 +12730,7 @@ dependencies = [
 [[package]]
 name = "solana-zk-elgamal-proof-program"
 version = "4.1.0-alpha.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=0ecd70f3bdaed01d6b2b371422d3ec874c87486f#0ecd70f3bdaed01d6b2b371422d3ec874c87486f"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=623eceb50d7200f418d38a04926e6b47037214e6#623eceb50d7200f418d38a04926e6b47037214e6"
 dependencies = [
  "bytemuck",
  "solana-instruction 3.3.0",
@@ -12814,7 +12814,7 @@ dependencies = [
 [[package]]
 name = "solana-zk-token-proof-program"
 version = "4.1.0-alpha.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=0ecd70f3bdaed01d6b2b371422d3ec874c87486f#0ecd70f3bdaed01d6b2b371422d3ec874c87486f"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=623eceb50d7200f418d38a04926e6b47037214e6#623eceb50d7200f418d38a04926e6b47037214e6"
 dependencies = [
  "solana-program-runtime",
 ]
@@ -14524,7 +14524,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ edition = "2021"
 readme = "README.md"
 
 [workspace.dependencies]
-agave-snapshots = { package = "agave-snapshots", git = "https://github.com/jito-foundation/jito-solana.git", rev = "0ecd70f3bdaed01d6b2b371422d3ec874c87486f" }
+agave-snapshots = { package = "agave-snapshots", git = "https://github.com/jito-foundation/jito-solana.git", rev = "623eceb50d7200f418d38a04926e6b47037214e6" }
 anyhow = "1.0.86"
 assert_matches = "1.5.0"
 base64 = "0.22.1"
@@ -79,47 +79,47 @@ serde_json = "1.0.102"
 serde_with = "3.9.0"
 shank = "0.4.2"
 shank_idl = "0.4.2"
-solana-account-decoder = { package = "solana-account-decoder", git = "https://github.com/jito-foundation/jito-solana.git", rev = "0ecd70f3bdaed01d6b2b371422d3ec874c87486f" }
-solana-account-info = { package = "solana-account-info", git = "https://github.com/jito-foundation/jito-solana.git", rev = "0ecd70f3bdaed01d6b2b371422d3ec874c87486f" }
-solana-accounts-db = { package = "solana-accounts-db", git = "https://github.com/jito-foundation/jito-solana.git", rev = "0ecd70f3bdaed01d6b2b371422d3ec874c87486f" }
+solana-account-decoder = { package = "solana-account-decoder", git = "https://github.com/jito-foundation/jito-solana.git", rev = "623eceb50d7200f418d38a04926e6b47037214e6" }
+solana-account-info = { package = "solana-account-info", git = "https://github.com/jito-foundation/jito-solana.git", rev = "623eceb50d7200f418d38a04926e6b47037214e6" }
+solana-accounts-db = { package = "solana-accounts-db", git = "https://github.com/jito-foundation/jito-solana.git", rev = "623eceb50d7200f418d38a04926e6b47037214e6" }
 solana-address-lookup-table-interface = { version = "=3.0.1" }
-solana-clap-utils = { package = "solana-clap-utils", git = "https://github.com/jito-foundation/jito-solana.git", rev = "0ecd70f3bdaed01d6b2b371422d3ec874c87486f" }
-solana-cli-config = { package = "solana-cli-config", git = "https://github.com/jito-foundation/jito-solana.git", rev = "0ecd70f3bdaed01d6b2b371422d3ec874c87486f" }
-solana-client = { package = "solana-client", git = "https://github.com/jito-foundation/jito-solana.git", rev = "0ecd70f3bdaed01d6b2b371422d3ec874c87486f" }
-solana-clock = { package = "solana-clock", git = "https://github.com/jito-foundation/jito-solana.git", rev = "0ecd70f3bdaed01d6b2b371422d3ec874c87486f" }
+solana-clap-utils = { package = "solana-clap-utils", git = "https://github.com/jito-foundation/jito-solana.git", rev = "623eceb50d7200f418d38a04926e6b47037214e6" }
+solana-cli-config = { package = "solana-cli-config", git = "https://github.com/jito-foundation/jito-solana.git", rev = "623eceb50d7200f418d38a04926e6b47037214e6" }
+solana-client = { package = "solana-client", git = "https://github.com/jito-foundation/jito-solana.git", rev = "623eceb50d7200f418d38a04926e6b47037214e6" }
+solana-clock = { package = "solana-clock", git = "https://github.com/jito-foundation/jito-solana.git", rev = "623eceb50d7200f418d38a04926e6b47037214e6" }
 solana-commitment-config = "=3.1.1"
 solana-compute-budget-interface = { version = "=3.0.0" }
-solana-core = { package = "solana-core", git = "https://github.com/jito-foundation/jito-solana.git", rev = "0ecd70f3bdaed01d6b2b371422d3ec874c87486f" }
+solana-core = { package = "solana-core", git = "https://github.com/jito-foundation/jito-solana.git", rev = "623eceb50d7200f418d38a04926e6b47037214e6" }
 solana-decode-error = "=2.3.0"
 solana-genesis-config = "=4.0.0"
-solana-genesis-utils = { package = "solana-genesis-utils", git = "https://github.com/jito-foundation/jito-solana.git", rev = "0ecd70f3bdaed01d6b2b371422d3ec874c87486f" }
-solana-geyser-plugin-manager = { package = "solana-geyser-plugin-manager", git = "https://github.com/jito-foundation/jito-solana.git", rev = "0ecd70f3bdaed01d6b2b371422d3ec874c87486f" }
-solana-gossip = { package = "solana-gossip", git = "https://github.com/jito-foundation/jito-solana.git", rev = "0ecd70f3bdaed01d6b2b371422d3ec874c87486f" }
-solana-instruction = { package = "solana-instruction", git = "https://github.com/jito-foundation/jito-solana.git", rev = "0ecd70f3bdaed01d6b2b371422d3ec874c87486f" }
-solana-ledger = { package = "solana-ledger", git = "https://github.com/jito-foundation/jito-solana.git", rev = "0ecd70f3bdaed01d6b2b371422d3ec874c87486f" }
-solana-measure = { git = "https://github.com/jito-foundation/jito-solana.git", rev = "0ecd70f3bdaed01d6b2b371422d3ec874c87486f" }
-solana-metrics = { package = "solana-metrics", git = "https://github.com/jito-foundation/jito-solana.git", rev = "0ecd70f3bdaed01d6b2b371422d3ec874c87486f" }
+solana-genesis-utils = { package = "solana-genesis-utils", git = "https://github.com/jito-foundation/jito-solana.git", rev = "623eceb50d7200f418d38a04926e6b47037214e6" }
+solana-geyser-plugin-manager = { package = "solana-geyser-plugin-manager", git = "https://github.com/jito-foundation/jito-solana.git", rev = "623eceb50d7200f418d38a04926e6b47037214e6" }
+solana-gossip = { package = "solana-gossip", git = "https://github.com/jito-foundation/jito-solana.git", rev = "623eceb50d7200f418d38a04926e6b47037214e6" }
+solana-instruction = { package = "solana-instruction", git = "https://github.com/jito-foundation/jito-solana.git", rev = "623eceb50d7200f418d38a04926e6b47037214e6" }
+solana-ledger = { package = "solana-ledger", git = "https://github.com/jito-foundation/jito-solana.git", rev = "623eceb50d7200f418d38a04926e6b47037214e6" }
+solana-measure = { git = "https://github.com/jito-foundation/jito-solana.git", rev = "623eceb50d7200f418d38a04926e6b47037214e6" }
+solana-metrics = { package = "solana-metrics", git = "https://github.com/jito-foundation/jito-solana.git", rev = "623eceb50d7200f418d38a04926e6b47037214e6" }
 solana-program = { version = "4.0.0", default-features = false, features = [] }
 solana-program-entrypoint = "3.0.0"
 solana-program-error = "=3.0.1"
-solana-program-test = { package = "solana-program-test", git = "https://github.com/jito-foundation/jito-solana.git", rev = "0ecd70f3bdaed01d6b2b371422d3ec874c87486f" }
+solana-program-test = { package = "solana-program-test", git = "https://github.com/jito-foundation/jito-solana.git", rev = "623eceb50d7200f418d38a04926e6b47037214e6" }
 solana-pubkey = "=4.1.0"
-solana-rpc = { git = "https://github.com/jito-foundation/jito-solana.git", rev = "0ecd70f3bdaed01d6b2b371422d3ec874c87486f" }
-solana-rpc-client = { package = "solana-rpc-client", git = "https://github.com/jito-foundation/jito-solana.git", rev = "0ecd70f3bdaed01d6b2b371422d3ec874c87486f" }
-solana-rpc-client-api = { git = "https://github.com/jito-foundation/jito-solana.git", rev = "0ecd70f3bdaed01d6b2b371422d3ec874c87486f" }
-solana-runtime = { package = "solana-runtime", git = "https://github.com/jito-foundation/jito-solana.git", rev = "0ecd70f3bdaed01d6b2b371422d3ec874c87486f" }
+solana-rpc = { git = "https://github.com/jito-foundation/jito-solana.git", rev = "623eceb50d7200f418d38a04926e6b47037214e6" }
+solana-rpc-client = { package = "solana-rpc-client", git = "https://github.com/jito-foundation/jito-solana.git", rev = "623eceb50d7200f418d38a04926e6b47037214e6" }
+solana-rpc-client-api = { git = "https://github.com/jito-foundation/jito-solana.git", rev = "623eceb50d7200f418d38a04926e6b47037214e6" }
+solana-runtime = { package = "solana-runtime", git = "https://github.com/jito-foundation/jito-solana.git", rev = "623eceb50d7200f418d38a04926e6b47037214e6" }
 solana-sdk = "=4.0.1"
 solana-security-txt = "1.1.1"
 solana-stake-interface = { version = "3.1.0", features = ["sysvar"] }
-#solana-stake-program = { package = "solana-stake-program", git = "https://github.com/jito-foundation/jito-solana.git", rev = "0ecd70f3bdaed01d6b2b371422d3ec874c87486f" }
-solana-streamer = { git = "https://github.com/jito-foundation/jito-solana.git", rev = "0ecd70f3bdaed01d6b2b371422d3ec874c87486f" }
+#solana-stake-program = { package = "solana-stake-program", git = "https://github.com/jito-foundation/jito-solana.git", rev = "623eceb50d7200f418d38a04926e6b47037214e6" }
+solana-streamer = { git = "https://github.com/jito-foundation/jito-solana.git", rev = "623eceb50d7200f418d38a04926e6b47037214e6" }
 solana-system-interface = { version = "3.1.0", features = ["bincode"] }
-solana-transaction-status = { package = "solana-transaction-status", git = "https://github.com/jito-foundation/jito-solana.git", rev = "0ecd70f3bdaed01d6b2b371422d3ec874c87486f" }
-solana-unified-scheduler-pool = { package = "solana-unified-scheduler-pool", git = "https://github.com/jito-foundation/jito-solana.git", rev = "0ecd70f3bdaed01d6b2b371422d3ec874c87486f" }
-solana-vote = { package = "solana-vote", git = "https://github.com/jito-foundation/jito-solana.git", rev = "0ecd70f3bdaed01d6b2b371422d3ec874c87486f" }
+solana-transaction-status = { package = "solana-transaction-status", git = "https://github.com/jito-foundation/jito-solana.git", rev = "623eceb50d7200f418d38a04926e6b47037214e6" }
+solana-unified-scheduler-pool = { package = "solana-unified-scheduler-pool", git = "https://github.com/jito-foundation/jito-solana.git", rev = "623eceb50d7200f418d38a04926e6b47037214e6" }
+solana-vote = { package = "solana-vote", git = "https://github.com/jito-foundation/jito-solana.git", rev = "623eceb50d7200f418d38a04926e6b47037214e6" }
 solana-vote-interface = { version = "=5.1.1", features = ["bincode"] }
-#solana-zk-sdk = { package = "solana-zk-sdk", git = "https://github.com/jito-foundation/jito-solana.git", rev = "0ecd70f3bdaed01d6b2b371422d3ec874c87486f" }
-#solana-zk-token-sdk = { package = "solana-zk-token-sdk", git = "https://github.com/jito-foundation/jito-solana.git", rev = "0ecd70f3bdaed01d6b2b371422d3ec874c87486f" }
+#solana-zk-sdk = { package = "solana-zk-sdk", git = "https://github.com/jito-foundation/jito-solana.git", rev = "623eceb50d7200f418d38a04926e6b47037214e6" }
+#solana-zk-token-sdk = { package = "solana-zk-token-sdk", git = "https://github.com/jito-foundation/jito-solana.git", rev = "623eceb50d7200f418d38a04926e6b47037214e6" }
 spl-associated-token-account-interface = { version = "2.0.0" }
 spl-math = { version = "0.3.0", features = ["no-entrypoint"] }
 spl-memo-interface = "2.0.0"
@@ -142,76 +142,76 @@ codegen-units = 1
 
 [patch.crates-io]
 switchboard-on-demand = { path = "vendor/switchboard-on-demand" }
-solana-account-decoder = { package = "solana-account-decoder", git = "https://github.com/jito-foundation/jito-solana.git", rev = "0ecd70f3bdaed01d6b2b371422d3ec874c87486f" }
-solana-account-decoder-client-types = { package = "solana-account-decoder-client-types", git = "https://github.com/jito-foundation/jito-solana.git", rev = "0ecd70f3bdaed01d6b2b371422d3ec874c87486f" }
-solana-accounts-db = { package = "solana-accounts-db", git = "https://github.com/jito-foundation/jito-solana.git", rev = "0ecd70f3bdaed01d6b2b371422d3ec874c87486f" }
-solana-banks-client = { package = "solana-banks-client", git = "https://github.com/jito-foundation/jito-solana.git", rev = "0ecd70f3bdaed01d6b2b371422d3ec874c87486f" }
-solana-banks-interface = { package = "solana-banks-interface", git = "https://github.com/jito-foundation/jito-solana.git", rev = "0ecd70f3bdaed01d6b2b371422d3ec874c87486f" }
-solana-banks-server = { package = "solana-banks-server", git = "https://github.com/jito-foundation/jito-solana.git", rev = "0ecd70f3bdaed01d6b2b371422d3ec874c87486f" }
-#solana-bloom = { package = "solana-bloom", git = "https://github.com/jito-foundation/jito-solana.git", rev = "0ecd70f3bdaed01d6b2b371422d3ec874c87486f" }
-#solana-bpf-loader-program = { package = "solana-bpf-loader-program", git = "https://github.com/jito-foundation/jito-solana.git", rev = "0ecd70f3bdaed01d6b2b371422d3ec874c87486f" }
-solana-bucket-map = { package = "solana-bucket-map", git = "https://github.com/jito-foundation/jito-solana.git", rev = "0ecd70f3bdaed01d6b2b371422d3ec874c87486f" }
-solana-builtins-default-costs = { package = "solana-builtins-default-costs", git = "https://github.com/jito-foundation/jito-solana.git", rev = "0ecd70f3bdaed01d6b2b371422d3ec874c87486f" }
-solana-clap-utils = { package = "solana-clap-utils", git = "https://github.com/jito-foundation/jito-solana.git", rev = "0ecd70f3bdaed01d6b2b371422d3ec874c87486f" }
-solana-cli-config = { package = "solana-cli-config", git = "https://github.com/jito-foundation/jito-solana.git", rev = "0ecd70f3bdaed01d6b2b371422d3ec874c87486f" }
-solana-client = { package = "solana-client", git = "https://github.com/jito-foundation/jito-solana.git", rev = "0ecd70f3bdaed01d6b2b371422d3ec874c87486f" }
-solana-compute-budget = { package = "solana-compute-budget", git = "https://github.com/jito-foundation/jito-solana.git", rev = "0ecd70f3bdaed01d6b2b371422d3ec874c87486f" }
-solana-connection-cache = { package = "solana-connection-cache", git = "https://github.com/jito-foundation/jito-solana.git", rev = "0ecd70f3bdaed01d6b2b371422d3ec874c87486f" }
-solana-core = { package = "solana-core", git = "https://github.com/jito-foundation/jito-solana.git", rev = "0ecd70f3bdaed01d6b2b371422d3ec874c87486f" }
-solana-cost-model = { package = "solana-cost-model", git = "https://github.com/jito-foundation/jito-solana.git", rev = "0ecd70f3bdaed01d6b2b371422d3ec874c87486f" }
-#solana-curve25519 = { package = "solana-curve25519", git = "https://github.com/jito-foundation/jito-solana.git", rev = "0ecd70f3bdaed01d6b2b371422d3ec874c87486f" }
-solana-entry = { package = "solana-entry", git = "https://github.com/jito-foundation/jito-solana.git", rev = "0ecd70f3bdaed01d6b2b371422d3ec874c87486f" }
-solana-faucet = { package = "solana-faucet", git = "https://github.com/jito-foundation/jito-solana.git", rev = "0ecd70f3bdaed01d6b2b371422d3ec874c87486f" }
-#solana-fee = { package = "solana-fee", git = "https://github.com/jito-foundation/jito-solana.git", rev = "0ecd70f3bdaed01d6b2b371422d3ec874c87486f" }
-solana-geyser-plugin-manager = { package = "solana-geyser-plugin-manager", git = "https://github.com/jito-foundation/jito-solana.git", rev = "0ecd70f3bdaed01d6b2b371422d3ec874c87486f" }
-#solana-gossip = { package = "solana-gossip", git = "https://github.com/jito-foundation/jito-solana.git", rev = "0ecd70f3bdaed01d6b2b371422d3ec874c87486f" }
-solana-lattice-hash = { package = "solana-lattice-hash", git = "https://github.com/jito-foundation/jito-solana.git", rev = "0ecd70f3bdaed01d6b2b371422d3ec874c87486f" }
-solana-ledger = { package = "solana-ledger", git = "https://github.com/jito-foundation/jito-solana.git", rev = "0ecd70f3bdaed01d6b2b371422d3ec874c87486f" }
-#solana-loader-v4-program = { package = "solana-loader-v4-program", git = "https://github.com/jito-foundation/jito-solana.git", rev = "0ecd70f3bdaed01d6b2b371422d3ec874c87486f" }
-solana-measure = { package = "solana-measure", git = "https://github.com/jito-foundation/jito-solana.git", rev = "0ecd70f3bdaed01d6b2b371422d3ec874c87486f" }
-solana-merkle-tree = { package = "solana-merkle-tree", git = "https://github.com/jito-foundation/jito-solana.git", rev = "0ecd70f3bdaed01d6b2b371422d3ec874c87486f" }
-solana-metrics = { package = "solana-metrics", git = "https://github.com/jito-foundation/jito-solana.git", rev = "0ecd70f3bdaed01d6b2b371422d3ec874c87486f" }
-#solana-net-utils = { package = "solana-net-utils", git = "https://github.com/jito-foundation/jito-solana.git", rev = "0ecd70f3bdaed01d6b2b371422d3ec874c87486f" }
-solana-perf = { package = "solana-perf", git = "https://github.com/jito-foundation/jito-solana.git", rev = "0ecd70f3bdaed01d6b2b371422d3ec874c87486f" }
-solana-poh = { package = "solana-poh", git = "https://github.com/jito-foundation/jito-solana.git", rev = "0ecd70f3bdaed01d6b2b371422d3ec874c87486f" }
-#solana-poseidon = { package = "solana-poseidon", git = "https://github.com/jito-foundation/jito-solana.git", rev = "0ecd70f3bdaed01d6b2b371422d3ec874c87486f" }
-#solana-program-runtime = { package = "solana-program-runtime", git = "https://github.com/jito-foundation/jito-solana.git", rev = "0ecd70f3bdaed01d6b2b371422d3ec874c87486f" }
-solana-program-test = { package = "solana-program-test", git = "https://github.com/jito-foundation/jito-solana.git", rev = "0ecd70f3bdaed01d6b2b371422d3ec874c87486f" }
-solana-pubsub-client = { package = "solana-pubsub-client", git = "https://github.com/jito-foundation/jito-solana.git", rev = "0ecd70f3bdaed01d6b2b371422d3ec874c87486f" }
-solana-quic-client = { package = "solana-quic-client", git = "https://github.com/jito-foundation/jito-solana.git", rev = "0ecd70f3bdaed01d6b2b371422d3ec874c87486f" }
-solana-rayon-threadlimit = { package = "solana-rayon-threadlimit", git = "https://github.com/jito-foundation/jito-solana.git", rev = "0ecd70f3bdaed01d6b2b371422d3ec874c87486f" }
-solana-remote-wallet = { package = "solana-remote-wallet", git = "https://github.com/jito-foundation/jito-solana.git", rev = "0ecd70f3bdaed01d6b2b371422d3ec874c87486f" }
-#solana-timings = { package = "solana-timings", git = "https://github.com/jito-foundation/jito-solana.git", rev = "0ecd70f3bdaed01d6b2b371422d3ec874c87486f" }
-solana-unified-scheduler-logic = { package = "solana-unified-scheduler-logic", git = "https://github.com/jito-foundation/jito-solana.git", rev = "0ecd70f3bdaed01d6b2b371422d3ec874c87486f" }
-solana-unified-scheduler-pool = { package = "solana-unified-scheduler-pool", git = "https://github.com/jito-foundation/jito-solana.git", rev = "0ecd70f3bdaed01d6b2b371422d3ec874c87486f" }
-solana-rpc = { package = "solana-rpc", git = "https://github.com/jito-foundation/jito-solana.git", rev = "0ecd70f3bdaed01d6b2b371422d3ec874c87486f" }
-solana-rpc-client = { package = "solana-rpc-client", git = "https://github.com/jito-foundation/jito-solana.git", rev = "0ecd70f3bdaed01d6b2b371422d3ec874c87486f" }
-solana-rpc-client-api = { package = "solana-rpc-client-api", git = "https://github.com/jito-foundation/jito-solana.git", rev = "0ecd70f3bdaed01d6b2b371422d3ec874c87486f" }
-solana-rpc-client-nonce-utils = { package = "solana-rpc-client-nonce-utils", git = "https://github.com/jito-foundation/jito-solana.git", rev = "0ecd70f3bdaed01d6b2b371422d3ec874c87486f" }
-solana-runtime = { package = "solana-runtime", git = "https://github.com/jito-foundation/jito-solana.git", rev = "0ecd70f3bdaed01d6b2b371422d3ec874c87486f" }
-#solana-runtime-transaction = { package = "solana-runtime-transaction", git = "https://github.com/jito-foundation/jito-solana.git", rev = "0ecd70f3bdaed01d6b2b371422d3ec874c87486f" }
-solana-send-transaction-service = { package = "solana-send-transaction-service", git = "https://github.com/jito-foundation/jito-solana.git", rev = "0ecd70f3bdaed01d6b2b371422d3ec874c87486f" }
-#solana-stake-program = { package = "solana-stake-program", git = "https://github.com/jito-foundation/jito-solana.git", rev = "0ecd70f3bdaed01d6b2b371422d3ec874c87486f" }
-solana-storage-bigtable = { package = "solana-storage-bigtable", git = "https://github.com/jito-foundation/jito-solana.git", rev = "0ecd70f3bdaed01d6b2b371422d3ec874c87486f" }
-solana-storage-proto = { package = "solana-storage-proto", git = "https://github.com/jito-foundation/jito-solana.git", rev = "0ecd70f3bdaed01d6b2b371422d3ec874c87486f" }
-solana-streamer = { package = "solana-streamer", git = "https://github.com/jito-foundation/jito-solana.git", rev = "0ecd70f3bdaed01d6b2b371422d3ec874c87486f" }
-#solana-svm = { package = "solana-svm", git = "https://github.com/jito-foundation/jito-solana.git", rev = "0ecd70f3bdaed01d6b2b371422d3ec874c87486f" }
-#solana-svm-rent-collector = { package = "solana-svm-rent-collector", git = "https://github.com/jito-foundation/jito-solana.git", rev = "0ecd70f3bdaed01d6b2b371422d3ec874c87486f" }
-#solana-svm-transaction = { package = "solana-svm-transaction", git = "https://github.com/jito-foundation/jito-solana.git", rev = "0ecd70f3bdaed01d6b2b371422d3ec874c87486f" }
-solana-system-program = { package = "solana-system-program", git = "https://github.com/jito-foundation/jito-solana.git", rev = "0ecd70f3bdaed01d6b2b371422d3ec874c87486f" }
-#solana-thin-client = { package = "solana-thin-client", git = "https://github.com/jito-foundation/jito-solana.git", rev = "0ecd70f3bdaed01d6b2b371422d3ec874c87486f" }
-solana-tpu-client = { package = "solana-tpu-client", git = "https://github.com/jito-foundation/jito-solana.git", rev = "0ecd70f3bdaed01d6b2b371422d3ec874c87486f" }
-solana-transaction-status = { package = "solana-transaction-status", git = "https://github.com/jito-foundation/jito-solana.git", rev = "0ecd70f3bdaed01d6b2b371422d3ec874c87486f" }
-solana-transaction-status-client-types = { package = "solana-transaction-status-client-types", git = "https://github.com/jito-foundation/jito-solana.git", rev = "0ecd70f3bdaed01d6b2b371422d3ec874c87486f" }
-#solana-transaction-metrics-tracker = { package = "solana-transaction-metrics-tracker", git = "https://github.com/jito-foundation/jito-solana.git", rev = "0ecd70f3bdaed01d6b2b371422d3ec874c87486f" }
-#solana-turbine = { package = "solana-turbine", git = "https://github.com/jito-foundation/jito-solana.git", rev = "0ecd70f3bdaed01d6b2b371422d3ec874c87486f" }
-#solana-type-overrides = { package = "solana-type-overrides", git = "https://github.com/jito-foundation/jito-solana.git", rev = "0ecd70f3bdaed01d6b2b371422d3ec874c87486f" }
-solana-udp-client = { package = "solana-udp-client", git = "https://github.com/jito-foundation/jito-solana.git", rev = "0ecd70f3bdaed01d6b2b371422d3ec874c87486f" }
-solana-version = { package = "solana-version", git = "https://github.com/jito-foundation/jito-solana.git", rev = "0ecd70f3bdaed01d6b2b371422d3ec874c87486f" }
-solana-vote = { package = "solana-vote", git = "https://github.com/jito-foundation/jito-solana.git", rev = "0ecd70f3bdaed01d6b2b371422d3ec874c87486f" }
-solana-vote-program = { package = "solana-vote-program", git = "https://github.com/jito-foundation/jito-solana.git", rev = "0ecd70f3bdaed01d6b2b371422d3ec874c87486f" }
-#solana-wen-restart = { package = "solana-wen-restart", git = "https://github.com/jito-foundation/jito-solana.git", rev = "0ecd70f3bdaed01d6b2b371422d3ec874c87486f" }
-solana-zk-elgamal-proof-program = { package = "solana-zk-elgamal-proof-program", git = "https://github.com/jito-foundation/jito-solana.git", rev = "0ecd70f3bdaed01d6b2b371422d3ec874c87486f" }
-#solana-zk-sdk = { package = "solana-zk-sdk", git = "https://github.com/jito-foundation/jito-solana.git", rev = "0ecd70f3bdaed01d6b2b371422d3ec874c87486f" }
-#solana-zk-token-proof-program = { package = "solana-zk-token-proof-program", git = "https://github.com/jito-foundation/jito-solana.git", rev = "0ecd70f3bdaed01d6b2b371422d3ec874c87486f" }
-#solana-zk-token-sdk = { package = "solana-zk-token-sdk", git = "https://github.com/jito-foundation/jito-solana.git", rev = "0ecd70f3bdaed01d6b2b371422d3ec874c87486f" }
+solana-account-decoder = { package = "solana-account-decoder", git = "https://github.com/jito-foundation/jito-solana.git", rev = "623eceb50d7200f418d38a04926e6b47037214e6" }
+solana-account-decoder-client-types = { package = "solana-account-decoder-client-types", git = "https://github.com/jito-foundation/jito-solana.git", rev = "623eceb50d7200f418d38a04926e6b47037214e6" }
+solana-accounts-db = { package = "solana-accounts-db", git = "https://github.com/jito-foundation/jito-solana.git", rev = "623eceb50d7200f418d38a04926e6b47037214e6" }
+solana-banks-client = { package = "solana-banks-client", git = "https://github.com/jito-foundation/jito-solana.git", rev = "623eceb50d7200f418d38a04926e6b47037214e6" }
+solana-banks-interface = { package = "solana-banks-interface", git = "https://github.com/jito-foundation/jito-solana.git", rev = "623eceb50d7200f418d38a04926e6b47037214e6" }
+solana-banks-server = { package = "solana-banks-server", git = "https://github.com/jito-foundation/jito-solana.git", rev = "623eceb50d7200f418d38a04926e6b47037214e6" }
+#solana-bloom = { package = "solana-bloom", git = "https://github.com/jito-foundation/jito-solana.git", rev = "623eceb50d7200f418d38a04926e6b47037214e6" }
+#solana-bpf-loader-program = { package = "solana-bpf-loader-program", git = "https://github.com/jito-foundation/jito-solana.git", rev = "623eceb50d7200f418d38a04926e6b47037214e6" }
+solana-bucket-map = { package = "solana-bucket-map", git = "https://github.com/jito-foundation/jito-solana.git", rev = "623eceb50d7200f418d38a04926e6b47037214e6" }
+solana-builtins-default-costs = { package = "solana-builtins-default-costs", git = "https://github.com/jito-foundation/jito-solana.git", rev = "623eceb50d7200f418d38a04926e6b47037214e6" }
+solana-clap-utils = { package = "solana-clap-utils", git = "https://github.com/jito-foundation/jito-solana.git", rev = "623eceb50d7200f418d38a04926e6b47037214e6" }
+solana-cli-config = { package = "solana-cli-config", git = "https://github.com/jito-foundation/jito-solana.git", rev = "623eceb50d7200f418d38a04926e6b47037214e6" }
+solana-client = { package = "solana-client", git = "https://github.com/jito-foundation/jito-solana.git", rev = "623eceb50d7200f418d38a04926e6b47037214e6" }
+solana-compute-budget = { package = "solana-compute-budget", git = "https://github.com/jito-foundation/jito-solana.git", rev = "623eceb50d7200f418d38a04926e6b47037214e6" }
+solana-connection-cache = { package = "solana-connection-cache", git = "https://github.com/jito-foundation/jito-solana.git", rev = "623eceb50d7200f418d38a04926e6b47037214e6" }
+solana-core = { package = "solana-core", git = "https://github.com/jito-foundation/jito-solana.git", rev = "623eceb50d7200f418d38a04926e6b47037214e6" }
+solana-cost-model = { package = "solana-cost-model", git = "https://github.com/jito-foundation/jito-solana.git", rev = "623eceb50d7200f418d38a04926e6b47037214e6" }
+#solana-curve25519 = { package = "solana-curve25519", git = "https://github.com/jito-foundation/jito-solana.git", rev = "623eceb50d7200f418d38a04926e6b47037214e6" }
+solana-entry = { package = "solana-entry", git = "https://github.com/jito-foundation/jito-solana.git", rev = "623eceb50d7200f418d38a04926e6b47037214e6" }
+solana-faucet = { package = "solana-faucet", git = "https://github.com/jito-foundation/jito-solana.git", rev = "623eceb50d7200f418d38a04926e6b47037214e6" }
+#solana-fee = { package = "solana-fee", git = "https://github.com/jito-foundation/jito-solana.git", rev = "623eceb50d7200f418d38a04926e6b47037214e6" }
+solana-geyser-plugin-manager = { package = "solana-geyser-plugin-manager", git = "https://github.com/jito-foundation/jito-solana.git", rev = "623eceb50d7200f418d38a04926e6b47037214e6" }
+#solana-gossip = { package = "solana-gossip", git = "https://github.com/jito-foundation/jito-solana.git", rev = "623eceb50d7200f418d38a04926e6b47037214e6" }
+solana-lattice-hash = { package = "solana-lattice-hash", git = "https://github.com/jito-foundation/jito-solana.git", rev = "623eceb50d7200f418d38a04926e6b47037214e6" }
+solana-ledger = { package = "solana-ledger", git = "https://github.com/jito-foundation/jito-solana.git", rev = "623eceb50d7200f418d38a04926e6b47037214e6" }
+#solana-loader-v4-program = { package = "solana-loader-v4-program", git = "https://github.com/jito-foundation/jito-solana.git", rev = "623eceb50d7200f418d38a04926e6b47037214e6" }
+solana-measure = { package = "solana-measure", git = "https://github.com/jito-foundation/jito-solana.git", rev = "623eceb50d7200f418d38a04926e6b47037214e6" }
+solana-merkle-tree = { package = "solana-merkle-tree", git = "https://github.com/jito-foundation/jito-solana.git", rev = "623eceb50d7200f418d38a04926e6b47037214e6" }
+solana-metrics = { package = "solana-metrics", git = "https://github.com/jito-foundation/jito-solana.git", rev = "623eceb50d7200f418d38a04926e6b47037214e6" }
+#solana-net-utils = { package = "solana-net-utils", git = "https://github.com/jito-foundation/jito-solana.git", rev = "623eceb50d7200f418d38a04926e6b47037214e6" }
+solana-perf = { package = "solana-perf", git = "https://github.com/jito-foundation/jito-solana.git", rev = "623eceb50d7200f418d38a04926e6b47037214e6" }
+solana-poh = { package = "solana-poh", git = "https://github.com/jito-foundation/jito-solana.git", rev = "623eceb50d7200f418d38a04926e6b47037214e6" }
+#solana-poseidon = { package = "solana-poseidon", git = "https://github.com/jito-foundation/jito-solana.git", rev = "623eceb50d7200f418d38a04926e6b47037214e6" }
+#solana-program-runtime = { package = "solana-program-runtime", git = "https://github.com/jito-foundation/jito-solana.git", rev = "623eceb50d7200f418d38a04926e6b47037214e6" }
+solana-program-test = { package = "solana-program-test", git = "https://github.com/jito-foundation/jito-solana.git", rev = "623eceb50d7200f418d38a04926e6b47037214e6" }
+solana-pubsub-client = { package = "solana-pubsub-client", git = "https://github.com/jito-foundation/jito-solana.git", rev = "623eceb50d7200f418d38a04926e6b47037214e6" }
+solana-quic-client = { package = "solana-quic-client", git = "https://github.com/jito-foundation/jito-solana.git", rev = "623eceb50d7200f418d38a04926e6b47037214e6" }
+solana-rayon-threadlimit = { package = "solana-rayon-threadlimit", git = "https://github.com/jito-foundation/jito-solana.git", rev = "623eceb50d7200f418d38a04926e6b47037214e6" }
+solana-remote-wallet = { package = "solana-remote-wallet", git = "https://github.com/jito-foundation/jito-solana.git", rev = "623eceb50d7200f418d38a04926e6b47037214e6" }
+#solana-timings = { package = "solana-timings", git = "https://github.com/jito-foundation/jito-solana.git", rev = "623eceb50d7200f418d38a04926e6b47037214e6" }
+solana-unified-scheduler-logic = { package = "solana-unified-scheduler-logic", git = "https://github.com/jito-foundation/jito-solana.git", rev = "623eceb50d7200f418d38a04926e6b47037214e6" }
+solana-unified-scheduler-pool = { package = "solana-unified-scheduler-pool", git = "https://github.com/jito-foundation/jito-solana.git", rev = "623eceb50d7200f418d38a04926e6b47037214e6" }
+solana-rpc = { package = "solana-rpc", git = "https://github.com/jito-foundation/jito-solana.git", rev = "623eceb50d7200f418d38a04926e6b47037214e6" }
+solana-rpc-client = { package = "solana-rpc-client", git = "https://github.com/jito-foundation/jito-solana.git", rev = "623eceb50d7200f418d38a04926e6b47037214e6" }
+solana-rpc-client-api = { package = "solana-rpc-client-api", git = "https://github.com/jito-foundation/jito-solana.git", rev = "623eceb50d7200f418d38a04926e6b47037214e6" }
+solana-rpc-client-nonce-utils = { package = "solana-rpc-client-nonce-utils", git = "https://github.com/jito-foundation/jito-solana.git", rev = "623eceb50d7200f418d38a04926e6b47037214e6" }
+solana-runtime = { package = "solana-runtime", git = "https://github.com/jito-foundation/jito-solana.git", rev = "623eceb50d7200f418d38a04926e6b47037214e6" }
+#solana-runtime-transaction = { package = "solana-runtime-transaction", git = "https://github.com/jito-foundation/jito-solana.git", rev = "623eceb50d7200f418d38a04926e6b47037214e6" }
+solana-send-transaction-service = { package = "solana-send-transaction-service", git = "https://github.com/jito-foundation/jito-solana.git", rev = "623eceb50d7200f418d38a04926e6b47037214e6" }
+#solana-stake-program = { package = "solana-stake-program", git = "https://github.com/jito-foundation/jito-solana.git", rev = "623eceb50d7200f418d38a04926e6b47037214e6" }
+solana-storage-bigtable = { package = "solana-storage-bigtable", git = "https://github.com/jito-foundation/jito-solana.git", rev = "623eceb50d7200f418d38a04926e6b47037214e6" }
+solana-storage-proto = { package = "solana-storage-proto", git = "https://github.com/jito-foundation/jito-solana.git", rev = "623eceb50d7200f418d38a04926e6b47037214e6" }
+solana-streamer = { package = "solana-streamer", git = "https://github.com/jito-foundation/jito-solana.git", rev = "623eceb50d7200f418d38a04926e6b47037214e6" }
+#solana-svm = { package = "solana-svm", git = "https://github.com/jito-foundation/jito-solana.git", rev = "623eceb50d7200f418d38a04926e6b47037214e6" }
+#solana-svm-rent-collector = { package = "solana-svm-rent-collector", git = "https://github.com/jito-foundation/jito-solana.git", rev = "623eceb50d7200f418d38a04926e6b47037214e6" }
+#solana-svm-transaction = { package = "solana-svm-transaction", git = "https://github.com/jito-foundation/jito-solana.git", rev = "623eceb50d7200f418d38a04926e6b47037214e6" }
+solana-system-program = { package = "solana-system-program", git = "https://github.com/jito-foundation/jito-solana.git", rev = "623eceb50d7200f418d38a04926e6b47037214e6" }
+#solana-thin-client = { package = "solana-thin-client", git = "https://github.com/jito-foundation/jito-solana.git", rev = "623eceb50d7200f418d38a04926e6b47037214e6" }
+solana-tpu-client = { package = "solana-tpu-client", git = "https://github.com/jito-foundation/jito-solana.git", rev = "623eceb50d7200f418d38a04926e6b47037214e6" }
+solana-transaction-status = { package = "solana-transaction-status", git = "https://github.com/jito-foundation/jito-solana.git", rev = "623eceb50d7200f418d38a04926e6b47037214e6" }
+solana-transaction-status-client-types = { package = "solana-transaction-status-client-types", git = "https://github.com/jito-foundation/jito-solana.git", rev = "623eceb50d7200f418d38a04926e6b47037214e6" }
+#solana-transaction-metrics-tracker = { package = "solana-transaction-metrics-tracker", git = "https://github.com/jito-foundation/jito-solana.git", rev = "623eceb50d7200f418d38a04926e6b47037214e6" }
+#solana-turbine = { package = "solana-turbine", git = "https://github.com/jito-foundation/jito-solana.git", rev = "623eceb50d7200f418d38a04926e6b47037214e6" }
+#solana-type-overrides = { package = "solana-type-overrides", git = "https://github.com/jito-foundation/jito-solana.git", rev = "623eceb50d7200f418d38a04926e6b47037214e6" }
+solana-udp-client = { package = "solana-udp-client", git = "https://github.com/jito-foundation/jito-solana.git", rev = "623eceb50d7200f418d38a04926e6b47037214e6" }
+solana-version = { package = "solana-version", git = "https://github.com/jito-foundation/jito-solana.git", rev = "623eceb50d7200f418d38a04926e6b47037214e6" }
+solana-vote = { package = "solana-vote", git = "https://github.com/jito-foundation/jito-solana.git", rev = "623eceb50d7200f418d38a04926e6b47037214e6" }
+solana-vote-program = { package = "solana-vote-program", git = "https://github.com/jito-foundation/jito-solana.git", rev = "623eceb50d7200f418d38a04926e6b47037214e6" }
+#solana-wen-restart = { package = "solana-wen-restart", git = "https://github.com/jito-foundation/jito-solana.git", rev = "623eceb50d7200f418d38a04926e6b47037214e6" }
+solana-zk-elgamal-proof-program = { package = "solana-zk-elgamal-proof-program", git = "https://github.com/jito-foundation/jito-solana.git", rev = "623eceb50d7200f418d38a04926e6b47037214e6" }
+#solana-zk-sdk = { package = "solana-zk-sdk", git = "https://github.com/jito-foundation/jito-solana.git", rev = "623eceb50d7200f418d38a04926e6b47037214e6" }
+#solana-zk-token-proof-program = { package = "solana-zk-token-proof-program", git = "https://github.com/jito-foundation/jito-solana.git", rev = "623eceb50d7200f418d38a04926e6b47037214e6" }
+#solana-zk-token-sdk = { package = "solana-zk-token-sdk", git = "https://github.com/jito-foundation/jito-solana.git", rev = "623eceb50d7200f418d38a04926e6b47037214e6" }

--- a/tip-router-operator-cli/Cargo.toml
+++ b/tip-router-operator-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tip-router-operator-cli"
-version = "4.0.2"
+version = "4.0.3"
 edition = "2021"
 description = "CLI for Jito Tip Router"
 

--- a/tip-router-operator-cli/src/process_epoch.rs
+++ b/tip-router-operator-cli/src/process_epoch.rs
@@ -19,6 +19,7 @@ use crate::{
 use anyhow::Result;
 use log::{error, info, warn};
 use meta_merkle_tree::generated_merkle_tree::{GeneratedMerkleTreeCollection, StakeMetaCollection};
+use rand::Rng;
 use solana_metrics::{datapoint_error, datapoint_info};
 use solana_rpc_client::nonblocking::rpc_client::RpcClient;
 use solana_runtime::bank::Bank;
@@ -27,8 +28,9 @@ use tokio::time;
 
 const MAX_WAIT_FOR_INCREMENTAL_SNAPSHOT_TICKS: u64 = 1200; // Experimentally determined
 const OPTIMAL_INCREMENTAL_SNAPSHOT_SLOT_RANGE: u64 = 800; // Experimentally determined
-const MAX_BLOCKSTORE_OPEN_RETRIES: u32 = 5;
+const MAX_BLOCKSTORE_OPEN_RETRIES: u32 = 60;
 const BLOCKSTORE_RETRY_DELAY_SECS: u64 = 10;
+const BLOCKSTORE_RETRY_JITTER_SECS: u64 = 10;
 
 pub async fn wait_for_next_epoch(rpc_client: &RpcClient, current_epoch: u64) -> EpochInfo {
     loop {
@@ -209,7 +211,9 @@ pub async fn loop_stages(
                         if blockstore_retries < MAX_BLOCKSTORE_OPEN_RETRIES =>
                     {
                         blockstore_retries += 1;
-                        warn!("Transient blockstore error (retry {blockstore_retries}/{MAX_BLOCKSTORE_OPEN_RETRIES}), retrying in {BLOCKSTORE_RETRY_DELAY_SECS}s: {e}");
+                        let retry_delay_secs = BLOCKSTORE_RETRY_DELAY_SECS
+                            + rand::thread_rng().gen_range(0..=BLOCKSTORE_RETRY_JITTER_SECS);
+                        warn!("Transient blockstore error (retry {blockstore_retries}/{MAX_BLOCKSTORE_OPEN_RETRIES}), retrying in {retry_delay_secs}s: {e}");
                         datapoint_error!(
                             "tip_router_cli.load_bank_from_snapshot",
                             ("operator_address", operator_address, String),
@@ -218,9 +222,10 @@ pub async fn loop_stages(
                             ("error", e.to_string(), String),
                             ("state", "blockstore_open_retry", String),
                             ("retry", blockstore_retries, i64),
+                            ("retry_delay_secs", retry_delay_secs, i64),
                             "cluster" => &cli.cluster,
                         );
-                        tokio::time::sleep(Duration::from_secs(BLOCKSTORE_RETRY_DELAY_SECS)).await;
+                        tokio::time::sleep(Duration::from_secs(retry_delay_secs)).await;
                     }
                     Err(e) => return Err(e.into()),
                 }

--- a/vendor/switchboard-on-demand/Cargo.toml
+++ b/vendor/switchboard-on-demand/Cargo.toml
@@ -215,7 +215,7 @@ package = "solana-account-decoder"
 git = "https://github.com/jito-foundation/jito-solana.git"
 optional = true
 package = "solana-account-decoder"
-rev = "0ecd70f3bdaed01d6b2b371422d3ec874c87486f"
+rev = "623eceb50d7200f418d38a04926e6b47037214e6"
 
 [dependencies.solana-client-v2]
 version = ">=2,<3"
@@ -226,7 +226,7 @@ package = "solana-client"
 git = "https://github.com/jito-foundation/jito-solana.git"
 optional = true
 package = "solana-client"
-rev = "0ecd70f3bdaed01d6b2b371422d3ec874c87486f"
+rev = "623eceb50d7200f418d38a04926e6b47037214e6"
 
 [dependencies.solana-program-v2]
 version = ">=2,<3"


### PR DESCRIPTION
## Summary
- pin tip-router jito-solana dependencies to jito-foundation/jito-solana@623eceb50d7200f418d38a04926e6b47037214e6
- update vendored switchboard-on-demand internal Solana pins to the same commit
- refresh Cargo.lock so active jito-solana sources resolve to the new commit

## Verification
- cargo build -p tip-router-operator-cli --bin tip-router-operator-cli

Solana branch: https://github.com/jito-foundation/jito-solana/tree/eb/tip-router-v4-blockstore-sync