### PR TITLE
Keeper: Logging improvements

### DIFF
--- a/cli/src/bin/main.rs
+++ b/cli/src/bin/main.rs
@@ -7,6 +7,7 @@ use jito_tip_router_cli::{args::Args, handler::CliHandler, log::init_logger};
 use log::info;
 
 #[tokio::main]
+#[allow(clippy::large_stack_frames)]
 async fn main() {
     dotenv().ok();
     init_logger();
@@ -17,7 +18,7 @@ async fn main() {
     }
 }
 
-#[allow(clippy::large_stack_frames)]
+#[allow(clippy::large_stack_frames, clippy::future_not_send)]
 async fn run() -> Result<()> {
     let args: Args = Args::parse();
 

--- a/cli/src/bin/main.rs
+++ b/cli/src/bin/main.rs
@@ -7,11 +7,18 @@ use jito_tip_router_cli::{args::Args, handler::CliHandler, log::init_logger};
 use log::info;
 
 #[tokio::main]
-#[allow(clippy::large_stack_frames)]
-async fn main() -> Result<()> {
+async fn main() {
     dotenv().ok();
     init_logger();
 
+    if let Err(error) = run().await {
+        log::error!("{error:#}");
+        std::process::exit(1);
+    }
+}
+
+#[allow(clippy::large_stack_frames)]
+async fn run() -> Result<()> {
     let args: Args = Args::parse();
 
     if args.markdown_help {

--- a/cli/src/instructions.rs
+++ b/cli/src/instructions.rs
@@ -3599,7 +3599,7 @@ pub async fn send_transactions(
                 retries
             );
 
-            sleep(Duration::from_secs(1 + iteration )).await;
+            sleep(Duration::from_secs(1 + iteration)).await;
             continue;
         }
 

--- a/cli/src/instructions.rs
+++ b/cli/src/instructions.rs
@@ -11,7 +11,7 @@ use crate::{
         get_vault_update_state_tracker, get_weight_table,
     },
     handler::CliHandler,
-    log::{boring_progress_bar, print_base58_tx},
+    log::print_base58_tx,
 };
 use anyhow::{anyhow, Ok, Result};
 use jito_bytemuck::AccountDeserialize;
@@ -3588,7 +3588,7 @@ pub async fn send_transactions(
             ..RpcSendTransactionConfig::default()
         };
         let result = client
-            .send_and_confirm_transaction_with_spinner_and_config(&tx, client.commitment(), config)
+            .send_and_confirm_transaction_with_config(&tx, client.commitment(), config)
             .await;
 
         if result.is_err() {
@@ -3599,7 +3599,7 @@ pub async fn send_transactions(
                 retries
             );
 
-            boring_progress_bar((1 + iteration) * 1000).await;
+            sleep(Duration::from_secs((1 + iteration).into())).await;
             continue;
         }
 

--- a/cli/src/instructions.rs
+++ b/cli/src/instructions.rs
@@ -3599,7 +3599,7 @@ pub async fn send_transactions(
                 retries
             );
 
-            sleep(Duration::from_secs((1 + iteration).into())).await;
+            sleep(Duration::from_secs(1 + iteration )).await;
             continue;
         }
 

--- a/cli/src/keeper/keeper_loop.rs
+++ b/cli/src/keeper/keeper_loop.rs
@@ -70,13 +70,11 @@ pub async fn check_and_timeout_error<T>(
 pub async fn timeout_error(duration_ms: u64) {
     info!("Error Timeout for {}s", duration_ms as f64 / 1000.0);
     sleep(Duration::from_millis(duration_ms)).await;
-    // progress_bar(duration_ms).await;
 }
 
 pub async fn timeout_keeper(duration_ms: u64) {
     info!("Keeper Timeout for {}s", duration_ms as f64 / 1000.0);
     sleep(Duration::from_millis(duration_ms)).await;
-    // boring_progress_bar(duration_ms).await;
 }
 
 #[allow(clippy::large_stack_frames)]

--- a/cli/src/keeper/keeper_loop.rs
+++ b/cli/src/keeper/keeper_loop.rs
@@ -123,7 +123,7 @@ pub async fn startup_keeper(
         // If there is a new epoch, this will do a full vault update on *all* vaults
         // created with restaking - this adds some extra redundancy
         if is_new_epoch && all_vault_update && run_operations {
-            info!("\n\n-2. Update Vaults - {}\n", current_keeper_epoch);
+            info!("-2. Update Vaults - {}", current_keeper_epoch);
             let result = update_all_vaults_in_network(handler).await;
 
             if check_and_timeout_error(
@@ -145,7 +145,7 @@ pub async fn startup_keeper(
         // If there is still work to be done on the given epoch, it will stay
         // Note: This will loop around and start back at the beginning
         {
-            info!("\n\nA. Progress Epoch - {}\n", current_keeper_epoch);
+            info!("A. Progress Epoch - {}", current_keeper_epoch);
             let starting_epoch = handler.epoch;
             let keeper_epoch = current_keeper_epoch;
 
@@ -161,10 +161,7 @@ pub async fn startup_keeper(
             .await;
 
             if current_keeper_epoch != result {
-                info!(
-                    "\n\nPROGRESS EPOCH: {} -> {}\n\n",
-                    current_keeper_epoch, result
-                );
+                info!("PROGRESS EPOCH: {} -> {}", current_keeper_epoch, result);
             }
 
             is_new_epoch = set_is_new_epoch;
@@ -178,7 +175,7 @@ pub async fn startup_keeper(
         // Emits metrics for the NCN state
         // This includes validators info, epoch info, ticket states and more
         if emit_metrics {
-            info!("\n\nB. Emit NCN Metrics - {}\n", current_keeper_epoch);
+            info!("B. Emit NCN Metrics - {}", current_keeper_epoch);
             let result = emit_ncn_metrics(handler, start_of_loop, &cluster_name).await;
 
             check_and_timeout_error(
@@ -195,7 +192,7 @@ pub async fn startup_keeper(
         // that need to be registered, this will do it. Since vaults are registered
         // with the Global Vault Registry, timing does not matter
         if run_operations {
-            info!("\n\n-1. Register Vaults - {}\n", current_keeper_epoch);
+            info!("-1. Register Vaults - {}", current_keeper_epoch);
             let result = crank_register_vaults(handler).await;
 
             if check_and_timeout_error(
@@ -214,7 +211,7 @@ pub async fn startup_keeper(
         // Fetches the current state of the keeper, which holds the Epoch State
         // and other helpful information for the keeper to function
         {
-            info!("\n\n0. Fetch Keeper State - {}\n", current_keeper_epoch);
+            info!("0. Fetch Keeper State - {}", current_keeper_epoch);
             if state.epoch != current_keeper_epoch {
                 let result = state.fetch(handler, current_keeper_epoch).await;
 
@@ -235,7 +232,7 @@ pub async fn startup_keeper(
         // Updates the Epoch State - pulls from the Epoch State account from on chain
         // and further updates the keeper state
         {
-            info!("\n\n1. Update Epoch State - {}\n", current_keeper_epoch);
+            info!("1. Update Epoch State - {}", current_keeper_epoch);
             let result = state.update_epoch_state(handler).await;
 
             if check_and_timeout_error(
@@ -254,10 +251,7 @@ pub async fn startup_keeper(
         // If there is no state found for the given epoch, this will create it, or
         // detect if its already been closed. Then the epoch will progress to the next
         if run_operations {
-            info!(
-                "\n\n2. Create or Complete State - {}\n",
-                current_keeper_epoch
-            );
+            info!("2. Create or Complete State - {}", current_keeper_epoch);
 
             // If complete, reset loop
             if state.is_epoch_completed {
@@ -286,7 +280,7 @@ pub async fn startup_keeper(
         // Calls the migrate TDA Merkle Root
         if run_migration {
             info!(
-                "\n\nC. Migrate TDA Merkle Root Upload Authorities - {}\n",
+                "C. Migrate TDA Merkle Root Upload Authorities - {}",
                 current_keeper_epoch
             );
 
@@ -311,9 +305,23 @@ pub async fn startup_keeper(
         // This is where the real work is done. Depending on the state, the keeper will crank through
         // whatever is needed to be done for the given epoch.
         if run_operations {
-            let current_state = state.current_state().expect("cannot get current state");
+            let current_state = match state.current_state() {
+                Ok(current_state) => current_state,
+                Err(error) => {
+                    let result: Result<State> = Err(error);
+                    check_and_timeout_error(
+                        "Read Keeper State".to_string(),
+                        &result,
+                        error_timeout_ms,
+                        state.epoch,
+                        &cluster_name,
+                    )
+                    .await;
+                    continue;
+                }
+            };
             info!(
-                "\n\n3. Crank State [{:?}] - {}\n",
+                "3. Crank State [{:?}] - {}",
                 current_state, current_keeper_epoch
             );
 
@@ -341,7 +349,7 @@ pub async fn startup_keeper(
 
         // Emits metrics for the Epoch State
         if emit_metrics {
-            info!("\n\nD. Emit Epoch Metrics - {}\n", current_keeper_epoch);
+            info!("D. Emit Epoch Metrics - {}", current_keeper_epoch);
 
             let result = emit_epoch_metrics(handler, state.epoch, &cluster_name).await;
 
@@ -360,7 +368,7 @@ pub async fn startup_keeper(
         // Waiting for voting to finish
         // Not enough rewards to distribute
         {
-            info!("\n\nE. Detect Stall - {}\n", current_keeper_epoch);
+            info!("E. Detect Stall - {}", current_keeper_epoch);
 
             let result = state.detect_stall(handler).await;
 
@@ -388,13 +396,13 @@ pub async fn startup_keeper(
             .await;
 
             if epoch_stall {
-                info!("\n\nSTALL DETECTED FOR {}\n\n", current_keeper_epoch);
+                info!("STALL DETECTED FOR {}", current_keeper_epoch);
             }
         }
 
         // Times out the keeper - this is the main loop timeout
         if end_of_loop && epoch_stall {
-            info!("\n\nF. Timeout - {}\n", current_keeper_epoch);
+            info!("F. Timeout - {}", current_keeper_epoch);
 
             timeout_keeper(loop_timeout_ms).await;
             tick += 1;

--- a/cli/src/log.rs
+++ b/cli/src/log.rs
@@ -1,5 +1,4 @@
-#![allow(clippy::integer_division)]
-use std::{io::Write, time::Duration};
+use std::io::Write;
 
 use chrono::Local;
 use env_logger::{
@@ -8,7 +7,6 @@ use env_logger::{
 };
 use log::Record;
 use solana_sdk::{bs58, instruction::Instruction};
-use tokio::time::{sleep, Instant};
 pub fn init_logger() {
     env_logger::Builder::from_env(Env::default().default_filter_or("info"))
         .format(format_log_message)
@@ -40,128 +38,6 @@ fn colored_level(style: &mut Style, level: log::Level) -> StyledValue<'_, &'stat
         log::Level::Warn => style.set_color(Color::Yellow).value("WARN "),
         log::Level::Error => style.set_color(Color::Red).value("ERROR"),
     }
-}
-
-pub async fn boring_progress_bar(duration_ms: u64) {
-    let start = Instant::now();
-    let duration = Duration::from_millis(duration_ms);
-    let clock_faces = [
-        "🕐", "🕑", "🕒", "🕓", "🕔", "🕕", "🕖", "🕗", "🕘", "🕙", "🕚", "🕛",
-    ];
-    let bar_width = 30; // Standard width since we're using single-width characters now
-
-    print!("\x1B[s");
-
-    loop {
-        let elapsed = start.elapsed();
-        if elapsed >= duration {
-            print!("\x1B[u\x1B[2K");
-            break;
-        }
-
-        let progress = elapsed.as_millis() as f64 / duration_ms as f64;
-        let filled_width = (progress * bar_width as f64) as usize;
-        let clock_idx = ((elapsed.as_millis() % 1000) as f64 / 1000.0 * 12.0) as usize % 12;
-
-        let progress_bar = format!(
-            "[{}{}]",
-            "█".repeat(filled_width),
-            "░".repeat(bar_width - filled_width)
-        );
-
-        // Calculate remaining time
-        let remaining = duration - elapsed;
-        let remaining_secs = remaining.as_secs();
-
-        let time_str = if remaining_secs >= 60 {
-            let minutes = (remaining_secs / 60).min(99);
-            let seconds = remaining_secs % 60;
-            format!("{:02}:{:02}", minutes, seconds)
-        } else {
-            let decaseconds = (remaining.as_millis() % 1000) / 10;
-            format!("{:02}:{:02}", remaining_secs, decaseconds)
-        };
-
-        print!(
-            "\x1B[u\x1B[2K{} {} {} ",
-            clock_faces[clock_idx], progress_bar, time_str,
-        );
-        let _ = std::io::stdout().flush();
-
-        sleep(Duration::from_millis(10)).await;
-    }
-
-    // Clean up: restore cursor position, clear line, and show cursor
-    print!("\x1B[u\x1B[2K\x1B[?25h");
-    let _ = std::io::stdout().flush();
-}
-
-pub async fn progress_bar(duration_ms: u64) {
-    let start = Instant::now();
-    let duration = Duration::from_millis(duration_ms);
-    let clock_faces = [
-        "🕐", "🕑", "🕒", "🕓", "🕔", "🕕", "🕖", "🕗", "🕘", "🕙", "🕚", "🕛",
-    ];
-    // Reduce bar_width since each fire emoji takes 2 spaces
-    let bar_width = 34; // This will effectively be 30 spaces wide due to double-width emojis
-
-    print!("\x1B[s");
-
-    loop {
-        let elapsed = start.elapsed();
-        if elapsed >= duration {
-            print!("\x1B[u\x1B[2K");
-            break;
-        }
-
-        let progress = elapsed.as_millis() as f64 / duration_ms as f64;
-        let dino_position = ((1.0 - progress) * (bar_width - 2) as f64) as usize;
-
-        let clock_idx = ((elapsed.as_millis() % 1000) as f64 / 1000.0 * 12.0) as usize % 12;
-
-        let mut progress_bar = String::with_capacity(bar_width + 2);
-        progress_bar.push('[');
-        progress_bar.push_str("🏝️");
-
-        // Add dots up to dino position
-        progress_bar.push_str(&" ".repeat(dino_position));
-
-        // Add dino
-        progress_bar.push('🦕');
-
-        // Add fire (each 🔥 counts as 2 spaces)
-        if !dino_position.is_multiple_of(2) {
-            progress_bar.push(' ');
-        }
-        progress_bar.push_str(&"🔥".repeat((bar_width - 2 - dino_position) / 2));
-        progress_bar.push('🌋');
-        progress_bar.push(']');
-
-        // Calculate remaining time
-        let remaining = duration - elapsed;
-        let remaining_secs = remaining.as_secs();
-
-        let time_str = if remaining_secs >= 60 {
-            let minutes = (remaining_secs / 60).min(99);
-            let seconds = remaining_secs % 60;
-            format!("{:02}:{:02}", minutes, seconds)
-        } else {
-            let decaseconds = (remaining.as_millis() % 1000) / 10;
-            format!("{:02}:{:02}", remaining_secs, decaseconds)
-        };
-
-        print!(
-            "\x1B[u\x1B[2K{} {} {} ",
-            clock_faces[clock_idx], progress_bar, time_str,
-        );
-        let _ = std::io::stdout().flush();
-
-        sleep(Duration::from_millis(10)).await;
-    }
-
-    // Clean up: restore cursor position, clear line, and show cursor
-    print!("\x1B[u\x1B[2K\x1B[?25h");
-    let _ = std::io::stdout().flush();
 }
 
 pub(crate) fn print_base58_tx(ixs: &[Instruction]) {

--- a/cli/src/log.rs
+++ b/cli/src/log.rs
@@ -17,13 +17,12 @@ fn format_log_message(buf: &mut Formatter, record: &Record) -> std::io::Result<(
     let mut style = buf.style();
     let level = colored_level(&mut style, record.level());
 
-    let _timestamp = Local::now().format("%Y-%m-%d %H:%M:%S%.3f");
+    let timestamp = Local::now().format("%Y-%m-%d %H:%M:%S%.3f");
 
     writeln!(
         buf,
-        // "[{} {} {}] {}",
-        "[{} {}] {}",
-        // timestamp,
+        "[{} {} {}] {}",
+        timestamp,
         level,
         record.target(),
         record.args()
@@ -42,21 +41,19 @@ fn colored_level(style: &mut Style, level: log::Level) -> StyledValue<'_, &'stat
 
 pub(crate) fn print_base58_tx(ixs: &[Instruction]) {
     ixs.iter().for_each(|ix| {
-        log::info!("\n------ IX ------\n");
+        log::info!("------ IX ------");
 
-        println!("{}\n", ix.program_id);
+        log::info!("{}", ix.program_id);
 
         ix.accounts.iter().for_each(|account| {
             let pubkey = format!("{}", account.pubkey);
             let writable = if account.is_writable { "W" } else { "" };
             let signer = if account.is_signer { "S" } else { "" };
 
-            println!("{:<44} {:>2} {:>1}", pubkey, writable, signer);
+            log::info!("{:<44} {:>2} {:>1}", pubkey, writable, signer);
         });
 
-        println!("\n");
-
         let base58_string = bs58::encode(&ix.data).into_string();
-        println!("{}\n", base58_string);
+        log::info!("{}", base58_string);
     });
 }


### PR DESCRIPTION
- Removes the spinner from keeper logs. The spinner eats up the system-logs and makes them annoying to read through
- Adds timestamps to more of the errors and logging so we can figure out when they actually happened in relation to each other