### PR TITLE
CLI: Re-enable crank_set_weight in keeper loop

### DIFF
--- a/cli/src/instructions.rs
+++ b/cli/src/instructions.rs
@@ -2619,8 +2619,8 @@ pub async fn crank_register_vaults(handler: &CliHandler) -> Result<()> {
     Ok(())
 }
 
-pub async fn crank_set_weight(_handler: &CliHandler, _epoch: u64) -> Result<()> {
-    /*let weight_table = get_or_create_weight_table(handler, epoch).await?;
+pub async fn crank_set_weight(handler: &CliHandler, epoch: u64) -> Result<()> {
+    let weight_table = get_or_create_weight_table(handler, epoch).await?;
 
     let st_mints = weight_table
         .table()
@@ -2640,7 +2640,7 @@ pub async fn crank_set_weight(_handler: &CliHandler, _epoch: u64) -> Result<()> 
                 err
             );
         }
-    }*/
+    }
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

The body of `crank_set_weight` was commented out in #178 (solana 3.0.x dep upgrade) and never restored, so any keeper built from master silently no-ops the SetWeight epoch state.

This went unnoticed for months because the mainnet ops keeper was running a `master-ncn-keeper-latest` image built 2025-09-25 (pre-#178). Redeploying the keeper on 2026-07-16 from `master-ncn-keeper-04a28a0` activated the no-op and stalled epoch 1003 at SetWeight: the keeper looped `Crank State [SetWeight]` doing nothing, and weights had to be set manually via the `set-weight` CLI subcommand.

## What Changed

- Un-commented the `crank_set_weight` body. The helpers it uses (`get_or_create_weight_table`, `set_weight_with_st_mint`) remained in use by the `set-weight` subcommand and compile unchanged.

## Validation

- `cargo check --locked -p jito-tip-router-cli`
- `cargo fmt --all`
- The identical code path was exercised on mainnet 2026-07-16 via `set-weight --vault ...` for all 5 st-mints of epoch 1003 (crank + set weight landed for each).