### PR TITLE
Retry Switchboard oracle gateways in keeper crank

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6839,7 +6839,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -13384,7 +13384,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -14524,7 +14524,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/cli/src/instructions.rs
+++ b/cli/src/instructions.rs
@@ -926,20 +926,51 @@ pub async fn crank_switchboard(handler: &CliHandler, switchboard_feed: &Pubkey) 
         return Err(anyhow!("No gateways found"));
     }
 
-    let gw = &gateways[0];
     let crossbar = CrossbarClient::default();
-    let (ix, _, _, _) = PullFeed::fetch_update_ix(
-        switchboard_context.clone(),
-        client,
-        FetchUpdateParams {
-            feed: *switchboard_feed,
-            payer: payer.pubkey(),
-            gateway: gw.clone(),
-            crossbar: Some(crossbar),
-            ..Default::default()
-        },
-    )
-    .await?;
+    let mut update_ix = None;
+    let mut last_error = None;
+    for (index, gateway) in gateways.iter().enumerate() {
+        log::info!(
+            "Fetching Switchboard update from gateway {}/{}: {}",
+            index + 1,
+            gateways.len(),
+            gateway.url()
+        );
+
+        match PullFeed::fetch_update_ix(
+            switchboard_context.clone(),
+            client,
+            FetchUpdateParams {
+                feed: *switchboard_feed,
+                payer: payer.pubkey(),
+                gateway: gateway.clone(),
+                crossbar: Some(crossbar.clone()),
+                ..Default::default()
+            },
+        )
+        .await
+        {
+            std::result::Result::Ok((ix, _, _, _)) => {
+                update_ix = Some(ix);
+                break;
+            }
+            Err(error) => {
+                log::warn!(
+                    "Failed to fetch Switchboard update from gateway {}: {:?}",
+                    gateway.url(),
+                    error
+                );
+                last_error = Some(error);
+            }
+        }
+    }
+    let ix = update_ix.ok_or_else(|| {
+        anyhow!(
+            "Failed to fetch Switchboard update from all {} gateways. Last error: {:?}",
+            gateways.len(),
+            last_error
+        )
+    })?;
 
     send_and_log_transaction(
         handler,

--- a/vendor/switchboard-on-demand/JITO_PATCHES.md
+++ b/vendor/switchboard-on-demand/JITO_PATCHES.md
@@ -1,0 +1,19 @@
+# Jito Patch Notes
+
+This vendored copy has local changes that are not present in the upstream
+Switchboard On-Demand crate version pinned by the workspace.
+
+## Gateway fallback support
+
+- `Gateway::test_gateway` requires a successful HTTP status before treating a
+  gateway as reachable. The upstream implementation accepted any non-empty body,
+  so an nginx `503 Service Temporarily Unavailable` page could be selected as a
+  healthy gateway.
+- `Gateway::fetch_signatures_from_encoded` now calls `error_for_status()` and
+  parses JSON through `reqwest`, returning an error instead of panicking on
+  non-JSON gateway responses.
+- `Gateway::url()` exposes the selected URI so the tip-router CLI can log and
+  retry alternate oracle gateway URIs.
+
+These changes support the keeper's Switchboard crank path, where the first
+oracle gateway in the queue can be down while other oracle gateways are healthy.

--- a/vendor/switchboard-on-demand/src/client/gateway.rs
+++ b/vendor/switchboard-on-demand/src/client/gateway.rs
@@ -179,6 +179,10 @@ impl Gateway {
         }
     }
 
+    pub fn url(&self) -> &str {
+        &self.gateway_url
+    }
+
     /// Fetches signatures from the gateway
     /// # Arguments
     /// * `params` - FetchSignaturesParams
@@ -213,10 +217,10 @@ impl Gateway {
             .header(CONTENT_TYPE, "application/json")
             .json(&body)
             .send()
-            .await?;
+            .await?
+            .error_for_status()?;
 
-        let raw = res.text().await?;
-        let res = serde_json::from_str::<FeedEvalResponseSingle>(&raw).unwrap();
+        let res = res.json::<FeedEvalResponseSingle>().await?;
 
         Ok(res)
     }
@@ -353,6 +357,10 @@ impl Gateway {
 
         // Process response
         if let Ok(resp) = response {
+            if !resp.status().is_success() {
+                return false;
+            }
+
             if let Ok(text) = resp.text().await {
                 !text.is_empty()
             } else {


### PR DESCRIPTION
## Summary

This PR hardens the keeper's Switchboard crank path so it can make progress when the first oracle gateway URI in the queue is down.

## What Changed

- Changed the tip-router CLI Switchboard crank to try each healthy gateway returned by the Switchboard queue instead of always using `gateways[0]`.
- Added gateway URI logging and per-gateway warning logs so failing oracle gateway URIs are visible during keeper runs.
- Patched the vendored Switchboard client to require successful HTTP status in `test_gateway`.
- Patched `fetch_signatures_from_encoded` to return request/parse errors instead of panicking on non-JSON responses such as nginx `503` HTML.
- Added `vendor/switchboard-on-demand/JITO_PATCHES.md` documenting the local vendored Switchboard changes.

## Root Cause

The Switchboard queue oracle account for index 0 stored a gateway URI that was returning `503 Service Temporarily Unavailable`. The vendored Switchboard client treated any non-empty `/test` body as healthy, so it selected the dead gateway and then panicked while parsing the 503 HTML response as JSON.

## Validation

- `cargo fmt --all`
- `git diff --check`
- `cargo check --locked -p jito-tip-router-cli`
- Manually cranked the affected Switchboard feed on mainnet after the patch; the CLI skipped the dead gateway and successfully used another oracle gateway.

Mainnet crank transaction observed during validation:

```text
4VVtCAwGxitEiZuo763SSMMp6BNY2pPjL2KyUzbaMHYGUsqTPsmDz78Hq6BSoSxndvBYPYwX9dEJvAxkgRVwwr6u
```
