### PR TITLE
Keeper: Fix discriminator on jito vault program

### DIFF
--- a/cli/src/instructions.rs
+++ b/cli/src/instructions.rs
@@ -113,6 +113,38 @@ use tokio::time::sleep;
 
 use jito_priority_fee_distribution_sdk;
 
+// -------- Deployed (pre-audit-#262) Jito Vault program discriminator fix --------
+//
+// The Jito Vault program deployed at `Vau1t6sLNxnzB7ZDsef8TLbPLfyZMYXH8WTNqUdm9g8` predates
+// restaking audit #262, which inserted `RevokeDelegateTokenAccount` at `VaultInstruction` enum
+// index 21. This repo builds vault instructions with `jito-vault-client` generated from a newer
+// SDK rev, so for every vault instruction at enum index >= 22 the client serializes a Borsh
+// discriminator one greater than what the on-chain program dispatches on (on_chain = client - 1).
+//
+// Until the vault SDK deps are pinned to the deployed rev, rewrite the discriminator byte to the
+// on-chain value before sending. Verified on mainnet: UpdateVaultBalance tx
+// `5bQam5ALwmHLxsyx1E1JA6Xcd9FLDqFemZvXtuo3iK8EgHdEk2i85158cQf2UuBTEjNC3onN3sSciJJPxP5uJRw9`
+// (data = 0x19 = 25, log "Instruction: UpdateVaultBalance", success).
+//
+// NOTE: `UpdateVaultBalance` additionally hits an isolated client-generation bug that already
+// emits 25, but we set it explicitly so the intent survives any future client regen / dep bump.
+mod onchain_vault_disc {
+    pub const UPDATE_VAULT_BALANCE: u8 = 25;
+    pub const INITIALIZE_UPDATE_STATE_TRACKER: u8 = 26;
+    pub const CRANK_UPDATE_STATE_TRACKER: u8 = 27;
+    pub const CLOSE_UPDATE_STATE_TRACKER: u8 = 28;
+}
+
+/// Rewrite a vault instruction's Borsh discriminator byte to the value the deployed
+/// (pre-audit-#262) Jito Vault program expects. See the module comment above for context.
+fn set_onchain_vault_discriminator(ix: &mut Instruction, on_chain_disc: u8) {
+    debug_assert!(
+        !ix.data.is_empty(),
+        "vault instruction must have a discriminator byte to override"
+    );
+    ix.data[0] = on_chain_disc;
+}
+
 // --------------------- ADMIN ------------------------------
 #[allow(clippy::too_many_arguments)]
 pub async fn admin_create_config(
@@ -1965,7 +1997,7 @@ pub async fn distribute_ncn_vault_rewards(
 
     let (vault_config, _, _) = VaultConfig::find_program_address(&handler.vault_program_id);
 
-    let update_vault_balance_ix = UpdateVaultBalanceBuilder::new()
+    let mut update_vault_balance_ix = UpdateVaultBalanceBuilder::new()
         .config(vault_config)
         .vault(vault)
         .token_program(spl_token_interface::id())
@@ -1973,6 +2005,10 @@ pub async fn distribute_ncn_vault_rewards(
         .vault_token_account(vault_token_account)
         .vrt_mint(vrt_mint)
         .instruction();
+    set_onchain_vault_discriminator(
+        &mut update_vault_balance_ix,
+        onchain_vault_disc::UPDATE_VAULT_BALANCE,
+    );
 
     let result = send_and_log_transaction(
         handler,
@@ -2310,7 +2346,7 @@ pub async fn full_vault_update(handler: &CliHandler, vault: &Pubkey) -> Result<(
         get_account(handler, &vault_update_state_tracker).await?;
 
     if vault_update_state_tracker_account.is_none() {
-        let initialize_vault_update_state_tracker_ix =
+        let mut initialize_vault_update_state_tracker_ix =
             InitializeVaultUpdateStateTrackerBuilder::new()
                 .vault(*vault)
                 .vault_update_state_tracker(vault_update_state_tracker)
@@ -2319,6 +2355,10 @@ pub async fn full_vault_update(handler: &CliHandler, vault: &Pubkey) -> Result<(
                 .payer(payer.pubkey())
                 .config(vault_config)
                 .instruction();
+        set_onchain_vault_discriminator(
+            &mut initialize_vault_update_state_tracker_ix,
+            onchain_vault_disc::INITIALIZE_UPDATE_STATE_TRACKER,
+        );
 
         let result = send_and_log_transaction(
             handler,
@@ -2370,13 +2410,18 @@ pub async fn full_vault_update(handler: &CliHandler, vault: &Pubkey) -> Result<(
                 operator,
             );
 
-            let crank_vault_update_state_tracker_ix = CrankVaultUpdateStateTrackerBuilder::new()
-                .vault(*vault)
-                .operator(*operator)
-                .config(vault_config)
-                .vault_operator_delegation(vault_operator_delegation)
-                .vault_update_state_tracker(vault_update_state_tracker)
-                .instruction();
+            let mut crank_vault_update_state_tracker_ix =
+                CrankVaultUpdateStateTrackerBuilder::new()
+                    .vault(*vault)
+                    .operator(*operator)
+                    .config(vault_config)
+                    .vault_operator_delegation(vault_operator_delegation)
+                    .vault_update_state_tracker(vault_update_state_tracker)
+                    .instruction();
+            set_onchain_vault_discriminator(
+                &mut crank_vault_update_state_tracker_ix,
+                onchain_vault_disc::CRANK_UPDATE_STATE_TRACKER,
+            );
 
             let result = send_and_log_transaction(
                 handler,
@@ -2408,13 +2453,17 @@ pub async fn full_vault_update(handler: &CliHandler, vault: &Pubkey) -> Result<(
         get_account(handler, &vault_update_state_tracker).await?;
 
     if vault_update_state_tracker_account.is_some() {
-        let close_vault_update_state_tracker_ix = CloseVaultUpdateStateTrackerBuilder::new()
+        let mut close_vault_update_state_tracker_ix = CloseVaultUpdateStateTrackerBuilder::new()
             .vault(*vault)
             .vault_update_state_tracker(vault_update_state_tracker)
             .payer(payer.pubkey())
             .config(vault_config)
             .ncn_epoch(ncn_epoch)
             .instruction();
+        set_onchain_vault_discriminator(
+            &mut close_vault_update_state_tracker_ix,
+            onchain_vault_disc::CLOSE_UPDATE_STATE_TRACKER,
+        );
 
         let result = send_and_log_transaction(
             handler,

--- a/cli/src/instructions.rs
+++ b/cli/src/instructions.rs
@@ -113,21 +113,6 @@ use tokio::time::sleep;
 
 use jito_priority_fee_distribution_sdk;
 
-// -------- Deployed (pre-audit-#262) Jito Vault program discriminator fix --------
-//
-// The Jito Vault program deployed at `Vau1t6sLNxnzB7ZDsef8TLbPLfyZMYXH8WTNqUdm9g8` predates
-// restaking audit #262, which inserted `RevokeDelegateTokenAccount` at `VaultInstruction` enum
-// index 21. This repo builds vault instructions with `jito-vault-client` generated from a newer
-// SDK rev, so for every vault instruction at enum index >= 22 the client serializes a Borsh
-// discriminator one greater than what the on-chain program dispatches on (on_chain = client - 1).
-//
-// Until the vault SDK deps are pinned to the deployed rev, rewrite the discriminator byte to the
-// on-chain value before sending. Verified on mainnet: UpdateVaultBalance tx
-// `5bQam5ALwmHLxsyx1E1JA6Xcd9FLDqFemZvXtuo3iK8EgHdEk2i85158cQf2UuBTEjNC3onN3sSciJJPxP5uJRw9`
-// (data = 0x19 = 25, log "Instruction: UpdateVaultBalance", success).
-//
-// NOTE: `UpdateVaultBalance` additionally hits an isolated client-generation bug that already
-// emits 25, but we set it explicitly so the intent survives any future client regen / dep bump.
 mod onchain_vault_disc {
     pub const UPDATE_VAULT_BALANCE: u8 = 25;
     pub const INITIALIZE_UPDATE_STATE_TRACKER: u8 = 26;

--- a/cli/src/instructions.rs
+++ b/cli/src/instructions.rs
@@ -121,7 +121,7 @@ mod onchain_vault_disc {
 }
 
 /// Rewrite a vault instruction's Borsh discriminator byte to the value the deployed
-/// (pre-audit-#262) Jito Vault program expects. See the module comment above for context.
+/// Jito Vault program expects.
 fn set_onchain_vault_discriminator(ix: &mut Instruction, on_chain_disc: u8) {
     debug_assert!(
         !ix.data.is_empty(),

--- a/cli/src/instructions.rs
+++ b/cli/src/instructions.rs
@@ -122,12 +122,15 @@ mod onchain_vault_disc {
 
 /// Rewrite a vault instruction's Borsh discriminator byte to the value the deployed
 /// Jito Vault program expects.
-fn set_onchain_vault_discriminator(ix: &mut Instruction, on_chain_disc: u8) {
-    debug_assert!(
-        !ix.data.is_empty(),
-        "vault instruction must have a discriminator byte to override"
-    );
-    ix.data[0] = on_chain_disc;
+///
+/// Returns an error (rather than panicking) if the builder produced an instruction with no data
+/// byte — this runs in the long-lived keeper, so we propagate instead of aborting the process.
+fn set_onchain_vault_discriminator(ix: &mut Instruction, on_chain_disc: u8) -> Result<()> {
+    let discriminator = ix.data.first_mut().ok_or_else(|| {
+        anyhow!("vault instruction has empty data; expected a discriminator byte to override")
+    })?;
+    *discriminator = on_chain_disc;
+    Ok(())
 }
 
 // --------------------- ADMIN ------------------------------
@@ -1993,7 +1996,7 @@ pub async fn distribute_ncn_vault_rewards(
     set_onchain_vault_discriminator(
         &mut update_vault_balance_ix,
         onchain_vault_disc::UPDATE_VAULT_BALANCE,
-    );
+    )?;
 
     let result = send_and_log_transaction(
         handler,
@@ -2343,7 +2346,7 @@ pub async fn full_vault_update(handler: &CliHandler, vault: &Pubkey) -> Result<(
         set_onchain_vault_discriminator(
             &mut initialize_vault_update_state_tracker_ix,
             onchain_vault_disc::INITIALIZE_UPDATE_STATE_TRACKER,
-        );
+        )?;
 
         let result = send_and_log_transaction(
             handler,
@@ -2406,7 +2409,7 @@ pub async fn full_vault_update(handler: &CliHandler, vault: &Pubkey) -> Result<(
             set_onchain_vault_discriminator(
                 &mut crank_vault_update_state_tracker_ix,
                 onchain_vault_disc::CRANK_UPDATE_STATE_TRACKER,
-            );
+            )?;
 
             let result = send_and_log_transaction(
                 handler,
@@ -2448,7 +2451,7 @@ pub async fn full_vault_update(handler: &CliHandler, vault: &Pubkey) -> Result<(
         set_onchain_vault_discriminator(
             &mut close_vault_update_state_tracker_ix,
             onchain_vault_disc::CLOSE_UPDATE_STATE_TRACKER,
-        );
+        )?;
 
         let result = send_and_log_transaction(
             handler,


### PR DESCRIPTION
## Problem

- Noticed some errors related jito vault program due to discriminator difference between program and repo

Update vaults

```txt
2026-07-29 14:48:22.735 error [2026-07-29T05:48:22.735Z ERROR jito_vault_crank] Failed to update vault vault=AKkqZwemKgFJG86FYQmmS8f8TVDqjfd56b2LYdSZLAPF: Transaction 1 failed after 10 retries: RPC response error -32002: Transaction simulation failed;  
2026-07-29 14:48:22.735 error [2026-07-29T05:48:22.735Z ERROR jito_vault_cranker::vault_handler] Transaction failed permanently tx=1/1 retries=10: Error { request: Some(SendTransaction), kind: RpcError(RpcResponseError { code: -32002, message: "Transaction simulation failed", data: Empty }) } 
2026-07-29 14:48:22.734 error [2026-07-29T05:48:22.734Z ERROR jito_vault_crank] Failed to update vault vault=E6KBP5nhuJZnNcGJwDdbk6mNyQZWWyEzR3PBu6HegFsV: Transaction 1 failed after 10 retries: RPC response error -32002: Transaction simulation failed;  
```

DistributeNcnVualtReward

```txt
2026-07-30 08:27:27.933 error [2026-07-29T23:27:27.932Z ERROR jito_tip_router_cli::instructions] Failed to distribute NCN vault rewards vault=AKkqZwemKgFJG86FYQmmS8f8TVDqjfd56b2LYdSZLAPF operator=GZxp4e2Tm3Pw9GyAaxuF6odT3XkRM96jpZkp3nxhoK4Y group=NcnFeeGroup { group: 0 } epoch=1009: Transaction failed: Error { request: Some(SendTransaction), kind: RpcError(RpcResponseError { code: -32002, message: "Transaction simulation failed", data: SendTransactionPreflightFailure(RpcSimulateTransactionResult { err: Some(UiTransactionError(InstructionError(3, BorshIoError))), logs: Some(["Program ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL invoke [1]", "Program log: CreateIdempotent", "Program ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL consumed 4461 of 1399850 compute units", "Program ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL success", "Program RouterBmuRBkPUbgEDMtdvTZ75GBdSREZR5uGUxxxpb invoke [1]", "Program log: Instruction: DistributeNcnVaultRewards", "Program SPoo1Ku8WFXoNDMHPsrGSTSG1Y47rzgn41SLUNakuHy invoke [2]", "Program log: Instruction: DepositSol", "Program 11111111111111111111111111111111 invoke [3]", "Program 11111111111111111111111111111111 success", "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA invoke [3]", "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA consumed 120 of 1339246 compute units", "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA success", "Program SPoo1Ku8WFXoNDMHPsrGSTSG1Y47rzgn41SLUNakuHy consumed 11464 of 1348729 compute units", "Program SPoo1Ku8WFXoNDMHPsrGSTSG1Y47rzgn41SLUNakuHy success", "Program RouterBmuRBkPUbgEDMtdvTZ75GBdSREZR5uGUxxxpb consumed 59105 of 1395389 compute units", "Program RouterBmuRBkPUbgEDMtdvTZ75GBdSREZR5uGUxxxpb success", "Program Vau1t6sLNxnzB7ZDsef8TLbPLfyZMYXH8WTNqUdm9g8 invoke [1]", "Program Vau1t6sLNxnzB7ZDsef8TLbPLfyZMYXH8WTNqUdm9g8 consumed 2186 of 1336284 compute units", "Program Vau1t6sLNxnzB7ZDsef8TLbPLfyZMYXH8WTNqUdm9g8 failed: Failed to serialize or deserialize account data"]), accounts: None, units_consumed: Some(65902), loaded_accounts_data_size: None, return_data: None, inner_instructions: None, replacement_blockhash: None, fee: None, pre_balances: None, post_balances: None, pre_token_balances: None, post_token_balances: None, loaded_addresses: None }) }) } 
```