### PR TITLE
Operator: build stake meta from bank stake accounts instead of VAT-filtered epoch stakes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13707,7 +13707,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tip-router-operator-cli"
-version = "4.0.4"
+version = "4.0.5"
 dependencies = [
  "agave-snapshots",
  "anyhow",

--- a/tip-router-operator-cli/Cargo.toml
+++ b/tip-router-operator-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tip-router-operator-cli"
-version = "4.0.4"
+version = "4.0.5"
 edition = "2021"
 description = "CLI for Jito Tip Router"
 

--- a/tip-router-operator-cli/src/ledger_utils.rs
+++ b/tip-router-operator-cli/src/ledger_utils.rs
@@ -1,4 +1,5 @@
 use std::{
+    collections::HashSet,
     path::{Path, PathBuf},
     sync::{
         atomic::{AtomicBool, Ordering},
@@ -16,6 +17,9 @@ use agave_snapshots::{
 use clap_old::ArgMatches;
 use log::{info, warn};
 use solana_accounts_db::accounts_db::TOTAL_IO_URING_BUFFERS_SIZE_LIMIT;
+use solana_accounts_db::accounts_index::{
+    AccountIndex, AccountSecondaryIndexes, AccountSecondaryIndexesIncludeExclude,
+};
 use solana_core::resource_limits;
 use solana_genesis_utils::{
     open_genesis_config, OpenGenesisConfigError, MAX_GENESIS_ARCHIVE_UNPACKED_SIZE,
@@ -60,6 +64,21 @@ pub enum LedgerUtilsError {
 
     #[error("Expected bank at slot {expected}, found {found}")]
     BankSlotMismatch { expected: u64, found: u64 },
+}
+
+/// Build a `ProgramId` secondary index scoped to just the stake program. Enabling this at bank
+/// load lets stake-meta generation fetch all stake accounts via a fast indexed lookup
+/// (`Bank::get_filtered_indexed_accounts`) instead of a full-accounts scan of the whole
+/// snapshot. The include-key filter keeps the index cheap: only stake-program-owned accounts are
+/// indexed (insertion honors `include_key`), bounding it to the ~1-2M stake accounts.
+pub(crate) fn stake_program_account_indexes() -> AccountSecondaryIndexes {
+    AccountSecondaryIndexes {
+        keys: Some(AccountSecondaryIndexesIncludeExclude {
+            exclude: false,
+            keys: HashSet::from([solana_stake_interface::program::id()]),
+        }),
+        indexes: HashSet::from([AccountIndex::ProgramId]),
+    }
 }
 
 /// Create the Bank for a desired slot for given file paths.
@@ -225,10 +244,12 @@ pub fn get_bank_from_ledger(
         ..SnapshotConfig::new_load_only()
     };
 
-    let process_options = ProcessOptions {
+    let mut process_options = ProcessOptions {
         halt_at_slot: Some(desired_slot.to_owned()),
         ..Default::default()
     };
+    // Enable the stake-program ProgramId index so stake-meta generation avoids a full scan.
+    process_options.accounts_db_config.account_indexes = Some(stake_program_account_indexes());
 
     let mut starting_slot = 0; // default start check with genesis
     let max_slot = process_options.halt_at_slot;
@@ -485,10 +506,12 @@ pub fn get_bank_from_snapshot_at_slot(
         return Err(LedgerUtilsError::MissingSnapshotAtSlot(snapshot_slot));
     }
     let full_snapshot_archive_info = full_snapshot_archives.first().expect("unreachable");
-    let process_options = ProcessOptions {
+    let mut process_options = ProcessOptions {
         halt_at_slot: Some(snapshot_slot.to_owned()),
         ..Default::default()
     };
+    // Enable the stake-program ProgramId index so stake-meta generation avoids a full scan.
+    process_options.accounts_db_config.account_indexes = Some(stake_program_account_indexes());
     let snapshot_config = SnapshotConfig {
         full_snapshot_archives_dir: full_snapshots_path.clone(),
         incremental_snapshot_archives_dir: full_snapshots_path.clone(),

--- a/tip-router-operator-cli/src/stake_meta_generator.rs
+++ b/tip-router-operator-cli/src/stake_meta_generator.rs
@@ -4,6 +4,7 @@ use jito_tip_distribution_sdk::TipDistributionAccount;
 use jito_tip_payment_sdk::{Config, CONFIG_ACCOUNT_SEED};
 use log::*;
 use meta_merkle_tree::generated_merkle_tree::{Delegation, StakeMeta, StakeMetaCollection};
+use solana_accounts_db::accounts_index::IndexKey;
 use solana_client::client_error::ClientError;
 use solana_genesis_utils::OpenGenesisConfigError;
 use solana_ledger::{
@@ -62,6 +63,8 @@ pub enum StakeMetaGeneratorError {
     PanicError(String),
 
     NoVoteAccounts(u64, u64),
+
+    ScanError(String),
 }
 
 impl Display for StakeMetaGeneratorError {
@@ -87,9 +90,38 @@ pub fn generate_stake_meta_collection(
                 bank.epoch(),
             ))?;
 
-    let top_epoch_stakes = bank.get_top_epoch_stakes();
-    let delegations = top_epoch_stakes.stake_delegations();
-    let voter_pubkey_to_delegations = group_delegations_by_voter_pubkey(delegations, bank);
+    // Enumerate every stake account directly from the bank instead of using
+    // `bank.get_top_epoch_stakes()`. Once the validator-admission-ticket feature
+    // (VAT, SIMD-0357 / Alpenglow) is active, `get_top_epoch_stakes()` returns a
+    // VAT-filtered `Stakes` whose `stake_delegations` map is unconditionally empty
+    // (it is built only for the leader-schedule `EpochStakes`). Relying on it would
+    // silently produce zero stake metas and crash meta-merkle-tree creation.
+    //
+    // Prefer the `ProgramId` secondary index (enabled at bank load, see
+    // `ledger_utils::stake_program_account_indexes`) so this is a fast indexed lookup rather
+    // than a full-accounts scan of the whole snapshot. Fall back to a full program scan when
+    // the index is not present (e.g. tests, or a bank loaded without the index).
+    let stake_program_id = solana_stake_interface::program::id();
+    let mut raw_stake_accounts = bank
+        .get_filtered_indexed_accounts(&IndexKey::ProgramId(stake_program_id), |_| true, None)
+        .map_err(|e| StakeMetaGeneratorError::ScanError(format!("{e:?}")))?;
+    if raw_stake_accounts.is_empty() {
+        warn!("ProgramId index returned no stake accounts; falling back to full program scan");
+        raw_stake_accounts = bank
+            .get_program_accounts(&stake_program_id)
+            .map_err(|e| StakeMetaGeneratorError::ScanError(format!("{e:?}")))?;
+    }
+    let stake_accounts: Vec<(Pubkey, StakeAccount)> = raw_stake_accounts
+        .into_iter()
+        .filter_map(|(stake_pubkey, account)| {
+            // `try_from` returns `Err` for non-delegated stake accounts (e.g. uninitialized
+            // or rewards-pool accounts), so this keeps only delegated stake accounts.
+            StakeAccount::try_from(account)
+                .ok()
+                .map(|stake_account| (stake_pubkey, stake_account))
+        })
+        .collect();
+    let voter_pubkey_to_delegations = group_delegations_by_voter_pubkey(&stake_accounts, bank);
 
     // Get config PDA
     let (config_pda, _) =
@@ -197,13 +229,15 @@ fn get_config(bank: &Arc<Bank>, config_pubkey: &Pubkey) -> Result<Config, StakeM
         })
 }
 
-/// Given an [EpochStakes] object, return delegations grouped by voter_pubkey (validator delegated to).
+/// Given the bank's delegated stake accounts, return delegations grouped by voter_pubkey
+/// (validator delegated to), keeping only delegations with a positive activated stake.
 fn group_delegations_by_voter_pubkey(
-    delegations: &imbl::HashMap<Pubkey, StakeAccount>,
+    stake_accounts: &[(Pubkey, StakeAccount)],
     bank: &Bank,
 ) -> HashMap<Pubkey, Vec<Delegation>> {
-    delegations
-        .into_iter()
+    stake_accounts
+        .iter()
+        .map(|(stake_pubkey, stake_account)| (stake_pubkey, stake_account))
         .filter(|(_stake_pubkey, stake_account)| {
             stake_account.delegation().stake(
                 bank.epoch(),


### PR DESCRIPTION
## Summary

The tip-router operator was crash-looping on mainnet (epoch 1006), producing
`num stake metas: 0` and panicking with `MerkleRootError`. Root cause: stake-meta
generation read stake delegations from `bank.get_top_epoch_stakes()`, which returns
an **empty** delegation set once the Validator Admission Ticket (VAT, SIMD-0357 /
Alpenglow) feature is active on the cluster. This PR sources stake delegations
directly from the bank's stake accounts instead, independent of VAT, and does so via
an indexed lookup so it doesn't require a full-accounts scan.

## Root cause

`generate_stake_meta_collection` used:

```rust
let top_epoch_stakes = bank.get_top_epoch_stakes();
let delegations = top_epoch_stakes.stake_delegations();
```

`get_top_epoch_stakes()` returns the full stakes **only while VAT is inactive**. When
VAT is active it returns a `Stakes` filtered for the leader-schedule `EpochStakes`,
whose `stake_delegations` map is unconditionally empty (`clone_and_filter_for_vat`
sets `stake_delegations: ImblHashMap::new()`). So every epoch vote account missed the
delegation lookup → `num stake metas: 0` → `num generated merkle trees: 0` →
`MetaMerkleTree::new_from_generated_merkle_tree_collection` returned `MerkleTreeError::MerkleRootError` → `panic` in `lib.rs`, and the systemd service
failed and restarted in a loop.

This was introduced in #218 (which swapped `bank.stakes_cache.stakes()` for
`bank.get_top_epoch_stakes()` — behaviorally identical while VAT was inactive), and
only surfaced once VAT activated on mainnet.

## Changes

- **`stake_meta_generator.rs`**: enumerate stake accounts from the bank instead of
  `get_top_epoch_stakes()`. Each account is rebuilt via `StakeAccount::try_from(AccountSharedData)` (which drops non-delegated accounts) and
fed to the existing `group_delegations_by_voter_pubkey`. This is VAT-independent.
- **Performance**: fetch stake accounts via the `ProgramId` secondary index

(`bank.get_filtered_indexed_accounts(IndexKey::ProgramId(stake_program), …)`) rather
than `get_program_accounts`, which always does a full-accounts scan of the entire
snapshot (that scan hung stake-meta generation for 2+ hours on mainnet). The index
is enabled at bank load in both load paths in `ledger_utils.rs`, scoped to just the
stake program (`AccountSecondaryIndexes { indexes: {ProgramId}, keys: include-only
stake program }`) so index build/memory stays bounded to the ~1–2M stake accounts.
- **Fallback**: if the indexed lookup returns empty (e.g. a bank loaded without the
index, such as in unit tests), fall back to a full `get_program_accounts` scan so
  behavior stays correct.

## Testing

- `cargo test -p tip-router-operator-cli --lib stake_meta_generator` — passes
(`test_generate_stake_meta_collection_happy_path`; exercises the fallback path).
- `cargo build` / `cargo clippy` clean (no new warnings).