### PR TITLE
Bump to 4.2.0

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -7,6 +7,7 @@ ignore = [
     "RUSTSEC-2024-0421", # idna - IDNA 2003 compatibility
     "RUSTSEC-2025-0009", # ring 0.16 - vulnerability
     "RUSTSEC-2026-0001", # rkyv - unsound
+    "RUSTSEC-2026-0235", # rust_decimal's optional rkyv 0.7 feature is not enabled by this workspace;
     "RUSTSEC-2026-0007", # bytes - vulnerability
     "RUSTSEC-2026-0009", # time - vulnerability
     "RUSTSEC-2026-0037", # quinn-proto - vulnerability

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  RUST_VERSION: "1.95.0"
+  RUST_VERSION: "1.96.1"
 
 jobs:
   security_audit:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,8 +56,8 @@ dependencies = [
 
 [[package]]
 name = "agave-banking-stage-ingress-types"
-version = "4.2.0-rc.1"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
+version = "4.2.0"
+source = "git+https://github.com/jito-foundation/jito-solana.git?tag=v4.2.0-jito#13fa43a6611c82183594c40210a0126009f6f565"
 dependencies = [
  "crossbeam-channel",
  "solana-perf",
@@ -65,8 +65,8 @@ dependencies = [
 
 [[package]]
 name = "agave-bls-cert-verify"
-version = "4.2.0-rc.1"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
+version = "4.2.0"
+source = "git+https://github.com/jito-foundation/jito-solana.git?tag=v4.2.0-jito#13fa43a6611c82183594c40210a0126009f6f565"
 dependencies = [
  "agave-votor-messages",
  "bitvec",
@@ -80,8 +80,8 @@ dependencies = [
 
 [[package]]
 name = "agave-bls-sigverify"
-version = "4.2.0-rc.1"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
+version = "4.2.0"
+source = "git+https://github.com/jito-foundation/jito-solana.git?tag=v4.2.0-jito#13fa43a6611c82183594c40210a0126009f6f565"
 dependencies = [
  "agave-bls-cert-verify",
  "agave-math-utils",
@@ -110,16 +110,16 @@ dependencies = [
 
 [[package]]
 name = "agave-cpu-utils"
-version = "4.2.0-rc.1"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
+version = "4.2.0"
+source = "git+https://github.com/jito-foundation/jito-solana.git?tag=v4.2.0-jito#13fa43a6611c82183594c40210a0126009f6f565"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "agave-feature-set"
-version = "4.2.0-rc.1"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
+version = "4.2.0"
+source = "git+https://github.com/jito-foundation/jito-solana.git?tag=v4.2.0-jito#13fa43a6611c82183594c40210a0126009f6f565"
 dependencies = [
  "ahash 0.8.12",
  "solana-epoch-schedule 3.2.0",
@@ -132,8 +132,8 @@ dependencies = [
 
 [[package]]
 name = "agave-fs"
-version = "4.2.0-rc.1"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
+version = "4.2.0"
+source = "git+https://github.com/jito-foundation/jito-solana.git?tag=v4.2.0-jito#13fa43a6611c82183594c40210a0126009f6f565"
 dependencies = [
  "agave-io-uring",
  "io-uring",
@@ -147,8 +147,8 @@ dependencies = [
 
 [[package]]
 name = "agave-geyser-plugin-interface"
-version = "4.2.0-rc.1"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
+version = "4.2.0"
+source = "git+https://github.com/jito-foundation/jito-solana.git?tag=v4.2.0-jito#13fa43a6611c82183594c40210a0126009f6f565"
 dependencies = [
  "log",
  "solana-clock 3.1.1",
@@ -162,8 +162,8 @@ dependencies = [
 
 [[package]]
 name = "agave-io-uring"
-version = "4.2.0-rc.1"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
+version = "4.2.0"
+source = "git+https://github.com/jito-foundation/jito-solana.git?tag=v4.2.0-jito#13fa43a6611c82183594c40210a0126009f6f565"
 dependencies = [
  "io-uring",
  "libc",
@@ -174,8 +174,8 @@ dependencies = [
 
 [[package]]
 name = "agave-logger"
-version = "4.2.0-rc.1"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
+version = "4.2.0"
+source = "git+https://github.com/jito-foundation/jito-solana.git?tag=v4.2.0-jito#13fa43a6611c82183594c40210a0126009f6f565"
 dependencies = [
  "env_logger 0.11.11",
  "libc",
@@ -185,16 +185,16 @@ dependencies = [
 
 [[package]]
 name = "agave-math-utils"
-version = "4.2.0-rc.1"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
+version = "4.2.0"
+source = "git+https://github.com/jito-foundation/jito-solana.git?tag=v4.2.0-jito#13fa43a6611c82183594c40210a0126009f6f565"
 dependencies = [
  "num-traits",
 ]
 
 [[package]]
 name = "agave-precompiles"
-version = "4.2.0-rc.1"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
+version = "4.2.0"
+source = "git+https://github.com/jito-foundation/jito-solana.git?tag=v4.2.0-jito#13fa43a6611c82183594c40210a0126009f6f565"
 dependencies = [
  "agave-feature-set",
  "bincode",
@@ -213,16 +213,16 @@ dependencies = [
 
 [[package]]
 name = "agave-random"
-version = "4.2.0-rc.1"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
+version = "4.2.0"
+source = "git+https://github.com/jito-foundation/jito-solana.git?tag=v4.2.0-jito#13fa43a6611c82183594c40210a0126009f6f565"
 dependencies = [
  "rand 0.9.5",
 ]
 
 [[package]]
 name = "agave-reserved-account-keys"
-version = "4.2.0-rc.1"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
+version = "4.2.0"
+source = "git+https://github.com/jito-foundation/jito-solana.git?tag=v4.2.0-jito#13fa43a6611c82183594c40210a0126009f6f565"
 dependencies = [
  "agave-feature-set",
  "solana-pubkey 4.2.0",
@@ -231,13 +231,13 @@ dependencies = [
 
 [[package]]
 name = "agave-scheduler-bindings"
-version = "4.2.0-rc.1"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
+version = "4.2.0"
+source = "git+https://github.com/jito-foundation/jito-solana.git?tag=v4.2.0-jito#13fa43a6611c82183594c40210a0126009f6f565"
 
 [[package]]
 name = "agave-scheduling-utils"
-version = "4.2.0-rc.1"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
+version = "4.2.0"
+source = "git+https://github.com/jito-foundation/jito-solana.git?tag=v4.2.0-jito#13fa43a6611c82183594c40210a0126009f6f565"
 dependencies = [
  "agave-feature-set",
  "agave-scheduler-bindings",
@@ -257,8 +257,8 @@ dependencies = [
 
 [[package]]
 name = "agave-snapshots"
-version = "4.2.0-rc.1"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
+version = "4.2.0"
+source = "git+https://github.com/jito-foundation/jito-solana.git?tag=v4.2.0-jito#13fa43a6611c82183594c40210a0126009f6f565"
 dependencies = [
  "agave-fs",
  "bincode",
@@ -287,8 +287,8 @@ dependencies = [
 
 [[package]]
 name = "agave-transaction-view"
-version = "4.2.0-rc.1"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
+version = "4.2.0"
+source = "git+https://github.com/jito-foundation/jito-solana.git?tag=v4.2.0-jito#13fa43a6611c82183594c40210a0126009f6f565"
 dependencies = [
  "bytes",
  "solana-hash 4.5.0",
@@ -304,8 +304,8 @@ dependencies = [
 
 [[package]]
 name = "agave-votor"
-version = "4.2.0-rc.1"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
+version = "4.2.0"
+source = "git+https://github.com/jito-foundation/jito-solana.git?tag=v4.2.0-jito#13fa43a6611c82183594c40210a0126009f6f565"
 dependencies = [
  "agave-bls-sigverify",
  "agave-logger",
@@ -347,8 +347,8 @@ dependencies = [
 
 [[package]]
 name = "agave-votor-messages"
-version = "4.2.0-rc.1"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
+version = "4.2.0"
+source = "git+https://github.com/jito-foundation/jito-solana.git?tag=v4.2.0-jito#13fa43a6611c82183594c40210a0126009f6f565"
 dependencies = [
  "agave-feature-set",
  "crossbeam-channel",
@@ -368,8 +368,8 @@ dependencies = [
 
 [[package]]
 name = "agave-xdp"
-version = "4.2.0-rc.1"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
+version = "4.2.0"
+source = "git+https://github.com/jito-foundation/jito-solana.git?tag=v4.2.0-jito#13fa43a6611c82183594c40210a0126009f6f565"
 dependencies = [
  "agave-cpu-utils",
  "agave-xdp-ebpf",
@@ -387,8 +387,8 @@ dependencies = [
 
 [[package]]
 name = "agave-xdp-ebpf"
-version = "4.2.0-rc.1"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
+version = "4.2.0"
+source = "git+https://github.com/jito-foundation/jito-solana.git?tag=v4.2.0-jito#13fa43a6611c82183594c40210a0126009f6f565"
 dependencies = [
  "aya",
  "aya-ebpf",
@@ -4156,7 +4156,7 @@ dependencies = [
  "solana-program 3.0.0",
  "solana-system-interface 3.2.0",
  "spl-associated-token-account-interface",
- "spl-token-2022-interface",
+ "spl-token-2022-interface 2.1.0",
  "spl-token-interface 2.0.0",
  "thiserror 2.0.18",
 ]
@@ -4172,8 +4172,8 @@ dependencies = [
 
 [[package]]
 name = "jito-protos"
-version = "4.2.0-rc.1"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
+version = "4.2.0"
+source = "git+https://github.com/jito-foundation/jito-solana.git?tag=v4.2.0-jito#13fa43a6611c82183594c40210a0126009f6f565"
 dependencies = [
  "bytes",
  "prost 0.14.4",
@@ -4239,7 +4239,7 @@ dependencies = [
  "solana-program 3.0.0",
  "solana-security-txt",
  "spl-associated-token-account-interface",
- "spl-token-2022-interface",
+ "spl-token-2022-interface 2.1.0",
  "spl-token-interface 2.0.0",
  "thiserror 2.0.18",
 ]
@@ -4481,7 +4481,7 @@ dependencies = [
  "solana-program 3.0.0",
  "solana-system-interface 3.2.0",
  "spl-associated-token-account-interface",
- "spl-token-2022-interface",
+ "spl-token-2022-interface 2.1.0",
  "spl-token-interface 2.0.0",
  "thiserror 2.0.18",
 ]
@@ -4503,7 +4503,7 @@ dependencies = [
  "solana-security-txt",
  "solana-system-interface 3.2.0",
  "spl-associated-token-account-interface",
- "spl-token-2022-interface",
+ "spl-token-2022-interface 2.1.0",
  "spl-token-interface 2.0.0",
  "thiserror 2.0.18",
 ]
@@ -5348,6 +5348,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -7612,8 +7613,8 @@ dependencies = [
 
 [[package]]
 name = "solana-account-decoder"
-version = "4.2.0-rc.1"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
+version = "4.2.0"
+source = "git+https://github.com/jito-foundation/jito-solana.git?tag=v4.2.0-jito#13fa43a6611c82183594c40210a0126009f6f565"
 dependencies = [
  "Inflector",
  "base64 0.22.1",
@@ -7642,11 +7643,12 @@ dependencies = [
  "solana-stake-interface 4.3.0",
  "solana-sysvar 4.1.0",
  "solana-vote-interface 6.0.3",
+ "solana-zk-sdk-pod",
  "spl-generic-token",
- "spl-token-2022-interface",
+ "spl-token-2022-interface 3.1.1",
  "spl-token-group-interface",
  "spl-token-interface 3.0.0",
- "spl-token-metadata-interface",
+ "spl-token-metadata-interface 1.0.1",
  "thiserror 2.0.18",
  "wincode",
  "zstd",
@@ -7654,8 +7656,8 @@ dependencies = [
 
 [[package]]
 name = "solana-account-decoder-client-types"
-version = "4.2.0-rc.1"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
+version = "4.2.0"
+source = "git+https://github.com/jito-foundation/jito-solana.git?tag=v4.2.0-jito#13fa43a6611c82183594c40210a0126009f6f565"
 dependencies = [
  "base64 0.22.1",
  "bs58 0.5.1",
@@ -7694,8 +7696,8 @@ dependencies = [
 
 [[package]]
 name = "solana-accounts-db"
-version = "4.2.0-rc.1"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
+version = "4.2.0"
+source = "git+https://github.com/jito-foundation/jito-solana.git?tag=v4.2.0-jito#13fa43a6611c82183594c40210a0126009f6f565"
 dependencies = [
  "agave-fs",
  "ahash 0.8.12",
@@ -7737,7 +7739,7 @@ dependencies = [
  "solana-sysvar 4.1.0",
  "solana-time-utils 3.0.0",
  "solana-transaction 4.1.5",
- "solana-transaction-context 4.2.0-rc.1",
+ "solana-transaction-context 4.2.0",
  "solana-transaction-error 3.3.1",
  "solana-vote-program",
  "spl-generic-token",
@@ -7835,8 +7837,8 @@ dependencies = [
 
 [[package]]
 name = "solana-banks-client"
-version = "4.2.0-rc.1"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
+version = "4.2.0"
+source = "git+https://github.com/jito-foundation/jito-solana.git?tag=v4.2.0-jito#13fa43a6611c82183594c40210a0126009f6f565"
 dependencies = [
  "borsh 1.8.0",
  "futures 0.3.32",
@@ -7852,7 +7854,7 @@ dependencies = [
  "solana-signature 3.4.1",
  "solana-sysvar 4.1.0",
  "solana-transaction 4.1.5",
- "solana-transaction-context 4.2.0-rc.1",
+ "solana-transaction-context 4.2.0",
  "solana-transaction-error 3.3.1",
  "tarpc",
  "thiserror 2.0.18",
@@ -7862,8 +7864,8 @@ dependencies = [
 
 [[package]]
 name = "solana-banks-interface"
-version = "4.2.0-rc.1"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
+version = "4.2.0"
+source = "git+https://github.com/jito-foundation/jito-solana.git?tag=v4.2.0-jito#13fa43a6611c82183594c40210a0126009f6f565"
 dependencies = [
  "serde",
  "solana-account 4.3.1",
@@ -7874,15 +7876,15 @@ dependencies = [
  "solana-pubkey 4.2.0",
  "solana-signature 3.4.1",
  "solana-transaction 4.1.5",
- "solana-transaction-context 4.2.0-rc.1",
+ "solana-transaction-context 4.2.0",
  "solana-transaction-error 3.3.1",
  "tarpc",
 ]
 
 [[package]]
 name = "solana-banks-server"
-version = "4.2.0-rc.1"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
+version = "4.2.0"
+source = "git+https://github.com/jito-foundation/jito-solana.git?tag=v4.2.0-jito#13fa43a6611c82183594c40210a0126009f6f565"
 dependencies = [
  "agave-feature-set",
  "bincode",
@@ -7978,8 +7980,8 @@ dependencies = [
 
 [[package]]
 name = "solana-bloom"
-version = "4.2.0-rc.1"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
+version = "4.2.0"
+source = "git+https://github.com/jito-foundation/jito-solana.git?tag=v4.2.0-jito#13fa43a6611c82183594c40210a0126009f6f565"
 dependencies = [
  "bv",
  "fnv",
@@ -8082,8 +8084,8 @@ dependencies = [
 
 [[package]]
 name = "solana-bpf-loader-program"
-version = "4.2.0-rc.1"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
+version = "4.2.0"
+source = "git+https://github.com/jito-foundation/jito-solana.git?tag=v4.2.0-jito#13fa43a6611c82183594c40210a0126009f6f565"
 dependencies = [
  "bincode",
  "qualifier_attr",
@@ -8103,13 +8105,13 @@ dependencies = [
  "solana-svm-type-overrides",
  "solana-syscalls",
  "solana-system-interface 3.2.0",
- "solana-transaction-context 4.2.0-rc.1",
+ "solana-transaction-context 4.2.0",
 ]
 
 [[package]]
 name = "solana-bucket-map"
-version = "4.2.0-rc.1"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
+version = "4.2.0"
+source = "git+https://github.com/jito-foundation/jito-solana.git?tag=v4.2.0-jito#13fa43a6611c82183594c40210a0126009f6f565"
 dependencies = [
  "ahash 0.8.12",
  "bv",
@@ -8127,8 +8129,8 @@ dependencies = [
 
 [[package]]
 name = "solana-builtins"
-version = "4.2.0-rc.1"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
+version = "4.2.0"
+source = "git+https://github.com/jito-foundation/jito-solana.git?tag=v4.2.0-jito#13fa43a6611c82183594c40210a0126009f6f565"
 dependencies = [
  "agave-feature-set",
  "solana-bpf-loader-program",
@@ -8145,8 +8147,8 @@ dependencies = [
 
 [[package]]
 name = "solana-builtins-default-costs"
-version = "4.2.0-rc.1"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
+version = "4.2.0"
+source = "git+https://github.com/jito-foundation/jito-solana.git?tag=v4.2.0-jito#13fa43a6611c82183594c40210a0126009f6f565"
 dependencies = [
  "agave-feature-set",
  "ahash 0.8.12",
@@ -8156,8 +8158,8 @@ dependencies = [
 
 [[package]]
 name = "solana-bundle"
-version = "4.2.0-rc.1"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
+version = "4.2.0"
+source = "git+https://github.com/jito-foundation/jito-solana.git?tag=v4.2.0-jito#13fa43a6611c82183594c40210a0126009f6f565"
 dependencies = [
  "itertools 0.14.0",
  "sha2 0.11.0",
@@ -8166,8 +8168,8 @@ dependencies = [
 
 [[package]]
 name = "solana-clap-utils"
-version = "4.2.0-rc.1"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
+version = "4.2.0"
+source = "git+https://github.com/jito-foundation/jito-solana.git?tag=v4.2.0-jito#13fa43a6611c82183594c40210a0126009f6f565"
 dependencies = [
  "bip39",
  "bs58 0.5.1",
@@ -8196,8 +8198,8 @@ dependencies = [
 
 [[package]]
 name = "solana-cli-config"
-version = "4.2.0-rc.1"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
+version = "4.2.0"
+source = "git+https://github.com/jito-foundation/jito-solana.git?tag=v4.2.0-jito#13fa43a6611c82183594c40210a0126009f6f565"
 dependencies = [
  "dirs-next",
  "serde",
@@ -8209,8 +8211,8 @@ dependencies = [
 
 [[package]]
 name = "solana-cli-output"
-version = "4.2.0-rc.1"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
+version = "4.2.0"
+source = "git+https://github.com/jito-foundation/jito-solana.git?tag=v4.2.0-jito#13fa43a6611c82183594c40210a0126009f6f565"
 dependencies = [
  "Inflector",
  "agave-reserved-account-keys",
@@ -8254,8 +8256,8 @@ dependencies = [
 
 [[package]]
 name = "solana-client"
-version = "4.2.0-rc.1"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
+version = "4.2.0"
+source = "git+https://github.com/jito-foundation/jito-solana.git?tag=v4.2.0-jito#13fa43a6611c82183594c40210a0126009f6f565"
 dependencies = [
  "async-trait",
  "bincode",
@@ -8401,8 +8403,8 @@ dependencies = [
 
 [[package]]
 name = "solana-compute-budget"
-version = "4.2.0-rc.1"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
+version = "4.2.0"
+source = "git+https://github.com/jito-foundation/jito-solana.git?tag=v4.2.0-jito#13fa43a6611c82183594c40210a0126009f6f565"
 dependencies = [
  "solana-fee-structure 3.0.0",
  "solana-program-runtime",
@@ -8410,8 +8412,8 @@ dependencies = [
 
 [[package]]
 name = "solana-compute-budget-instruction"
-version = "4.2.0-rc.1"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
+version = "4.2.0"
+source = "git+https://github.com/jito-foundation/jito-solana.git?tag=v4.2.0-jito#13fa43a6611c82183594c40210a0126009f6f565"
 dependencies = [
  "agave-feature-set",
  "solana-borsh 3.0.2",
@@ -8452,8 +8454,8 @@ dependencies = [
 
 [[package]]
 name = "solana-compute-budget-program"
-version = "4.2.0-rc.1"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
+version = "4.2.0"
+source = "git+https://github.com/jito-foundation/jito-solana.git?tag=v4.2.0-jito#13fa43a6611c82183594c40210a0126009f6f565"
 dependencies = [
  "solana-program-runtime",
 ]
@@ -8477,8 +8479,8 @@ dependencies = [
 
 [[package]]
 name = "solana-connection-cache"
-version = "4.2.0-rc.1"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
+version = "4.2.0"
+source = "git+https://github.com/jito-foundation/jito-solana.git?tag=v4.2.0-jito#13fa43a6611c82183594c40210a0126009f6f565"
 dependencies = [
  "async-trait",
  "crossbeam-channel",
@@ -8495,8 +8497,8 @@ dependencies = [
 
 [[package]]
 name = "solana-core"
-version = "4.2.0-rc.1"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
+version = "4.2.0"
+source = "git+https://github.com/jito-foundation/jito-solana.git?tag=v4.2.0-jito#13fa43a6611c82183594c40210a0126009f6f565"
 dependencies = [
  "agave-banking-stage-ingress-types",
  "agave-bls-cert-verify",
@@ -8651,8 +8653,8 @@ dependencies = [
 
 [[package]]
 name = "solana-cost-model"
-version = "4.2.0-rc.1"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
+version = "4.2.0"
+source = "git+https://github.com/jito-foundation/jito-solana.git?tag=v4.2.0-jito#13fa43a6611c82183594c40210a0126009f6f565"
 dependencies = [
  "agave-feature-set",
  "ahash 0.8.12",
@@ -8786,8 +8788,8 @@ dependencies = [
 
 [[package]]
 name = "solana-download-utils"
-version = "4.2.0-rc.1"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
+version = "4.2.0"
+source = "git+https://github.com/jito-foundation/jito-solana.git?tag=v4.2.0-jito#13fa43a6611c82183594c40210a0126009f6f565"
 dependencies = [
  "agave-snapshots",
  "log",
@@ -8826,8 +8828,8 @@ dependencies = [
 
 [[package]]
 name = "solana-entry"
-version = "4.2.0-rc.1"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
+version = "4.2.0"
+source = "git+https://github.com/jito-foundation/jito-solana.git?tag=v4.2.0-jito#13fa43a6611c82183594c40210a0126009f6f565"
 dependencies = [
  "agave-votor-messages",
  "crossbeam-channel",
@@ -9024,8 +9026,8 @@ dependencies = [
 
 [[package]]
 name = "solana-faucet"
-version = "4.2.0-rc.1"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
+version = "4.2.0"
+source = "git+https://github.com/jito-foundation/jito-solana.git?tag=v4.2.0-jito#13fa43a6611c82183594c40210a0126009f6f565"
 dependencies = [
  "crossbeam-channel",
  "log",
@@ -9113,8 +9115,8 @@ dependencies = [
 
 [[package]]
 name = "solana-fee"
-version = "4.2.0-rc.1"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
+version = "4.2.0"
+source = "git+https://github.com/jito-foundation/jito-solana.git?tag=v4.2.0-jito#13fa43a6611c82183594c40210a0126009f6f565"
 dependencies = [
  "agave-feature-set",
  "solana-fee-structure 3.0.0",
@@ -9239,8 +9241,8 @@ dependencies = [
 
 [[package]]
 name = "solana-genesis-utils"
-version = "4.2.0-rc.1"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
+version = "4.2.0"
+source = "git+https://github.com/jito-foundation/jito-solana.git?tag=v4.2.0-jito#13fa43a6611c82183594c40210a0126009f6f565"
 dependencies = [
  "agave-snapshots",
  "log",
@@ -9264,8 +9266,8 @@ dependencies = [
 
 [[package]]
 name = "solana-geyser-plugin-manager"
-version = "4.2.0-rc.1"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
+version = "4.2.0"
+source = "git+https://github.com/jito-foundation/jito-solana.git?tag=v4.2.0-jito#13fa43a6611c82183594c40210a0126009f6f565"
 dependencies = [
  "agave-geyser-plugin-interface",
  "arc-swap",
@@ -9298,8 +9300,8 @@ dependencies = [
 
 [[package]]
 name = "solana-gossip"
-version = "4.2.0-rc.1"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
+version = "4.2.0"
+source = "git+https://github.com/jito-foundation/jito-solana.git?tag=v4.2.0-jito#13fa43a6611c82183594c40210a0126009f6f565"
 dependencies = [
  "agave-logger",
  "agave-random",
@@ -9648,8 +9650,8 @@ dependencies = [
 
 [[package]]
 name = "solana-lattice-hash"
-version = "4.2.0-rc.1"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
+version = "4.2.0"
+source = "git+https://github.com/jito-foundation/jito-solana.git?tag=v4.2.0-jito#13fa43a6611c82183594c40210a0126009f6f565"
 dependencies = [
  "base64 0.22.1",
  "blake3",
@@ -9659,8 +9661,8 @@ dependencies = [
 
 [[package]]
 name = "solana-leader-schedule"
-version = "4.2.0-rc.1"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
+version = "4.2.0"
+source = "git+https://github.com/jito-foundation/jito-solana.git?tag=v4.2.0-jito#13fa43a6611c82183594c40210a0126009f6f565"
 dependencies = [
  "agave-random",
  "itertools 0.14.0",
@@ -9672,8 +9674,8 @@ dependencies = [
 
 [[package]]
 name = "solana-ledger"
-version = "4.2.0-rc.1"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
+version = "4.2.0"
+source = "git+https://github.com/jito-foundation/jito-solana.git?tag=v4.2.0-jito#13fa43a6611c82183594c40210a0126009f6f565"
 dependencies = [
  "agave-feature-set",
  "agave-reserved-account-keys",
@@ -9749,7 +9751,7 @@ dependencies = [
  "solana-system-transaction 4.0.0",
  "solana-time-utils 3.0.0",
  "solana-transaction 4.1.5",
- "solana-transaction-context 4.2.0-rc.1",
+ "solana-transaction-context 4.2.0",
  "solana-transaction-error 3.3.1",
  "solana-transaction-status",
  "solana-vote",
@@ -9883,13 +9885,13 @@ dependencies = [
 
 [[package]]
 name = "solana-measure"
-version = "4.2.0-rc.1"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
+version = "4.2.0"
+source = "git+https://github.com/jito-foundation/jito-solana.git?tag=v4.2.0-jito#13fa43a6611c82183594c40210a0126009f6f565"
 
 [[package]]
 name = "solana-merkle-tree"
-version = "4.2.0-rc.1"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
+version = "4.2.0"
+source = "git+https://github.com/jito-foundation/jito-solana.git?tag=v4.2.0-jito#13fa43a6611c82183594c40210a0126009f6f565"
 dependencies = [
  "fast-math",
  "solana-hash 4.5.0",
@@ -9958,8 +9960,8 @@ dependencies = [
 
 [[package]]
 name = "solana-metrics"
-version = "4.2.0-rc.1"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
+version = "4.2.0"
+source = "git+https://github.com/jito-foundation/jito-solana.git?tag=v4.2.0-jito#13fa43a6611c82183594c40210a0126009f6f565"
 dependencies = [
  "crossbeam-channel",
  "gethostname",
@@ -10003,8 +10005,8 @@ checksum = "ae8dd4c280dca9d046139eb5b7a5ac9ad10403fbd64964c7d7571214950d758f"
 
 [[package]]
 name = "solana-net-utils"
-version = "4.2.0-rc.1"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
+version = "4.2.0"
+source = "git+https://github.com/jito-foundation/jito-solana.git?tag=v4.2.0-jito#13fa43a6611c82183594c40210a0126009f6f565"
 dependencies = [
  "agave-xdp",
  "bincode",
@@ -10091,6 +10093,7 @@ version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec7b49f68ccea949a6ea75f485dbe2e17cf4c1d894ed262371d584269359e1a0"
 dependencies = [
+ "borsh 1.8.0",
  "bytemuck",
 ]
 
@@ -10166,8 +10169,8 @@ dependencies = [
 
 [[package]]
 name = "solana-perf"
-version = "4.2.0-rc.1"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
+version = "4.2.0"
+source = "git+https://github.com/jito-foundation/jito-solana.git?tag=v4.2.0-jito#13fa43a6611c82183594c40210a0126009f6f565"
 dependencies = [
  "agave-transaction-view",
  "ahash 0.8.12",
@@ -10192,14 +10195,14 @@ dependencies = [
  "solana-short-vec 3.2.2",
  "solana-signature 3.4.1",
  "solana-time-utils 3.0.0",
- "solana-transaction-context 4.2.0-rc.1",
+ "solana-transaction-context 4.2.0",
  "wincode",
 ]
 
 [[package]]
 name = "solana-poh"
-version = "4.2.0-rc.1"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
+version = "4.2.0"
+source = "git+https://github.com/jito-foundation/jito-solana.git?tag=v4.2.0-jito#13fa43a6611c82183594c40210a0126009f6f565"
 dependencies = [
  "agave-cpu-utils",
  "agave-votor-messages",
@@ -10492,8 +10495,8 @@ dependencies = [
 
 [[package]]
 name = "solana-program-binaries"
-version = "4.2.0-rc.1"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
+version = "4.2.0"
+source = "git+https://github.com/jito-foundation/jito-solana.git?tag=v4.2.0-jito#13fa43a6611c82183594c40210a0126009f6f565"
 dependencies = [
  "bincode",
  "solana-account 4.3.1",
@@ -10605,8 +10608,8 @@ dependencies = [
 
 [[package]]
 name = "solana-program-runtime"
-version = "4.2.0-rc.1"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
+version = "4.2.0"
+source = "git+https://github.com/jito-foundation/jito-solana.git?tag=v4.2.0-jito#13fa43a6611c82183594c40210a0126009f6f565"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -10645,15 +10648,15 @@ dependencies = [
  "solana-system-interface 3.2.0",
  "solana-sysvar 4.1.0",
  "solana-sysvar-id 3.1.0",
- "solana-transaction-context 4.2.0-rc.1",
+ "solana-transaction-context 4.2.0",
  "thiserror 2.0.18",
  "wincode",
 ]
 
 [[package]]
 name = "solana-program-test"
-version = "4.2.0-rc.1"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
+version = "4.2.0"
+source = "git+https://github.com/jito-foundation/jito-solana.git?tag=v4.2.0-jito#13fa43a6611c82183594c40210a0126009f6f565"
 dependencies = [
  "agave-feature-set",
  "agave-logger",
@@ -10704,7 +10707,7 @@ dependencies = [
  "solana-sysvar 4.1.0",
  "solana-sysvar-id 3.1.0",
  "solana-transaction 4.1.5",
- "solana-transaction-context 4.2.0-rc.1",
+ "solana-transaction-context 4.2.0",
  "solana-transaction-error 3.3.1",
  "solana-vote-program",
  "spl-generic-token",
@@ -10761,8 +10764,8 @@ dependencies = [
 
 [[package]]
 name = "solana-pubsub-client"
-version = "4.2.0-rc.1"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
+version = "4.2.0"
+source = "git+https://github.com/jito-foundation/jito-solana.git?tag=v4.2.0-jito#13fa43a6611c82183594c40210a0126009f6f565"
 dependencies = [
  "crossbeam-channel",
  "futures-util",
@@ -10784,8 +10787,8 @@ dependencies = [
 
 [[package]]
 name = "solana-quic-client"
-version = "4.2.0-rc.1"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
+version = "4.2.0"
+source = "git+https://github.com/jito-foundation/jito-solana.git?tag=v4.2.0-jito#13fa43a6611c82183594c40210a0126009f6f565"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -10818,8 +10821,8 @@ dependencies = [
 
 [[package]]
 name = "solana-rayon-threadlimit"
-version = "4.2.0-rc.1"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
+version = "4.2.0"
+source = "git+https://github.com/jito-foundation/jito-solana.git?tag=v4.2.0-jito#13fa43a6611c82183594c40210a0126009f6f565"
 dependencies = [
  "log",
  "num_cpus",
@@ -10827,8 +10830,8 @@ dependencies = [
 
 [[package]]
 name = "solana-remote-wallet"
-version = "4.2.0-rc.1"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
+version = "4.2.0"
+source = "git+https://github.com/jito-foundation/jito-solana.git?tag=v4.2.0-jito#13fa43a6611c82183594c40210a0126009f6f565"
 dependencies = [
  "console 0.16.4",
  "dialoguer",
@@ -10949,8 +10952,8 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc"
-version = "4.2.0-rc.1"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
+version = "4.2.0"
+source = "git+https://github.com/jito-foundation/jito-solana.git?tag=v4.2.0-jito#13fa43a6611c82183594c40210a0126009f6f565"
 dependencies = [
  "agave-feature-set",
  "agave-snapshots",
@@ -11014,7 +11017,7 @@ dependencies = [
  "solana-time-utils 3.0.0",
  "solana-tls-utils",
  "solana-transaction 4.1.5",
- "solana-transaction-context 4.2.0-rc.1",
+ "solana-transaction-context 4.2.0",
  "solana-transaction-error 3.3.1",
  "solana-transaction-status",
  "solana-validator-exit 3.0.0",
@@ -11022,7 +11025,7 @@ dependencies = [
  "solana-vote",
  "solana-vote-program",
  "spl-generic-token",
- "spl-token-2022-interface",
+ "spl-token-2022-interface 3.1.1",
  "spl-token-interface 3.0.0",
  "stream-cancel",
  "thiserror 2.0.18",
@@ -11033,8 +11036,8 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc-client"
-version = "4.2.0-rc.1"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
+version = "4.2.0"
+source = "git+https://github.com/jito-foundation/jito-solana.git?tag=v4.2.0-jito#13fa43a6611c82183594c40210a0126009f6f565"
 dependencies = [
  "agave-votor-messages",
  "async-trait",
@@ -11075,8 +11078,8 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc-client-api"
-version = "4.2.0-rc.1"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
+version = "4.2.0"
+source = "git+https://github.com/jito-foundation/jito-solana.git?tag=v4.2.0-jito#13fa43a6611c82183594c40210a0126009f6f565"
 dependencies = [
  "anyhow",
  "jsonrpc-core",
@@ -11098,8 +11101,8 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc-client-nonce-utils"
-version = "4.2.0-rc.1"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
+version = "4.2.0"
+source = "git+https://github.com/jito-foundation/jito-solana.git?tag=v4.2.0-jito#13fa43a6611c82183594c40210a0126009f6f565"
 dependencies = [
  "solana-account 4.3.1",
  "solana-commitment-config 3.1.1",
@@ -11114,8 +11117,8 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc-client-types"
-version = "4.2.0-rc.1"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
+version = "4.2.0"
+source = "git+https://github.com/jito-foundation/jito-solana.git?tag=v4.2.0-jito#13fa43a6611c82183594c40210a0126009f6f565"
 dependencies = [
  "base64 0.22.1",
  "bs58 0.5.1",
@@ -11138,8 +11141,8 @@ dependencies = [
 
 [[package]]
 name = "solana-runtime"
-version = "4.2.0-rc.1"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
+version = "4.2.0"
+source = "git+https://github.com/jito-foundation/jito-solana.git?tag=v4.2.0-jito#13fa43a6611c82183594c40210a0126009f6f565"
 dependencies = [
  "agave-bls-cert-verify",
  "agave-feature-set",
@@ -11251,7 +11254,7 @@ dependencies = [
  "solana-sysvar-id 3.1.0",
  "solana-time-utils 3.0.0",
  "solana-transaction 4.1.5",
- "solana-transaction-context 4.2.0-rc.1",
+ "solana-transaction-context 4.2.0",
  "solana-transaction-error 3.3.1",
  "solana-transaction-status-client-types",
  "solana-unified-scheduler-logic",
@@ -11270,8 +11273,8 @@ dependencies = [
 
 [[package]]
 name = "solana-runtime-transaction"
-version = "4.2.0-rc.1"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
+version = "4.2.0"
+source = "git+https://github.com/jito-foundation/jito-solana.git?tag=v4.2.0-jito#13fa43a6611c82183594c40210a0126009f6f565"
 dependencies = [
  "agave-feature-set",
  "agave-transaction-view",
@@ -11285,7 +11288,7 @@ dependencies = [
  "solana-signature 3.4.1",
  "solana-svm-transaction",
  "solana-transaction 4.1.5",
- "solana-transaction-context 4.2.0-rc.1",
+ "solana-transaction-context 4.2.0",
  "solana-transaction-error 3.3.1",
  "wincode",
 ]
@@ -11600,8 +11603,8 @@ dependencies = [
 
 [[package]]
 name = "solana-send-transaction-service"
-version = "4.2.0-rc.1"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
+version = "4.2.0"
+source = "git+https://github.com/jito-foundation/jito-solana.git?tag=v4.2.0-jito#13fa43a6611c82183594c40210a0126009f6f565"
 dependencies = [
  "async-trait",
  "crossbeam-channel",
@@ -11974,8 +11977,8 @@ dependencies = [
 
 [[package]]
 name = "solana-storage-bigtable"
-version = "4.2.0-rc.1"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
+version = "4.2.0"
+source = "git+https://github.com/jito-foundation/jito-solana.git?tag=v4.2.0-jito#13fa43a6611c82183594c40210a0126009f6f565"
 dependencies = [
  "agave-reserved-account-keys",
  "base64 0.22.1",
@@ -12011,8 +12014,8 @@ dependencies = [
 
 [[package]]
 name = "solana-storage-proto"
-version = "4.2.0-rc.1"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
+version = "4.2.0"
+source = "git+https://github.com/jito-foundation/jito-solana.git?tag=v4.2.0-jito#13fa43a6611c82183594c40210a0126009f6f565"
 dependencies = [
  "bs58 0.5.1",
  "prost 0.14.4",
@@ -12026,7 +12029,7 @@ dependencies = [
  "solana-serde 3.0.0",
  "solana-signature 3.4.1",
  "solana-transaction 4.1.5",
- "solana-transaction-context 4.2.0-rc.1",
+ "solana-transaction-context 4.2.0",
  "solana-transaction-error 3.3.1",
  "solana-transaction-status",
  "thiserror 2.0.18",
@@ -12036,8 +12039,8 @@ dependencies = [
 
 [[package]]
 name = "solana-streamer"
-version = "4.2.0-rc.1"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
+version = "4.2.0"
+source = "git+https://github.com/jito-foundation/jito-solana.git?tag=v4.2.0-jito#13fa43a6611c82183594c40210a0126009f6f565"
 dependencies = [
  "agave-xdp",
  "bytes",
@@ -12073,8 +12076,8 @@ dependencies = [
 
 [[package]]
 name = "solana-svm"
-version = "4.2.0-rc.1"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
+version = "4.2.0"
+source = "git+https://github.com/jito-foundation/jito-solana.git?tag=v4.2.0-jito#13fa43a6611c82183594c40210a0126009f6f565"
 dependencies = [
  "ahash 0.8.12",
  "log",
@@ -12114,7 +12117,7 @@ dependencies = [
  "solana-system-interface 3.2.0",
  "solana-system-program",
  "solana-sysvar-id 3.1.0",
- "solana-transaction-context 4.2.0-rc.1",
+ "solana-transaction-context 4.2.0",
  "solana-transaction-error 3.3.1",
  "spl-generic-token",
  "thiserror 2.0.18",
@@ -12122,8 +12125,8 @@ dependencies = [
 
 [[package]]
 name = "solana-svm-callback"
-version = "4.2.0-rc.1"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
+version = "4.2.0"
+source = "git+https://github.com/jito-foundation/jito-solana.git?tag=v4.2.0-jito#13fa43a6611c82183594c40210a0126009f6f565"
 dependencies = [
  "solana-account 4.3.1",
  "solana-clock 3.1.1",
@@ -12133,26 +12136,26 @@ dependencies = [
 
 [[package]]
 name = "solana-svm-feature-set"
-version = "4.2.0-rc.1"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
+version = "4.2.0"
+source = "git+https://github.com/jito-foundation/jito-solana.git?tag=v4.2.0-jito#13fa43a6611c82183594c40210a0126009f6f565"
 
 [[package]]
 name = "solana-svm-log-collector"
-version = "4.2.0-rc.1"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
+version = "4.2.0"
+source = "git+https://github.com/jito-foundation/jito-solana.git?tag=v4.2.0-jito#13fa43a6611c82183594c40210a0126009f6f565"
 dependencies = [
  "log",
 ]
 
 [[package]]
 name = "solana-svm-measure"
-version = "4.2.0-rc.1"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
+version = "4.2.0"
+source = "git+https://github.com/jito-foundation/jito-solana.git?tag=v4.2.0-jito#13fa43a6611c82183594c40210a0126009f6f565"
 
 [[package]]
 name = "solana-svm-timings"
-version = "4.2.0-rc.1"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
+version = "4.2.0"
+source = "git+https://github.com/jito-foundation/jito-solana.git?tag=v4.2.0-jito#13fa43a6611c82183594c40210a0126009f6f565"
 dependencies = [
  "eager",
  "enum-iterator",
@@ -12175,16 +12178,16 @@ dependencies = [
 
 [[package]]
 name = "solana-svm-type-overrides"
-version = "4.2.0-rc.1"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
+version = "4.2.0"
+source = "git+https://github.com/jito-foundation/jito-solana.git?tag=v4.2.0-jito#13fa43a6611c82183594c40210a0126009f6f565"
 dependencies = [
  "rand 0.9.5",
 ]
 
 [[package]]
 name = "solana-syscalls"
-version = "4.2.0-rc.1"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
+version = "4.2.0"
+source = "git+https://github.com/jito-foundation/jito-solana.git?tag=v4.2.0-jito#13fa43a6611c82183594c40210a0126009f6f565"
 dependencies = [
  "bincode",
  "libsecp256k1 0.7.2",
@@ -12217,7 +12220,7 @@ dependencies = [
  "solana-svm-type-overrides",
  "solana-sysvar 4.1.0",
  "solana-sysvar-id 3.1.0",
- "solana-transaction-context 4.2.0-rc.1",
+ "solana-transaction-context 4.2.0",
  "thiserror 2.0.18",
  "wincode",
 ]
@@ -12271,8 +12274,8 @@ dependencies = [
 
 [[package]]
 name = "solana-system-program"
-version = "4.2.0-rc.1"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
+version = "4.2.0"
+source = "git+https://github.com/jito-foundation/jito-solana.git?tag=v4.2.0-jito#13fa43a6611c82183594c40210a0126009f6f565"
 dependencies = [
  "bincode",
  "log",
@@ -12289,7 +12292,7 @@ dependencies = [
  "solana-svm-log-collector",
  "solana-system-interface 3.2.0",
  "solana-sysvar 4.1.0",
- "solana-transaction-context 4.2.0-rc.1",
+ "solana-transaction-context 4.2.0",
 ]
 
 [[package]]
@@ -12463,8 +12466,8 @@ checksum = "0ced92c60aa76ec4780a9d93f3bd64dfa916e1b998eacc6f1c110f3f444f02c9"
 
 [[package]]
 name = "solana-tls-utils"
-version = "4.2.0-rc.1"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
+version = "4.2.0"
+source = "git+https://github.com/jito-foundation/jito-solana.git?tag=v4.2.0-jito#13fa43a6611c82183594c40210a0126009f6f565"
 dependencies = [
  "quinn",
  "rustls 0.23.42",
@@ -12476,8 +12479,8 @@ dependencies = [
 
 [[package]]
 name = "solana-tpu-client"
-version = "4.2.0-rc.1"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
+version = "4.2.0"
+source = "git+https://github.com/jito-foundation/jito-solana.git?tag=v4.2.0-jito#13fa43a6611c82183594c40210a0126009f6f565"
 dependencies = [
  "futures-util",
  "indicatif",
@@ -12505,8 +12508,8 @@ dependencies = [
 
 [[package]]
 name = "solana-tpu-client-next"
-version = "4.2.0-rc.1"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
+version = "4.2.0"
+source = "git+https://github.com/jito-foundation/jito-solana.git?tag=v4.2.0-jito#13fa43a6611c82183594c40210a0126009f6f565"
 dependencies = [
  "async-trait",
  "futures 0.3.32",
@@ -12601,8 +12604,8 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-context"
-version = "4.2.0-rc.1"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
+version = "4.2.0"
+source = "git+https://github.com/jito-foundation/jito-solana.git?tag=v4.2.0-jito#13fa43a6611c82183594c40210a0126009f6f565"
 dependencies = [
  "bincode",
  "serde",
@@ -12643,8 +12646,8 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-status"
-version = "4.2.0-rc.1"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
+version = "4.2.0"
+source = "git+https://github.com/jito-foundation/jito-solana.git?tag=v4.2.0-jito#13fa43a6611c82183594c40210a0126009f6f565"
 dependencies = [
  "Inflector",
  "agave-reserved-account-keys",
@@ -12673,20 +12676,21 @@ dependencies = [
  "solana-transaction-error 3.3.1",
  "solana-transaction-status-client-types",
  "solana-vote-interface 6.0.3",
+ "solana-zk-sdk-pod",
  "spl-associated-token-account-interface",
  "spl-memo-interface",
- "spl-token-2022-interface",
+ "spl-token-2022-interface 3.1.1",
  "spl-token-group-interface",
  "spl-token-interface 3.0.0",
- "spl-token-metadata-interface",
+ "spl-token-metadata-interface 1.0.1",
  "thiserror 2.0.18",
  "wincode",
 ]
 
 [[package]]
 name = "solana-transaction-status-client-types"
-version = "4.2.0-rc.1"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
+version = "4.2.0"
+source = "git+https://github.com/jito-foundation/jito-solana.git?tag=v4.2.0-jito#13fa43a6611c82183594c40210a0126009f6f565"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -12700,7 +12704,7 @@ dependencies = [
  "solana-reward-info 6.2.0",
  "solana-signature 3.4.1",
  "solana-transaction 4.1.5",
- "solana-transaction-context 4.2.0-rc.1",
+ "solana-transaction-context 4.2.0",
  "solana-transaction-error 3.3.1",
  "thiserror 2.0.18",
  "wincode",
@@ -12708,8 +12712,8 @@ dependencies = [
 
 [[package]]
 name = "solana-turbine"
-version = "4.2.0-rc.1"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
+version = "4.2.0"
+source = "git+https://github.com/jito-foundation/jito-solana.git?tag=v4.2.0-jito#13fa43a6611c82183594c40210a0126009f6f565"
 dependencies = [
  "agave-feature-set",
  "agave-votor",
@@ -12758,8 +12762,8 @@ dependencies = [
 
 [[package]]
 name = "solana-udp-client"
-version = "4.2.0-rc.1"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
+version = "4.2.0"
+source = "git+https://github.com/jito-foundation/jito-solana.git?tag=v4.2.0-jito#13fa43a6611c82183594c40210a0126009f6f565"
 dependencies = [
  "async-trait",
  "solana-connection-cache",
@@ -12771,8 +12775,8 @@ dependencies = [
 
 [[package]]
 name = "solana-unified-scheduler-logic"
-version = "4.2.0-rc.1"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
+version = "4.2.0"
+source = "git+https://github.com/jito-foundation/jito-solana.git?tag=v4.2.0-jito#13fa43a6611c82183594c40210a0126009f6f565"
 dependencies = [
  "assert_matches",
  "solana-clock 3.1.1",
@@ -12786,8 +12790,8 @@ dependencies = [
 
 [[package]]
 name = "solana-unified-scheduler-pool"
-version = "4.2.0-rc.1"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
+version = "4.2.0"
+source = "git+https://github.com/jito-foundation/jito-solana.git?tag=v4.2.0-jito#13fa43a6611c82183594c40210a0126009f6f565"
 dependencies = [
  "agave-banking-stage-ingress-types",
  "aquamarine",
@@ -12829,8 +12833,8 @@ checksum = "c5d2face763df5afeaa9509b9019968860e69cc1531ec8b4a2e6c7b702204d5a"
 
 [[package]]
 name = "solana-version"
-version = "4.2.0-rc.1"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
+version = "4.2.0"
+source = "git+https://github.com/jito-foundation/jito-solana.git?tag=v4.2.0-jito#13fa43a6611c82183594c40210a0126009f6f565"
 dependencies = [
  "agave-feature-set",
  "rand 0.9.5",
@@ -12844,8 +12848,8 @@ dependencies = [
 
 [[package]]
 name = "solana-vote"
-version = "4.2.0-rc.1"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
+version = "4.2.0"
+source = "git+https://github.com/jito-foundation/jito-solana.git?tag=v4.2.0-jito#13fa43a6611c82183594c40210a0126009f6f565"
 dependencies = [
  "bincode",
  "log",
@@ -12923,8 +12927,8 @@ dependencies = [
 
 [[package]]
 name = "solana-vote-program"
-version = "4.2.0-rc.1"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
+version = "4.2.0"
+source = "git+https://github.com/jito-foundation/jito-solana.git?tag=v4.2.0-jito#13fa43a6611c82183594c40210a0126009f6f565"
 dependencies = [
  "agave-feature-set",
  "bincode",
@@ -12943,7 +12947,7 @@ dependencies = [
  "solana-sdk-ids 3.1.0",
  "solana-slot-hashes 3.1.0",
  "solana-system-interface 3.2.0",
- "solana-transaction-context 4.2.0-rc.1",
+ "solana-transaction-context 4.2.0",
  "solana-vote-interface 6.0.3",
 ]
 
@@ -12968,9 +12972,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-zk-elgamal-proof-interface"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8da7f01db2148a1dc16261ff1dc6f3930a1e255a33cece4f1b56658694f27f7"
+dependencies = [
+ "bytemuck",
+ "bytemuck_derive",
+ "num-derive",
+ "num-traits",
+ "solana-address 2.6.1",
+ "solana-instruction 3.4.0",
+ "solana-sdk-ids 3.1.0",
+ "solana-zk-sdk-pod",
+]
+
+[[package]]
 name = "solana-zk-elgamal-proof-program"
-version = "4.2.0-rc.1"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
+version = "4.2.0"
+source = "git+https://github.com/jito-foundation/jito-solana.git?tag=v4.2.0-jito#13fa43a6611c82183594c40210a0126009f6f565"
 dependencies = [
  "bytemuck",
  "solana-instruction 3.4.0",
@@ -13052,9 +13072,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-zk-sdk-pod"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a800583b7a4cea3e851686af162cc6e4712eef97fa91dfa9aca2459b95c84777"
+dependencies = [
+ "base64 0.22.1",
+ "bytemuck",
+ "bytemuck_derive",
+ "solana-nullable",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "solana-zk-token-proof-program"
-version = "4.2.0-rc.1"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
+version = "4.2.0"
+source = "git+https://github.com/jito-foundation/jito-solana.git?tag=v4.2.0-jito#13fa43a6611c82183594c40210a0126009f6f565"
 dependencies = [
  "solana-program-runtime",
 ]
@@ -13196,10 +13229,40 @@ dependencies = [
  "solana-sdk-ids 3.1.0",
  "solana-zk-sdk 4.0.0",
  "spl-pod",
- "spl-token-confidential-transfer-proof-extraction",
+ "spl-token-confidential-transfer-proof-extraction 0.5.1",
  "spl-token-confidential-transfer-proof-generation",
  "spl-token-group-interface",
- "spl-token-metadata-interface",
+ "spl-token-metadata-interface 0.8.0",
+ "spl-type-length-value",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "spl-token-2022-interface"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "821d96d034ea31c4965d182c742153c491ae0abee531331b55771086c5030d86"
+dependencies = [
+ "arrayref",
+ "bytemuck",
+ "getrandom 0.2.17",
+ "num-derive",
+ "num-traits",
+ "num_enum",
+ "solana-account-info 3.1.1",
+ "solana-address 2.6.1",
+ "solana-instruction 3.4.0",
+ "solana-nullable",
+ "solana-program-error 3.0.1",
+ "solana-program-option 3.1.0",
+ "solana-program-pack 3.1.0",
+ "solana-sdk-ids 3.1.0",
+ "solana-zero-copy",
+ "solana-zk-elgamal-proof-interface",
+ "solana-zk-sdk-pod",
+ "spl-token-confidential-transfer-proof-extraction 0.6.1",
+ "spl-token-group-interface",
+ "spl-token-metadata-interface 1.0.1",
  "spl-type-length-value",
  "thiserror 2.0.18",
 ]
@@ -13221,6 +13284,26 @@ dependencies = [
  "solana-sdk-ids 3.1.0",
  "solana-zk-sdk 4.0.0",
  "spl-pod",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "spl-token-confidential-transfer-proof-extraction"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c1a845ec724e807643a04f1d43439ee3571dd913848112ac76aa90b850eaf7c"
+dependencies = [
+ "bytemuck",
+ "solana-account-info 3.1.1",
+ "solana-address 2.6.1",
+ "solana-curve25519 4.0.1",
+ "solana-instruction 3.4.0",
+ "solana-instructions-sysvar 3.0.1",
+ "solana-msg 3.1.0",
+ "solana-program-error 3.0.1",
+ "solana-sdk-ids 3.1.0",
+ "solana-zk-elgamal-proof-interface",
+ "solana-zk-sdk-pod",
  "thiserror 2.0.18",
 ]
 
@@ -13309,6 +13392,26 @@ dependencies = [
  "solana-pubkey 3.0.0",
  "spl-discriminator",
  "spl-pod",
+ "spl-type-length-value",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "spl-token-metadata-interface"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3d96f175e7022ff200464dfa75a3708a4e9b70c83c4ecd04fe52ee479f4fef"
+dependencies = [
+ "borsh 1.8.0",
+ "num-derive",
+ "num-traits",
+ "num_enum",
+ "solana-address 2.6.1",
+ "solana-borsh 3.0.2",
+ "solana-instruction 3.4.0",
+ "solana-nullable",
+ "solana-program-error 3.0.1",
+ "spl-discriminator",
  "spl-type-length-value",
  "thiserror 2.0.18",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1906,30 +1906,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
-name = "cloud-storage"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7602ac4363f68ac757d6b87dd5d850549a14d37489902ae639c06ecec06ad275"
-dependencies = [
- "async-trait",
- "base64 0.13.1",
- "bytes",
- "chrono",
- "dotenv",
- "futures-util",
- "hex",
- "jsonwebtoken",
- "lazy_static",
- "pem 0.8.3",
- "percent-encoding 2.3.2",
- "reqwest 0.11.27",
- "ring 0.16.20",
- "serde",
- "serde_json",
- "tokio",
-]
-
-[[package]]
 name = "cmov"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3234,13 +3210,10 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap 4.6.2",
- "cloud-storage",
  "env_logger 0.10.2",
- "futures-util",
  "hostname",
  "log",
  "regex",
- "serde_json",
  "solana-client",
  "solana-metrics",
  "tokio",
@@ -4195,7 +4168,6 @@ dependencies = [
  "anyhow",
  "borsh 1.8.0",
  "solana-program 4.0.0",
- "solana-pubkey 4.2.0",
 ]
 
 [[package]]
@@ -4302,7 +4274,6 @@ dependencies = [
  "anyhow",
  "borsh 1.8.0",
  "solana-program 4.0.0",
- "solana-pubkey 4.2.0",
 ]
 
 [[package]]
@@ -4326,7 +4297,6 @@ dependencies = [
  "jito-restaking-client",
  "jito-restaking-core",
  "jito-restaking-program",
- "jito-restaking-sdk",
  "jito-tip-distribution-sdk",
  "jito-tip-router-client",
  "jito-tip-router-core",
@@ -4334,23 +4304,19 @@ dependencies = [
  "jito-vault-client",
  "jito-vault-core",
  "jito-vault-program",
- "jito-vault-sdk",
  "log",
  "num-derive",
  "num-traits",
  "solana-account-decoder",
  "solana-account-info 3.1.1",
- "solana-address-lookup-table-interface 3.1.0",
  "solana-cli-config",
  "solana-client",
  "solana-commitment-config 3.1.1",
  "solana-compute-budget-interface 3.0.0",
- "solana-genesis-config 4.0.0",
  "solana-metrics",
  "solana-program 4.0.0",
  "solana-rpc-client",
  "solana-sdk 4.0.1",
- "solana-stake-interface 4.3.0",
  "solana-system-interface 3.2.0",
  "solana-transaction-status",
  "spl-associated-token-account-interface",
@@ -4438,7 +4404,6 @@ dependencies = [
  "solana-system-interface 3.2.0",
  "solana-vote-interface 6.0.3",
  "spl-associated-token-account-interface",
- "spl-pod",
  "spl-token-interface 2.0.0",
  "thiserror 2.0.18",
  "tokio",
@@ -4479,11 +4444,9 @@ name = "jito-tip-router-shank-cli"
 version = "0.0.1"
 dependencies = [
  "anyhow",
- "clap 4.6.2",
  "env_logger 0.10.2",
  "envfile",
  "log",
- "shank",
  "shank_idl",
 ]
 
@@ -4753,20 +4716,6 @@ dependencies = [
  "tokio-stream",
  "tokio-util 0.6.10",
  "unicase",
-]
-
-[[package]]
-name = "jsonwebtoken"
-version = "7.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afabcc15e437a6484fc4f12d0fd63068fe457bf93f1c148d3d9649c60b103f32"
-dependencies = [
- "base64 0.12.3",
- "pem 0.8.3",
- "ring 0.16.20",
- "serde",
- "serde_json",
- "simple_asn1",
 ]
 
 [[package]]
@@ -5144,26 +5093,14 @@ dependencies = [
 name = "meta-merkle-tree"
 version = "0.0.1"
 dependencies = [
- "borsh 1.8.0",
- "bytemuck",
  "fast-math",
  "hex",
- "jito-bytemuck",
- "jito-jsm-core",
- "jito-restaking-core",
- "jito-restaking-sdk",
  "jito-vault-core",
- "jito-vault-sdk",
  "log",
- "rand 0.8.7",
  "serde",
  "serde_json",
- "shank",
  "solana-program 4.0.0",
  "solana-sdk 4.0.1",
- "spl-associated-token-account-interface",
- "spl-math",
- "spl-token-interface 2.0.0",
  "thiserror 2.0.18",
  "wincode",
 ]
@@ -5660,17 +5597,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
 dependencies = [
  "digest 0.10.7",
-]
-
-[[package]]
-name = "pem"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd56cbd21fea48d0c440b41cd69c589faacade08c992d9a54e471b79d0fd13eb"
-dependencies = [
- "base64 0.13.1",
- "once_cell",
- "regex",
 ]
 
 [[package]]
@@ -6283,7 +6209,7 @@ dependencies = [
  "lru-slab",
  "rand 0.10.2",
  "rand_pcg",
- "ring 0.17.14",
+ "ring",
  "rustc-hash",
  "rustls 0.23.42",
  "rustls-pki-types",
@@ -6541,7 +6467,7 @@ dependencies = [
  "lru 0.7.8",
  "parking_lot 0.11.2",
  "smallvec",
- "spin 0.9.9",
+ "spin",
 ]
 
 [[package]]
@@ -6637,12 +6563,10 @@ dependencies = [
  "tokio",
  "tokio-native-tls",
  "tokio-rustls 0.24.1",
- "tokio-util 0.7.18",
  "tower-service",
  "url 2.5.8",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams",
  "web-sys",
  "webpki-roots 0.25.4",
  "winreg",
@@ -6752,21 +6676,6 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.16.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
-dependencies = [
- "cc",
- "libc",
- "once_cell",
- "spin 0.5.2",
- "untrusted 0.7.1",
- "web-sys",
- "winapi",
-]
-
-[[package]]
-name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
@@ -6775,7 +6684,7 @@ dependencies = [
  "cfg-if 1.0.4",
  "getrandom 0.2.17",
  "libc",
- "untrusted 0.9.0",
+ "untrusted",
  "windows-sys 0.52.0",
 ]
 
@@ -6935,7 +6844,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
 dependencies = [
  "log",
- "ring 0.17.14",
+ "ring",
  "rustls-webpki 0.101.7",
  "sct",
 ]
@@ -6948,7 +6857,7 @@ checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
 dependencies = [
  "log",
  "once_cell",
- "ring 0.17.14",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki 0.103.13",
  "subtle",
@@ -7019,8 +6928,8 @@ version = "0.101.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
- "ring 0.17.14",
- "untrusted 0.9.0",
+ "ring",
+ "untrusted",
 ]
 
 [[package]]
@@ -7029,9 +6938,9 @@ version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
- "ring 0.17.14",
+ "ring",
  "rustls-pki-types",
- "untrusted 0.9.0",
+ "untrusted",
 ]
 
 [[package]]
@@ -7109,8 +7018,8 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
 dependencies = [
- "ring 0.17.14",
- "untrusted 0.9.0",
+ "ring",
+ "untrusted",
 ]
 
 [[package]]
@@ -7554,17 +7463,6 @@ name = "simpl"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a30f10c911c0355f80f1c2faa8096efc4a58cdf8590b954d5b395efa071c711"
-
-[[package]]
-name = "simple_asn1"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "692ca13de57ce0613a363c8c2f1de925adebc81b04c923ac60c5488bb44abe4b"
-dependencies = [
- "chrono",
- "num-bigint 0.2.6",
- "num-traits",
-]
 
 [[package]]
 name = "siphasher"
@@ -12152,7 +12050,7 @@ dependencies = [
  "log",
  "nix",
  "num_cpus",
- "pem 1.1.1",
+ "pem",
  "quinn",
  "rand 0.9.5",
  "rustls 0.23.42",
@@ -13163,12 +13061,6 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
-
-[[package]]
-name = "spin"
 version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
@@ -13921,8 +13813,6 @@ dependencies = [
  "clap 4.6.2",
  "crossbeam-channel",
  "env_logger 0.10.2",
- "hex",
- "imbl",
  "itertools 0.11.0",
  "jito-bytemuck",
  "jito-priority-fee-distribution-sdk",
@@ -13936,7 +13826,6 @@ dependencies = [
  "log",
  "meta-merkle-tree",
  "rand 0.8.7",
- "serde",
  "serde_json",
  "solana-account-decoder",
  "solana-accounts-db",
@@ -13960,11 +13849,9 @@ dependencies = [
  "solana-sdk 4.0.1",
  "solana-shred-version 3.0.1",
  "solana-stake-interface 4.3.0",
- "solana-streamer",
  "solana-system-interface 3.2.0",
  "solana-transaction-status",
  "solana-unified-scheduler-pool",
- "solana-vote",
  "spl-memo-interface",
  "tempfile",
  "thiserror 2.0.18",
@@ -14555,12 +14442,6 @@ checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
-
-[[package]]
-name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
@@ -14756,19 +14637,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "wasm-streams"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
-dependencies = [
- "futures-util",
- "js-sys",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,8 +56,8 @@ dependencies = [
 
 [[package]]
 name = "agave-banking-stage-ingress-types"
-version = "4.1.2"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=bdf2e1d844b6453819ce6d4a24bc15df830908a4#bdf2e1d844b6453819ce6d4a24bc15df830908a4"
+version = "4.2.0-rc.1"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
 dependencies = [
  "crossbeam-channel",
  "solana-perf",
@@ -65,8 +65,8 @@ dependencies = [
 
 [[package]]
 name = "agave-bls-cert-verify"
-version = "4.1.2"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=bdf2e1d844b6453819ce6d4a24bc15df830908a4#bdf2e1d844b6453819ce6d4a24bc15df830908a4"
+version = "4.2.0-rc.1"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
 dependencies = [
  "agave-votor-messages",
  "bitvec",
@@ -79,9 +79,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "agave-bls-sigverify"
+version = "4.2.0-rc.1"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
+dependencies = [
+ "agave-bls-cert-verify",
+ "agave-math-utils",
+ "agave-votor-messages",
+ "bitvec",
+ "crossbeam-channel",
+ "log",
+ "parking_lot 0.12.5",
+ "qualifier_attr",
+ "rayon",
+ "solana-bls-signatures",
+ "solana-clock 3.1.1",
+ "solana-gossip",
+ "solana-ledger",
+ "solana-measure",
+ "solana-metrics",
+ "solana-packet 4.2.0",
+ "solana-perf",
+ "solana-pubkey 4.2.0",
+ "solana-runtime",
+ "solana-signer-store",
+ "solana-streamer",
+ "thiserror 2.0.18",
+ "wincode",
+]
+
+[[package]]
+name = "agave-cpu-utils"
+version = "4.2.0-rc.1"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "agave-feature-set"
-version = "4.1.2"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=bdf2e1d844b6453819ce6d4a24bc15df830908a4#bdf2e1d844b6453819ce6d4a24bc15df830908a4"
+version = "4.2.0-rc.1"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
 dependencies = [
  "ahash 0.8.12",
  "solana-epoch-schedule 3.2.0",
@@ -94,8 +132,8 @@ dependencies = [
 
 [[package]]
 name = "agave-fs"
-version = "4.1.2"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=bdf2e1d844b6453819ce6d4a24bc15df830908a4#bdf2e1d844b6453819ce6d4a24bc15df830908a4"
+version = "4.2.0-rc.1"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
 dependencies = [
  "agave-io-uring",
  "io-uring",
@@ -109,8 +147,8 @@ dependencies = [
 
 [[package]]
 name = "agave-geyser-plugin-interface"
-version = "4.1.2"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=bdf2e1d844b6453819ce6d4a24bc15df830908a4#bdf2e1d844b6453819ce6d4a24bc15df830908a4"
+version = "4.2.0-rc.1"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
 dependencies = [
  "log",
  "solana-clock 3.1.1",
@@ -124,8 +162,8 @@ dependencies = [
 
 [[package]]
 name = "agave-io-uring"
-version = "4.1.2"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=bdf2e1d844b6453819ce6d4a24bc15df830908a4#bdf2e1d844b6453819ce6d4a24bc15df830908a4"
+version = "4.2.0-rc.1"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
 dependencies = [
  "io-uring",
  "libc",
@@ -136,8 +174,8 @@ dependencies = [
 
 [[package]]
 name = "agave-logger"
-version = "4.1.2"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=bdf2e1d844b6453819ce6d4a24bc15df830908a4#bdf2e1d844b6453819ce6d4a24bc15df830908a4"
+version = "4.2.0-rc.1"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
 dependencies = [
  "env_logger 0.11.11",
  "libc",
@@ -147,16 +185,16 @@ dependencies = [
 
 [[package]]
 name = "agave-math-utils"
-version = "4.1.2"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=bdf2e1d844b6453819ce6d4a24bc15df830908a4#bdf2e1d844b6453819ce6d4a24bc15df830908a4"
+version = "4.2.0-rc.1"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
 dependencies = [
  "num-traits",
 ]
 
 [[package]]
 name = "agave-precompiles"
-version = "4.1.2"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=bdf2e1d844b6453819ce6d4a24bc15df830908a4#bdf2e1d844b6453819ce6d4a24bc15df830908a4"
+version = "4.2.0-rc.1"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
 dependencies = [
  "agave-feature-set",
  "bincode",
@@ -175,16 +213,16 @@ dependencies = [
 
 [[package]]
 name = "agave-random"
-version = "4.1.2"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=bdf2e1d844b6453819ce6d4a24bc15df830908a4#bdf2e1d844b6453819ce6d4a24bc15df830908a4"
+version = "4.2.0-rc.1"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
 dependencies = [
  "rand 0.9.5",
 ]
 
 [[package]]
 name = "agave-reserved-account-keys"
-version = "4.1.2"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=bdf2e1d844b6453819ce6d4a24bc15df830908a4#bdf2e1d844b6453819ce6d4a24bc15df830908a4"
+version = "4.2.0-rc.1"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
 dependencies = [
  "agave-feature-set",
  "solana-pubkey 4.2.0",
@@ -193,13 +231,13 @@ dependencies = [
 
 [[package]]
 name = "agave-scheduler-bindings"
-version = "4.1.2"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=bdf2e1d844b6453819ce6d4a24bc15df830908a4#bdf2e1d844b6453819ce6d4a24bc15df830908a4"
+version = "4.2.0-rc.1"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
 
 [[package]]
 name = "agave-scheduling-utils"
-version = "4.1.2"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=bdf2e1d844b6453819ce6d4a24bc15df830908a4#bdf2e1d844b6453819ce6d4a24bc15df830908a4"
+version = "4.2.0-rc.1"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
 dependencies = [
  "agave-feature-set",
  "agave-scheduler-bindings",
@@ -212,14 +250,15 @@ dependencies = [
  "slotmap",
  "solana-fee",
  "solana-pubkey 4.2.0",
+ "solana-runtime-transaction",
  "solana-transaction-error 3.3.1",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "agave-snapshots"
-version = "4.1.2"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=bdf2e1d844b6453819ce6d4a24bc15df830908a4#bdf2e1d844b6453819ce6d4a24bc15df830908a4"
+version = "4.2.0-rc.1"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
 dependencies = [
  "agave-fs",
  "bincode",
@@ -248,43 +287,38 @@ dependencies = [
 
 [[package]]
 name = "agave-transaction-view"
-version = "4.1.2"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=bdf2e1d844b6453819ce6d4a24bc15df830908a4#bdf2e1d844b6453819ce6d4a24bc15df830908a4"
+version = "4.2.0-rc.1"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
 dependencies = [
  "bytes",
  "solana-hash 4.5.0",
  "solana-message 4.3.0",
  "solana-packet 4.2.0",
- "solana-program-runtime",
  "solana-pubkey 4.2.0",
  "solana-sdk-ids 3.1.0",
  "solana-short-vec 3.2.2",
  "solana-signature 3.4.1",
  "solana-svm-transaction",
  "solana-transaction 4.1.5",
- "solana-transaction-context 4.1.2",
 ]
 
 [[package]]
 name = "agave-votor"
-version = "4.1.2"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=bdf2e1d844b6453819ce6d4a24bc15df830908a4#bdf2e1d844b6453819ce6d4a24bc15df830908a4"
+version = "4.2.0-rc.1"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
 dependencies = [
+ "agave-bls-sigverify",
  "agave-logger",
  "agave-math-utils",
  "agave-votor-messages",
- "bincode",
  "bitvec",
  "crossbeam-channel",
  "itertools 0.14.0",
  "lazy-lru",
  "log",
  "parking_lot 0.12.5",
- "qualifier_attr",
  "serde",
  "serde_bytes",
- "solana-accounts-db",
- "solana-bloom",
  "solana-bls-signatures",
  "solana-client",
  "solana-clock 3.1.1",
@@ -293,6 +327,7 @@ dependencies = [
  "solana-gossip",
  "solana-hash 4.5.0",
  "solana-keypair 3.1.2",
+ "solana-leader-schedule",
  "solana-ledger",
  "solana-measure",
  "solana-metrics",
@@ -306,18 +341,17 @@ dependencies = [
  "solana-time-utils 3.0.0",
  "solana-transaction 4.1.5",
  "solana-transaction-error 3.3.1",
- "solana-vote",
- "solana-vote-program",
  "thiserror 2.0.18",
  "wincode",
 ]
 
 [[package]]
 name = "agave-votor-messages"
-version = "4.1.2"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=bdf2e1d844b6453819ce6d4a24bc15df830908a4#bdf2e1d844b6453819ce6d4a24bc15df830908a4"
+version = "4.2.0-rc.1"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
 dependencies = [
  "agave-feature-set",
+ "crossbeam-channel",
  "log",
  "serde",
  "solana-address 2.6.1",
@@ -334,16 +368,18 @@ dependencies = [
 
 [[package]]
 name = "agave-xdp"
-version = "4.1.2"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=bdf2e1d844b6453819ce6d4a24bc15df830908a4#bdf2e1d844b6453819ce6d4a24bc15df830908a4"
+version = "4.2.0-rc.1"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
 dependencies = [
+ "agave-cpu-utils",
  "agave-xdp-ebpf",
  "arc-swap",
+ "arrayvec",
  "aya",
  "bytes",
  "caps",
- "core_affinity",
  "crossbeam-channel",
+ "crossbeam-queue",
  "libc",
  "log",
  "thiserror 2.0.18",
@@ -351,8 +387,8 @@ dependencies = [
 
 [[package]]
 name = "agave-xdp-ebpf"
-version = "4.1.2"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=bdf2e1d844b6453819ce6d4a24bc15df830908a4#bdf2e1d844b6453819ce6d4a24bc15df830908a4"
+version = "4.2.0-rc.1"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
 dependencies = [
  "aya",
  "aya-ebpf",
@@ -1156,19 +1192,20 @@ dependencies = [
 
 [[package]]
 name = "aya"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d18bc4e506fbb85ab7392ed993a7db4d1a452c71b75a246af4a80ab8c9d2dd50"
+checksum = "66e644424fada9fff4fdc63848db1732fb69b626e8328202ef55c03df1f4d939"
 dependencies = [
  "assert_matches",
  "aya-obj",
  "bitflags 2.13.1",
- "bytes",
+ "hashbrown 0.17.1",
  "libc",
  "log",
  "object",
  "once_cell",
- "thiserror 1.0.69",
+ "scopeguard",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1226,16 +1263,14 @@ dependencies = [
 
 [[package]]
 name = "aya-obj"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c51b96c5a8ed8705b40d655273bc4212cbbf38d4e3be2788f36306f154523ec7"
+checksum = "8c76b9c75d9cdc155ff8f6a06d61e873f67bf47be8cfa92a3b5aaea43f4b4077"
 dependencies = [
  "bytes",
- "core-error",
- "hashbrown 0.15.5",
  "log",
  "object",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1285,22 +1320,42 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.69.5"
+version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
  "bitflags 2.13.1",
  "cexpr",
  "clang-sys",
- "itertools 0.10.5",
- "lazy_static",
- "lazycell",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash 1.1.0",
+ "rustc-hash",
  "shlex 1.3.0",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "bip39"
+version = "2.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90dbd31c98227229239363921e60fcf5e558e43ec69094d46fc4996f08d1d5bc"
+dependencies = [
+ "bitcoin_hashes",
+ "rand 0.8.7",
+ "rand_core 0.6.4",
+ "serde",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "bitcoin_hashes"
+version = "0.14.101"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bca4c7abb40c8817d77403c880988cfd484f23ab2365726afb2f798363e2c4a2"
+dependencies = [
+ "hex-conservative",
 ]
 
 [[package]]
@@ -1784,7 +1839,6 @@ checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
 dependencies = [
  "glob",
  "libc",
- "libloading 0.8.9",
 ]
 
 [[package]]
@@ -2035,15 +2089,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "core-error"
-version = "0.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efcdb2972eb64230b4c50646d8498ff73f5128d196a90c7236eec4cbe8619b8f"
-dependencies = [
- "version_check",
-]
-
-[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2068,17 +2113,6 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
-
-[[package]]
-name = "core_affinity"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a034b3a7b624016c6e13f5df875747cc25f884156aad2abd12b6c46797971342"
-dependencies = [
- "libc",
- "num_cpus",
- "winapi",
-]
 
 [[package]]
 name = "cpufeatures"
@@ -2131,6 +2165,15 @@ name = "crossbeam-epoch"
 version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "803d13fb3b09d88be9f4dbc29062c66b19bf7170867ceb746d2a8689bf6c7a26"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -2537,29 +2580,6 @@ name = "displaydoc"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.119",
-]
-
-[[package]]
-name = "dlopen2"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e2c5bd4158e66d1e215c49b837e11d62f3267b30c92f1d171c4d3105e3dc4d4"
-dependencies = [
- "dlopen2_derive",
- "libc",
- "once_cell",
- "winapi",
-]
-
-[[package]]
-name = "dlopen2_derive"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fbbb781877580993a8707ec48672673ec7b81eeba04cfd2310bd28c08e47c8f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3491,6 +3511,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hex-conservative"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fda06d18ac606267c40c04e41b9947729bf8b9efe74bd4e82b61a5f26a510b9f"
+dependencies = [
+ "arrayvec",
+]
+
+[[package]]
 name = "histogram"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4155,7 +4184,7 @@ dependencies = [
  "solana-system-interface 3.2.0",
  "spl-associated-token-account-interface",
  "spl-token-2022-interface",
- "spl-token-interface",
+ "spl-token-interface 2.0.0",
  "thiserror 2.0.18",
 ]
 
@@ -4171,8 +4200,8 @@ dependencies = [
 
 [[package]]
 name = "jito-protos"
-version = "4.1.2"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=bdf2e1d844b6453819ce6d4a24bc15df830908a4#bdf2e1d844b6453819ce6d4a24bc15df830908a4"
+version = "4.2.0-rc.1"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
 dependencies = [
  "bytes",
  "prost 0.14.4",
@@ -4218,7 +4247,7 @@ dependencies = [
  "shank",
  "solana-program 3.0.0",
  "spl-associated-token-account-interface",
- "spl-token-interface",
+ "spl-token-interface 2.0.0",
  "thiserror 2.0.18",
 ]
 
@@ -4239,7 +4268,7 @@ dependencies = [
  "solana-security-txt",
  "spl-associated-token-account-interface",
  "spl-token-2022-interface",
- "spl-token-interface",
+ "spl-token-interface 2.0.0",
  "thiserror 2.0.18",
 ]
 
@@ -4321,11 +4350,11 @@ dependencies = [
  "solana-program 4.0.0",
  "solana-rpc-client",
  "solana-sdk 4.0.1",
- "solana-stake-interface 3.1.0",
+ "solana-stake-interface 4.3.0",
  "solana-system-interface 3.2.0",
  "solana-transaction-status",
  "spl-associated-token-account-interface",
- "spl-token-interface",
+ "spl-token-interface 2.0.0",
  "switchboard-on-demand",
  "thiserror 2.0.18",
  "tokio",
@@ -4370,7 +4399,7 @@ dependencies = [
  "solana-system-interface 3.2.0",
  "spl-associated-token-account-interface",
  "spl-math",
- "spl-token-interface",
+ "spl-token-interface 2.0.0",
  "thiserror 2.0.18",
 ]
 
@@ -4405,12 +4434,12 @@ dependencies = [
  "solana-program-test",
  "solana-sdk 4.0.1",
  "solana-security-txt",
- "solana-stake-interface 3.1.0",
+ "solana-stake-interface 4.3.0",
  "solana-system-interface 3.2.0",
  "solana-vote-interface 6.0.3",
  "spl-associated-token-account-interface",
  "spl-pod",
- "spl-token-interface",
+ "spl-token-interface 2.0.0",
  "thiserror 2.0.18",
  "tokio",
 ]
@@ -4440,7 +4469,7 @@ dependencies = [
  "solana-security-txt",
  "solana-system-interface 3.2.0",
  "spl-associated-token-account-interface",
- "spl-token-interface",
+ "spl-token-interface 2.0.0",
  "switchboard-on-demand",
  "thiserror 2.0.18",
 ]
@@ -4490,7 +4519,7 @@ dependencies = [
  "solana-system-interface 3.2.0",
  "spl-associated-token-account-interface",
  "spl-token-2022-interface",
- "spl-token-interface",
+ "spl-token-interface 2.0.0",
  "thiserror 2.0.18",
 ]
 
@@ -4512,7 +4541,7 @@ dependencies = [
  "solana-system-interface 3.2.0",
  "spl-associated-token-account-interface",
  "spl-token-2022-interface",
- "spl-token-interface",
+ "spl-token-interface 2.0.0",
  "thiserror 2.0.18",
 ]
 
@@ -4527,7 +4556,7 @@ dependencies = [
  "solana-program 3.0.0",
  "solana-system-interface 3.2.0",
  "spl-associated-token-account-interface",
- "spl-token-interface",
+ "spl-token-interface 2.0.0",
  "thiserror 2.0.18",
 ]
 
@@ -4785,12 +4814,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
-name = "lazycell"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
-
-[[package]]
 name = "libbz2-rs-sys"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4801,16 +4824,6 @@ name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
-
-[[package]]
-name = "libloading"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
-dependencies = [
- "cfg-if 1.0.4",
- "windows-link",
-]
 
 [[package]]
 name = "libloading"
@@ -4839,14 +4852,13 @@ dependencies = [
 
 [[package]]
 name = "librocksdb-sys"
-version = "0.16.0+8.10.0"
+version = "0.17.3+10.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce3d60bc059831dc1c83903fb45c103f75db65c5a7bf22272764d9cc683e348c"
+checksum = "cef2a00ee60fe526157c9023edab23943fae1ce2ab6f4abb2a807c1746835de9"
 dependencies = [
  "bindgen",
  "bzip2-sys",
  "cc",
- "glob",
  "libc",
  "libz-sys",
  "lz4-sys",
@@ -5151,7 +5163,7 @@ dependencies = [
  "solana-sdk 4.0.1",
  "spl-associated-token-account-interface",
  "spl-math",
- "spl-token-interface",
+ "spl-token-interface 2.0.0",
  "thiserror 2.0.18",
  "wincode",
 ]
@@ -5435,12 +5447,12 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.36.7"
+version = "0.39.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
+checksum = "2e5a6c098c7a3b6547378093f5cc30bc54fd361ce711e05293a5cc589562739b"
 dependencies = [
  "crc32fast",
- "hashbrown 0.15.5",
+ "hashbrown 0.17.1",
  "indexmap 2.14.0",
  "memchr",
 ]
@@ -5648,16 +5660,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
 dependencies = [
  "digest 0.10.7",
-]
-
-[[package]]
-name = "pbkdf2"
-version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
-dependencies = [
- "digest 0.10.7",
- "hmac 0.12.1",
 ]
 
 [[package]]
@@ -6046,7 +6048,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -6260,7 +6262,7 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash 2.1.3",
+ "rustc-hash",
  "rustls 0.23.42",
  "socket2 0.6.5",
  "thiserror 2.0.18",
@@ -6282,7 +6284,7 @@ dependencies = [
  "rand 0.10.2",
  "rand_pcg",
  "ring 0.17.14",
- "rustc-hash 2.1.3",
+ "rustc-hash",
  "rustls 0.23.42",
  "rustls-pki-types",
  "rustls-platform-verifier",
@@ -6808,9 +6810,9 @@ dependencies = [
 
 [[package]]
 name = "rocksdb"
-version = "0.22.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bd13e55d6d7b8cd0ea569161127567cd587676c99f4472f779a0279aa60a7a7"
+checksum = "ddb7af00d2b17dbd07d82c0063e25411959748ff03e8d4f96134c2ff41fce34f"
 dependencies = [
  "libc",
  "librocksdb-sys",
@@ -6888,12 +6890,6 @@ name = "rustc-demangle"
 version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b74b56ffa8bb2830709a538c2cbcae9aa062db0d2a42563bfb09bdaae44020eb"
-
-[[package]]
-name = "rustc-hash"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
@@ -7718,8 +7714,8 @@ dependencies = [
 
 [[package]]
 name = "solana-account-decoder"
-version = "4.1.2"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=bdf2e1d844b6453819ce6d4a24bc15df830908a4#bdf2e1d844b6453819ce6d4a24bc15df830908a4"
+version = "4.2.0-rc.1"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
 dependencies = [
  "Inflector",
  "base64 0.22.1",
@@ -7745,22 +7741,23 @@ dependencies = [
  "solana-sdk-ids 3.1.0",
  "solana-slot-hashes 3.1.0",
  "solana-slot-history 3.1.0",
- "solana-stake-interface 3.1.0",
+ "solana-stake-interface 4.3.0",
  "solana-sysvar 4.1.0",
  "solana-vote-interface 6.0.3",
  "spl-generic-token",
  "spl-token-2022-interface",
  "spl-token-group-interface",
- "spl-token-interface",
+ "spl-token-interface 3.0.0",
  "spl-token-metadata-interface",
  "thiserror 2.0.18",
+ "wincode",
  "zstd",
 ]
 
 [[package]]
 name = "solana-account-decoder-client-types"
-version = "4.1.2"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=bdf2e1d844b6453819ce6d4a24bc15df830908a4#bdf2e1d844b6453819ce6d4a24bc15df830908a4"
+version = "4.2.0-rc.1"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
 dependencies = [
  "base64 0.22.1",
  "bs58 0.5.1",
@@ -7799,8 +7796,8 @@ dependencies = [
 
 [[package]]
 name = "solana-accounts-db"
-version = "4.1.2"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=bdf2e1d844b6453819ce6d4a24bc15df830908a4#bdf2e1d844b6453819ce6d4a24bc15df830908a4"
+version = "4.2.0-rc.1"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
 dependencies = [
  "agave-fs",
  "ahash 0.8.12",
@@ -7809,7 +7806,6 @@ dependencies = [
  "dashmap 5.5.3",
  "itertools 0.14.0",
  "log",
- "memmap2 0.9.11",
  "modular-bitfield",
  "num_cpus",
  "qualifier_attr",
@@ -7837,13 +7833,13 @@ dependencies = [
  "solana-reward-info 6.2.0",
  "solana-signer 3.0.1",
  "solana-slot-hashes 3.1.0",
- "solana-stake-interface 3.1.0",
+ "solana-stake-interface 4.3.0",
  "solana-svm-transaction",
  "solana-system-interface 3.2.0",
  "solana-sysvar 4.1.0",
  "solana-time-utils 3.0.0",
  "solana-transaction 4.1.5",
- "solana-transaction-context 4.1.2",
+ "solana-transaction-context 4.2.0-rc.1",
  "solana-transaction-error 3.3.1",
  "solana-vote-program",
  "spl-generic-token",
@@ -7918,6 +7914,7 @@ dependencies = [
  "solana-pubkey 4.2.0",
  "solana-sdk-ids 3.1.0",
  "solana-slot-hashes 3.1.0",
+ "wincode",
 ]
 
 [[package]]
@@ -7940,8 +7937,8 @@ dependencies = [
 
 [[package]]
 name = "solana-banks-client"
-version = "4.1.2"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=bdf2e1d844b6453819ce6d4a24bc15df830908a4#bdf2e1d844b6453819ce6d4a24bc15df830908a4"
+version = "4.2.0-rc.1"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
 dependencies = [
  "borsh 1.8.0",
  "futures 0.3.32",
@@ -7957,7 +7954,7 @@ dependencies = [
  "solana-signature 3.4.1",
  "solana-sysvar 4.1.0",
  "solana-transaction 4.1.5",
- "solana-transaction-context 4.1.2",
+ "solana-transaction-context 4.2.0-rc.1",
  "solana-transaction-error 3.3.1",
  "tarpc",
  "thiserror 2.0.18",
@@ -7967,8 +7964,8 @@ dependencies = [
 
 [[package]]
 name = "solana-banks-interface"
-version = "4.1.2"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=bdf2e1d844b6453819ce6d4a24bc15df830908a4#bdf2e1d844b6453819ce6d4a24bc15df830908a4"
+version = "4.2.0-rc.1"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
 dependencies = [
  "serde",
  "solana-account 4.3.1",
@@ -7979,15 +7976,15 @@ dependencies = [
  "solana-pubkey 4.2.0",
  "solana-signature 3.4.1",
  "solana-transaction 4.1.5",
- "solana-transaction-context 4.1.2",
+ "solana-transaction-context 4.2.0-rc.1",
  "solana-transaction-error 3.3.1",
  "tarpc",
 ]
 
 [[package]]
 name = "solana-banks-server"
-version = "4.1.2"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=bdf2e1d844b6453819ce6d4a24bc15df830908a4#bdf2e1d844b6453819ce6d4a24bc15df830908a4"
+version = "4.2.0-rc.1"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
 dependencies = [
  "agave-feature-set",
  "bincode",
@@ -8083,8 +8080,8 @@ dependencies = [
 
 [[package]]
 name = "solana-bloom"
-version = "4.1.2"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=bdf2e1d844b6453819ce6d4a24bc15df830908a4#bdf2e1d844b6453819ce6d4a24bc15df830908a4"
+version = "4.2.0-rc.1"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
 dependencies = [
  "bv",
  "fnv",
@@ -8092,6 +8089,7 @@ dependencies = [
  "serde",
  "solana-sanitize 3.0.1",
  "solana-time-utils 3.0.0",
+ "wincode",
 ]
 
 [[package]]
@@ -8186,8 +8184,8 @@ dependencies = [
 
 [[package]]
 name = "solana-bpf-loader-program"
-version = "4.1.2"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=bdf2e1d844b6453819ce6d4a24bc15df830908a4#bdf2e1d844b6453819ce6d4a24bc15df830908a4"
+version = "4.2.0-rc.1"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
 dependencies = [
  "bincode",
  "qualifier_attr",
@@ -8207,13 +8205,13 @@ dependencies = [
  "solana-svm-type-overrides",
  "solana-syscalls",
  "solana-system-interface 3.2.0",
- "solana-transaction-context 4.1.2",
+ "solana-transaction-context 4.2.0-rc.1",
 ]
 
 [[package]]
 name = "solana-bucket-map"
-version = "4.1.2"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=bdf2e1d844b6453819ce6d4a24bc15df830908a4#bdf2e1d844b6453819ce6d4a24bc15df830908a4"
+version = "4.2.0-rc.1"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
 dependencies = [
  "ahash 0.8.12",
  "bv",
@@ -8231,8 +8229,8 @@ dependencies = [
 
 [[package]]
 name = "solana-builtins"
-version = "4.1.2"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=bdf2e1d844b6453819ce6d4a24bc15df830908a4#bdf2e1d844b6453819ce6d4a24bc15df830908a4"
+version = "4.2.0-rc.1"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
 dependencies = [
  "agave-feature-set",
  "solana-bpf-loader-program",
@@ -8249,8 +8247,8 @@ dependencies = [
 
 [[package]]
 name = "solana-builtins-default-costs"
-version = "4.1.2"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=bdf2e1d844b6453819ce6d4a24bc15df830908a4#bdf2e1d844b6453819ce6d4a24bc15df830908a4"
+version = "4.2.0-rc.1"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
 dependencies = [
  "agave-feature-set",
  "ahash 0.8.12",
@@ -8260,8 +8258,8 @@ dependencies = [
 
 [[package]]
 name = "solana-bundle"
-version = "4.1.2"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=bdf2e1d844b6453819ce6d4a24bc15df830908a4#bdf2e1d844b6453819ce6d4a24bc15df830908a4"
+version = "4.2.0-rc.1"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
 dependencies = [
  "itertools 0.14.0",
  "sha2 0.11.0",
@@ -8270,9 +8268,10 @@ dependencies = [
 
 [[package]]
 name = "solana-clap-utils"
-version = "4.1.2"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=bdf2e1d844b6453819ce6d4a24bc15df830908a4#bdf2e1d844b6453819ce6d4a24bc15df830908a4"
+version = "4.2.0-rc.1"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
 dependencies = [
+ "bip39",
  "bs58 0.5.1",
  "chrono",
  "clap 2.34.0",
@@ -8293,15 +8292,14 @@ dependencies = [
  "solana-signature 3.4.1",
  "solana-signer 3.0.1",
  "thiserror 2.0.18",
- "tiny-bip39",
  "uriparse",
  "url 2.5.8",
 ]
 
 [[package]]
 name = "solana-cli-config"
-version = "4.1.2"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=bdf2e1d844b6453819ce6d4a24bc15df830908a4#bdf2e1d844b6453819ce6d4a24bc15df830908a4"
+version = "4.2.0-rc.1"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
 dependencies = [
  "dirs-next",
  "serde",
@@ -8313,12 +8311,14 @@ dependencies = [
 
 [[package]]
 name = "solana-cli-output"
-version = "4.1.2"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=bdf2e1d844b6453819ce6d4a24bc15df830908a4#bdf2e1d844b6453819ce6d4a24bc15df830908a4"
+version = "4.2.0-rc.1"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
 dependencies = [
  "Inflector",
  "agave-reserved-account-keys",
+ "agave-votor-messages",
  "base64 0.22.1",
+ "bitvec",
  "chrono",
  "clap 2.34.0",
  "console 0.16.4",
@@ -8331,18 +8331,21 @@ dependencies = [
  "solana-account 4.3.1",
  "solana-account-decoder",
  "solana-bincode 3.1.0",
+ "solana-bls-signatures",
  "solana-clap-utils",
  "solana-cli-config",
  "solana-clock 3.1.1",
  "solana-epoch-info 3.1.0",
+ "solana-epoch-schedule 3.2.0",
  "solana-hash 4.5.0",
  "solana-message 4.3.0",
+ "solana-native-token 3.0.0",
  "solana-packet 4.2.0",
  "solana-pubkey 4.2.0",
  "solana-rpc-client-api",
  "solana-sdk-ids 3.1.0",
  "solana-signature 3.4.1",
- "solana-stake-interface 3.1.0",
+ "solana-stake-interface 4.3.0",
  "solana-system-interface 3.2.0",
  "solana-transaction 4.1.5",
  "solana-transaction-status",
@@ -8353,8 +8356,8 @@ dependencies = [
 
 [[package]]
 name = "solana-client"
-version = "4.1.2"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=bdf2e1d844b6453819ce6d4a24bc15df830908a4#bdf2e1d844b6453819ce6d4a24bc15df830908a4"
+version = "4.2.0-rc.1"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
 dependencies = [
  "async-trait",
  "bincode",
@@ -8500,8 +8503,8 @@ dependencies = [
 
 [[package]]
 name = "solana-compute-budget"
-version = "4.1.2"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=bdf2e1d844b6453819ce6d4a24bc15df830908a4#bdf2e1d844b6453819ce6d4a24bc15df830908a4"
+version = "4.2.0-rc.1"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
 dependencies = [
  "solana-fee-structure 3.0.0",
  "solana-program-runtime",
@@ -8509,8 +8512,8 @@ dependencies = [
 
 [[package]]
 name = "solana-compute-budget-instruction"
-version = "4.1.2"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=bdf2e1d844b6453819ce6d4a24bc15df830908a4#bdf2e1d844b6453819ce6d4a24bc15df830908a4"
+version = "4.2.0-rc.1"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
 dependencies = [
  "agave-feature-set",
  "solana-borsh 3.0.2",
@@ -8551,8 +8554,8 @@ dependencies = [
 
 [[package]]
 name = "solana-compute-budget-program"
-version = "4.1.2"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=bdf2e1d844b6453819ce6d4a24bc15df830908a4#bdf2e1d844b6453819ce6d4a24bc15df830908a4"
+version = "4.2.0-rc.1"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
 dependencies = [
  "solana-program-runtime",
 ]
@@ -8576,8 +8579,8 @@ dependencies = [
 
 [[package]]
 name = "solana-connection-cache"
-version = "4.1.2"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=bdf2e1d844b6453819ce6d4a24bc15df830908a4#bdf2e1d844b6453819ce6d4a24bc15df830908a4"
+version = "4.2.0-rc.1"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
 dependencies = [
  "async-trait",
  "crossbeam-channel",
@@ -8594,11 +8597,12 @@ dependencies = [
 
 [[package]]
 name = "solana-core"
-version = "4.1.2"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=bdf2e1d844b6453819ce6d4a24bc15df830908a4#bdf2e1d844b6453819ce6d4a24bc15df830908a4"
+version = "4.2.0-rc.1"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
 dependencies = [
  "agave-banking-stage-ingress-types",
  "agave-bls-cert-verify",
+ "agave-bls-sigverify",
  "agave-feature-set",
  "agave-fs",
  "agave-logger",
@@ -8617,6 +8621,7 @@ dependencies = [
  "assert_matches",
  "async-trait",
  "bincode",
+ "bitvec",
  "borsh 1.8.0",
  "bs58 0.5.1",
  "bytemuck",
@@ -8704,6 +8709,7 @@ dependencies = [
  "solana-shred-version 3.0.1",
  "solana-signature 3.4.1",
  "solana-signer 3.0.1",
+ "solana-signer-store",
  "solana-slot-hashes 3.1.0",
  "solana-slot-history 3.1.0",
  "solana-streamer",
@@ -8735,6 +8741,7 @@ dependencies = [
  "sysctl",
  "tempfile",
  "thiserror 2.0.18",
+ "tikv-jemalloc-ctl",
  "tokio",
  "tokio-stream",
  "tokio-util 0.7.18",
@@ -8746,8 +8753,8 @@ dependencies = [
 
 [[package]]
 name = "solana-cost-model"
-version = "4.1.2"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=bdf2e1d844b6453819ce6d4a24bc15df830908a4#bdf2e1d844b6453819ce6d4a24bc15df830908a4"
+version = "4.2.0-rc.1"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
 dependencies = [
  "agave-feature-set",
  "ahash 0.8.12",
@@ -8881,8 +8888,8 @@ dependencies = [
 
 [[package]]
 name = "solana-download-utils"
-version = "4.1.2"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=bdf2e1d844b6453819ce6d4a24bc15df830908a4#bdf2e1d844b6453819ce6d4a24bc15df830908a4"
+version = "4.2.0-rc.1"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
 dependencies = [
  "agave-snapshots",
  "log",
@@ -8921,12 +8928,11 @@ dependencies = [
 
 [[package]]
 name = "solana-entry"
-version = "4.1.2"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=bdf2e1d844b6453819ce6d4a24bc15df830908a4#bdf2e1d844b6453819ce6d4a24bc15df830908a4"
+version = "4.2.0-rc.1"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
 dependencies = [
  "agave-votor-messages",
  "crossbeam-channel",
- "dlopen2",
  "log",
  "num_cpus",
  "rayon",
@@ -8934,6 +8940,7 @@ dependencies = [
  "solana-address 2.6.1",
  "solana-bls-signatures",
  "solana-clock 3.1.1",
+ "solana-cost-model",
  "solana-hash 4.5.0",
  "solana-measure",
  "solana-merkle-tree",
@@ -9119,8 +9126,8 @@ dependencies = [
 
 [[package]]
 name = "solana-faucet"
-version = "4.1.2"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=bdf2e1d844b6453819ce6d4a24bc15df830908a4#bdf2e1d844b6453819ce6d4a24bc15df830908a4"
+version = "4.2.0-rc.1"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
 dependencies = [
  "crossbeam-channel",
  "log",
@@ -9208,8 +9215,8 @@ dependencies = [
 
 [[package]]
 name = "solana-fee"
-version = "4.1.2"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=bdf2e1d844b6453819ce6d4a24bc15df830908a4#bdf2e1d844b6453819ce6d4a24bc15df830908a4"
+version = "4.2.0-rc.1"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
 dependencies = [
  "agave-feature-set",
  "solana-fee-structure 3.0.0",
@@ -9334,8 +9341,8 @@ dependencies = [
 
 [[package]]
 name = "solana-genesis-utils"
-version = "4.1.2"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=bdf2e1d844b6453819ce6d4a24bc15df830908a4#bdf2e1d844b6453819ce6d4a24bc15df830908a4"
+version = "4.2.0-rc.1"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
 dependencies = [
  "agave-snapshots",
  "log",
@@ -9359,8 +9366,8 @@ dependencies = [
 
 [[package]]
 name = "solana-geyser-plugin-manager"
-version = "4.1.2"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=bdf2e1d844b6453819ce6d4a24bc15df830908a4#bdf2e1d844b6453819ce6d4a24bc15df830908a4"
+version = "4.2.0-rc.1"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
 dependencies = [
  "agave-geyser-plugin-interface",
  "arc-swap",
@@ -9368,18 +9375,19 @@ dependencies = [
  "crossbeam-channel",
  "json5",
  "jsonrpc-core",
- "libloading 0.9.0",
+ "lazy-lru",
+ "libloading",
  "log",
  "serde_json",
  "solana-account 4.3.1",
  "solana-accounts-db",
  "solana-clock 3.1.1",
  "solana-entry",
+ "solana-gossip",
  "solana-hash 4.5.0",
  "solana-ledger",
  "solana-measure",
  "solana-message 4.3.0",
- "solana-metrics",
  "solana-pubkey 4.2.0",
  "solana-rpc",
  "solana-runtime",
@@ -9392,17 +9400,17 @@ dependencies = [
 
 [[package]]
 name = "solana-gossip"
-version = "4.1.2"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=bdf2e1d844b6453819ce6d4a24bc15df830908a4#bdf2e1d844b6453819ce6d4a24bc15df830908a4"
+version = "4.2.0-rc.1"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
 dependencies = [
  "agave-logger",
  "agave-random",
  "arc-swap",
- "arrayvec",
  "assert_matches",
- "bincode",
  "bv",
+ "bytes",
  "crossbeam-channel",
+ "ed25519-dalek 2.2.0",
  "flate2",
  "indexmap 2.14.0",
  "itertools 0.14.0",
@@ -9415,7 +9423,6 @@ dependencies = [
  "serde",
  "serde-big-array",
  "serde_bytes",
- "siphasher 1.0.3",
  "solana-bloom",
  "solana-client",
  "solana-clock 3.1.1",
@@ -9444,6 +9451,7 @@ dependencies = [
  "solana-version",
  "solana-vote",
  "solana-vote-program",
+ "solana-wincode-varint",
  "static_assertions",
  "thiserror 2.0.18",
  "wincode",
@@ -9623,6 +9631,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-instructions-sysvar"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e38363a181313d607f7a118df2b401bb27b477a0104b09283cbf504f5f0f00cc"
+dependencies = [
+ "bitflags 2.13.1",
+ "solana-account-info 3.1.1",
+ "solana-instruction 3.4.0",
+ "solana-instruction-error",
+ "solana-program-error 3.0.1",
+ "solana-sanitize 3.0.1",
+ "solana-sdk-ids 3.1.0",
+ "solana-serialize-utils 3.1.2",
+ "solana-sysvar-id 3.1.0",
+]
+
+[[package]]
 name = "solana-invoke"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9725,8 +9750,8 @@ dependencies = [
 
 [[package]]
 name = "solana-lattice-hash"
-version = "4.1.2"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=bdf2e1d844b6453819ce6d4a24bc15df830908a4#bdf2e1d844b6453819ce6d4a24bc15df830908a4"
+version = "4.2.0-rc.1"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
 dependencies = [
  "base64 0.22.1",
  "blake3",
@@ -9736,8 +9761,8 @@ dependencies = [
 
 [[package]]
 name = "solana-leader-schedule"
-version = "4.1.2"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=bdf2e1d844b6453819ce6d4a24bc15df830908a4#bdf2e1d844b6453819ce6d4a24bc15df830908a4"
+version = "4.2.0-rc.1"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
 dependencies = [
  "agave-random",
  "itertools 0.14.0",
@@ -9749,8 +9774,8 @@ dependencies = [
 
 [[package]]
 name = "solana-ledger"
-version = "4.1.2"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=bdf2e1d844b6453819ce6d4a24bc15df830908a4#bdf2e1d844b6453819ce6d4a24bc15df830908a4"
+version = "4.2.0-rc.1"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
 dependencies = [
  "agave-feature-set",
  "agave-reserved-account-keys",
@@ -9758,7 +9783,6 @@ dependencies = [
  "agave-votor-messages",
  "anyhow",
  "assert_matches",
- "bincode",
  "bitflags 2.13.1",
  "bytes",
  "bzip2",
@@ -9816,7 +9840,7 @@ dependencies = [
  "solana-shred-version 3.0.1",
  "solana-signature 3.4.1",
  "solana-signer 3.0.1",
- "solana-stake-interface 3.1.0",
+ "solana-stake-interface 4.3.0",
  "solana-storage-bigtable",
  "solana-storage-proto",
  "solana-streamer",
@@ -9827,7 +9851,7 @@ dependencies = [
  "solana-system-transaction 4.0.0",
  "solana-time-utils 3.0.0",
  "solana-transaction 4.1.5",
- "solana-transaction-context 4.1.2",
+ "solana-transaction-context 4.2.0-rc.1",
  "solana-transaction-error 3.3.1",
  "solana-transaction-status",
  "solana-vote",
@@ -9961,13 +9985,13 @@ dependencies = [
 
 [[package]]
 name = "solana-measure"
-version = "4.1.2"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=bdf2e1d844b6453819ce6d4a24bc15df830908a4#bdf2e1d844b6453819ce6d4a24bc15df830908a4"
+version = "4.2.0-rc.1"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
 
 [[package]]
 name = "solana-merkle-tree"
-version = "4.1.2"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=bdf2e1d844b6453819ce6d4a24bc15df830908a4#bdf2e1d844b6453819ce6d4a24bc15df830908a4"
+version = "4.2.0-rc.1"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
 dependencies = [
  "fast-math",
  "solana-hash 4.5.0",
@@ -10036,8 +10060,8 @@ dependencies = [
 
 [[package]]
 name = "solana-metrics"
-version = "4.1.2"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=bdf2e1d844b6453819ce6d4a24bc15df830908a4#bdf2e1d844b6453819ce6d4a24bc15df830908a4"
+version = "4.2.0-rc.1"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
 dependencies = [
  "crossbeam-channel",
  "gethostname",
@@ -10081,12 +10105,14 @@ checksum = "ae8dd4c280dca9d046139eb5b7a5ac9ad10403fbd64964c7d7571214950d758f"
 
 [[package]]
 name = "solana-net-utils"
-version = "4.1.2"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=bdf2e1d844b6453819ce6d4a24bc15df830908a4#bdf2e1d844b6453819ce6d4a24bc15df830908a4"
+version = "4.2.0-rc.1"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
 dependencies = [
+ "agave-xdp",
  "bincode",
  "bytes",
  "cfg-if 1.0.4",
+ "crossbeam-channel",
  "dashmap 5.5.3",
  "itertools 0.14.0",
  "log",
@@ -10242,11 +10268,12 @@ dependencies = [
 
 [[package]]
 name = "solana-perf"
-version = "4.1.2"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=bdf2e1d844b6453819ce6d4a24bc15df830908a4#bdf2e1d844b6453819ce6d4a24bc15df830908a4"
+version = "4.2.0-rc.1"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
 dependencies = [
  "agave-transaction-view",
  "ahash 0.8.12",
+ "arc-swap",
  "bincode",
  "bytes",
  "caps",
@@ -10262,21 +10289,23 @@ dependencies = [
  "solana-metrics",
  "solana-packet 4.2.0",
  "solana-pubkey 4.2.0",
+ "solana-runtime-transaction",
  "solana-sdk-ids 3.1.0",
  "solana-short-vec 3.2.2",
  "solana-signature 3.4.1",
  "solana-time-utils 3.0.0",
- "solana-transaction-context 4.1.2",
+ "solana-transaction-context 4.2.0-rc.1",
+ "wincode",
 ]
 
 [[package]]
 name = "solana-poh"
-version = "4.1.2"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=bdf2e1d844b6453819ce6d4a24bc15df830908a4#bdf2e1d844b6453819ce6d4a24bc15df830908a4"
+version = "4.2.0-rc.1"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
 dependencies = [
+ "agave-cpu-utils",
  "agave-votor-messages",
  "arc-swap",
- "core_affinity",
  "crossbeam-channel",
  "log",
  "qualifier_attr",
@@ -10565,8 +10594,8 @@ dependencies = [
 
 [[package]]
 name = "solana-program-binaries"
-version = "4.1.2"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=bdf2e1d844b6453819ce6d4a24bc15df830908a4#bdf2e1d844b6453819ce6d4a24bc15df830908a4"
+version = "4.2.0-rc.1"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
 dependencies = [
  "bincode",
  "solana-account 4.3.1",
@@ -10678,8 +10707,8 @@ dependencies = [
 
 [[package]]
 name = "solana-program-runtime"
-version = "4.1.2"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=bdf2e1d844b6453819ce6d4a24bc15df830908a4#bdf2e1d844b6453819ce6d4a24bc15df830908a4"
+version = "4.2.0-rc.1"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -10707,7 +10736,7 @@ dependencies = [
  "solana-sdk-ids 3.1.0",
  "solana-slot-hashes 3.1.0",
  "solana-stable-layout 3.0.1",
- "solana-stake-interface 3.1.0",
+ "solana-stake-interface 4.3.0",
  "solana-svm-callback",
  "solana-svm-feature-set",
  "solana-svm-log-collector",
@@ -10718,14 +10747,15 @@ dependencies = [
  "solana-system-interface 3.2.0",
  "solana-sysvar 4.1.0",
  "solana-sysvar-id 3.1.0",
- "solana-transaction-context 4.1.2",
+ "solana-transaction-context 4.2.0-rc.1",
  "thiserror 2.0.18",
+ "wincode",
 ]
 
 [[package]]
 name = "solana-program-test"
-version = "4.1.2"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=bdf2e1d844b6453819ce6d4a24bc15df830908a4#bdf2e1d844b6453819ce6d4a24bc15df830908a4"
+version = "4.2.0-rc.1"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
 dependencies = [
  "agave-feature-set",
  "agave-logger",
@@ -10769,17 +10799,18 @@ dependencies = [
  "solana-sbpf",
  "solana-sdk-ids 3.1.0",
  "solana-signer 3.0.1",
- "solana-stake-interface 3.1.0",
+ "solana-stake-interface 4.3.0",
  "solana-svm-log-collector",
  "solana-svm-timings",
  "solana-system-interface 3.2.0",
  "solana-sysvar 4.1.0",
  "solana-sysvar-id 3.1.0",
  "solana-transaction 4.1.5",
- "solana-transaction-context 4.1.2",
+ "solana-transaction-context 4.2.0-rc.1",
  "solana-transaction-error 3.3.1",
  "solana-vote-program",
  "spl-generic-token",
+ "spl-memo-interface",
  "thiserror 2.0.18",
  "tokio",
 ]
@@ -10832,8 +10863,8 @@ dependencies = [
 
 [[package]]
 name = "solana-pubsub-client"
-version = "4.1.2"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=bdf2e1d844b6453819ce6d4a24bc15df830908a4#bdf2e1d844b6453819ce6d4a24bc15df830908a4"
+version = "4.2.0-rc.1"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
 dependencies = [
  "crossbeam-channel",
  "futures-util",
@@ -10855,8 +10886,8 @@ dependencies = [
 
 [[package]]
 name = "solana-quic-client"
-version = "4.1.2"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=bdf2e1d844b6453819ce6d4a24bc15df830908a4#bdf2e1d844b6453819ce6d4a24bc15df830908a4"
+version = "4.2.0-rc.1"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -10889,8 +10920,8 @@ dependencies = [
 
 [[package]]
 name = "solana-rayon-threadlimit"
-version = "4.1.2"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=bdf2e1d844b6453819ce6d4a24bc15df830908a4#bdf2e1d844b6453819ce6d4a24bc15df830908a4"
+version = "4.2.0-rc.1"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
 dependencies = [
  "log",
  "num_cpus",
@@ -10898,8 +10929,8 @@ dependencies = [
 
 [[package]]
 name = "solana-remote-wallet"
-version = "4.1.2"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=bdf2e1d844b6453819ce6d4a24bc15df830908a4#bdf2e1d844b6453819ce6d4a24bc15df830908a4"
+version = "4.2.0-rc.1"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
 dependencies = [
  "console 0.16.4",
  "dialoguer",
@@ -11020,11 +11051,12 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc"
-version = "4.1.2"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=bdf2e1d844b6453819ce6d4a24bc15df830908a4#bdf2e1d844b6453819ce6d4a24bc15df830908a4"
+version = "4.2.0-rc.1"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
 dependencies = [
  "agave-feature-set",
  "agave-snapshots",
+ "agave-votor-messages",
  "base64 0.22.1",
  "bs58 0.5.1",
  "crossbeam-channel",
@@ -11058,6 +11090,7 @@ dependencies = [
  "solana-gossip",
  "solana-hash 4.5.0",
  "solana-keypair 3.1.2",
+ "solana-leader-schedule",
  "solana-ledger",
  "solana-measure",
  "solana-message 4.3.0",
@@ -11083,7 +11116,7 @@ dependencies = [
  "solana-time-utils 3.0.0",
  "solana-tls-utils",
  "solana-transaction 4.1.5",
- "solana-transaction-context 4.1.2",
+ "solana-transaction-context 4.2.0-rc.1",
  "solana-transaction-error 3.3.1",
  "solana-transaction-status",
  "solana-validator-exit 3.0.0",
@@ -11092,7 +11125,7 @@ dependencies = [
  "solana-vote-program",
  "spl-generic-token",
  "spl-token-2022-interface",
- "spl-token-interface",
+ "spl-token-interface 3.0.0",
  "stream-cancel",
  "thiserror 2.0.18",
  "tokio",
@@ -11102,9 +11135,10 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc-client"
-version = "4.1.2"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=bdf2e1d844b6453819ce6d4a24bc15df830908a4#bdf2e1d844b6453819ce6d4a24bc15df830908a4"
+version = "4.2.0-rc.1"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
 dependencies = [
+ "agave-votor-messages",
  "async-trait",
  "base64 0.22.1",
  "bincode",
@@ -11120,6 +11154,7 @@ dependencies = [
  "solana-account 4.3.1",
  "solana-account-decoder",
  "solana-account-decoder-client-types",
+ "solana-bls-signatures",
  "solana-clock 3.1.1",
  "solana-commitment-config 3.1.1",
  "solana-epoch-info 3.1.0",
@@ -11137,12 +11172,13 @@ dependencies = [
  "solana-version",
  "solana-vote-interface 6.0.3",
  "tokio",
+ "wincode",
 ]
 
 [[package]]
 name = "solana-rpc-client-api"
-version = "4.1.2"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=bdf2e1d844b6453819ce6d4a24bc15df830908a4#bdf2e1d844b6453819ce6d4a24bc15df830908a4"
+version = "4.2.0-rc.1"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
 dependencies = [
  "anyhow",
  "jsonrpc-core",
@@ -11164,8 +11200,8 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc-client-nonce-utils"
-version = "4.1.2"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=bdf2e1d844b6453819ce6d4a24bc15df830908a4#bdf2e1d844b6453819ce6d4a24bc15df830908a4"
+version = "4.2.0-rc.1"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
 dependencies = [
  "solana-account 4.3.1",
  "solana-commitment-config 3.1.1",
@@ -11180,8 +11216,8 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc-client-types"
-version = "4.1.2"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=bdf2e1d844b6453819ce6d4a24bc15df830908a4#bdf2e1d844b6453819ce6d4a24bc15df830908a4"
+version = "4.2.0-rc.1"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
 dependencies = [
  "base64 0.22.1",
  "bs58 0.5.1",
@@ -11204,8 +11240,8 @@ dependencies = [
 
 [[package]]
 name = "solana-runtime"
-version = "4.1.2"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=bdf2e1d844b6453819ce6d4a24bc15df830908a4#bdf2e1d844b6453819ce6d4a24bc15df830908a4"
+version = "4.2.0-rc.1"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
 dependencies = [
  "agave-bls-cert-verify",
  "agave-feature-set",
@@ -11221,8 +11257,10 @@ dependencies = [
  "assert_matches",
  "base64 0.22.1",
  "bincode",
+ "bitvec",
  "bytemuck",
  "crossbeam-channel",
+ "crossbeam-utils",
  "dashmap 5.5.3",
  "imbl",
  "itertools 0.14.0",
@@ -11231,7 +11269,6 @@ dependencies = [
  "mockall",
  "num-derive",
  "num-traits",
- "num_cpus",
  "percentage",
  "qualifier_attr",
  "rand 0.9.5",
@@ -11304,7 +11341,7 @@ dependencies = [
  "solana-signer-store",
  "solana-slot-hashes 3.1.0",
  "solana-slot-history 3.1.0",
- "solana-stake-interface 3.1.0",
+ "solana-stake-interface 4.3.0",
  "solana-svm",
  "solana-svm-callback",
  "solana-svm-timings",
@@ -11316,7 +11353,7 @@ dependencies = [
  "solana-sysvar-id 3.1.0",
  "solana-time-utils 3.0.0",
  "solana-transaction 4.1.5",
- "solana-transaction-context 4.1.2",
+ "solana-transaction-context 4.2.0-rc.1",
  "solana-transaction-error 3.3.1",
  "solana-transaction-status-client-types",
  "solana-unified-scheduler-logic",
@@ -11328,7 +11365,6 @@ dependencies = [
  "static_assertions",
  "strum",
  "strum_macros",
- "symlink",
  "tempfile",
  "thiserror 2.0.18",
  "wincode",
@@ -11336,8 +11372,8 @@ dependencies = [
 
 [[package]]
 name = "solana-runtime-transaction"
-version = "4.1.2"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=bdf2e1d844b6453819ce6d4a24bc15df830908a4#bdf2e1d844b6453819ce6d4a24bc15df830908a4"
+version = "4.2.0-rc.1"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
 dependencies = [
  "agave-feature-set",
  "agave-transaction-view",
@@ -11351,7 +11387,7 @@ dependencies = [
  "solana-signature 3.4.1",
  "solana-svm-transaction",
  "solana-transaction 4.1.5",
- "solana-transaction-context 4.1.2",
+ "solana-transaction-context 4.2.0-rc.1",
  "solana-transaction-error 3.3.1",
  "wincode",
 ]
@@ -11370,9 +11406,9 @@ checksum = "dcf09694a0fc14e5ffb18f9b7b7c0f15ecb6eac5b5610bf76a1853459d19daf9"
 
 [[package]]
 name = "solana-sbpf"
-version = "0.21.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f84c593fa3d4131045b606dec5acf9d8eac73791bc786ca9911057aec8f43ec"
+checksum = "d777d7a89267dd133e985113c7e7f820fb7cfd9123a4a350cf8b39ebae1920bc"
 dependencies = [
  "byteorder",
  "combine 3.8.1",
@@ -11649,7 +11685,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36187af2324f079f65a675ec22b31c24919cb4ac22c79472e85d819db9bbbc15"
 dependencies = [
  "hmac 0.12.1",
- "pbkdf2 0.11.0",
+ "pbkdf2",
  "sha2 0.10.9",
 ]
 
@@ -11660,14 +11696,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc905b200a95f2ea9146e43f2a7181e3aeb55de6bc12afb36462d00a3c7310de"
 dependencies = [
  "hmac 0.12.1",
- "pbkdf2 0.11.0",
+ "pbkdf2",
  "sha2 0.10.9",
 ]
 
 [[package]]
 name = "solana-send-transaction-service"
-version = "4.1.2"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=bdf2e1d844b6453819ce6d4a24bc15df830908a4#bdf2e1d844b6453819ce6d4a24bc15df830908a4"
+version = "4.2.0-rc.1"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
 dependencies = [
  "async-trait",
  "crossbeam-channel",
@@ -11913,6 +11949,7 @@ dependencies = [
  "solana-hash 4.5.0",
  "solana-sdk-ids 3.1.0",
  "solana-sysvar-id 3.1.0",
+ "wincode",
 ]
 
 [[package]]
@@ -11940,6 +11977,7 @@ dependencies = [
  "solana-get-sysvar",
  "solana-sdk-ids 3.1.0",
  "solana-sysvar-id 3.1.0",
+ "wincode",
 ]
 
 [[package]]
@@ -12018,9 +12056,9 @@ dependencies = [
 
 [[package]]
 name = "solana-stake-interface"
-version = "3.1.0"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f49eb5c77484214c3484921e2cdda79d185373118b5458c1b2df0f1a04c3bc30"
+checksum = "252b4291eb25a5a356149ed4d4a940d5f655186210fa84b5d0d8d55c3dd42a81"
 dependencies = [
  "num-traits",
  "serde",
@@ -12033,12 +12071,13 @@ dependencies = [
  "solana-system-interface 3.2.0",
  "solana-sysvar 4.1.0",
  "solana-sysvar-id 3.1.0",
+ "wincode",
 ]
 
 [[package]]
 name = "solana-storage-bigtable"
-version = "4.1.2"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=bdf2e1d844b6453819ce6d4a24bc15df830908a4#bdf2e1d844b6453819ce6d4a24bc15df830908a4"
+version = "4.2.0-rc.1"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
 dependencies = [
  "agave-reserved-account-keys",
  "base64 0.22.1",
@@ -12074,10 +12113,9 @@ dependencies = [
 
 [[package]]
 name = "solana-storage-proto"
-version = "4.1.2"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=bdf2e1d844b6453819ce6d4a24bc15df830908a4#bdf2e1d844b6453819ce6d4a24bc15df830908a4"
+version = "4.2.0-rc.1"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
 dependencies = [
- "bincode",
  "bs58 0.5.1",
  "prost 0.14.4",
  "protobuf-src",
@@ -12090,17 +12128,18 @@ dependencies = [
  "solana-serde 3.0.0",
  "solana-signature 3.4.1",
  "solana-transaction 4.1.5",
- "solana-transaction-context 4.1.2",
+ "solana-transaction-context 4.2.0-rc.1",
  "solana-transaction-error 3.3.1",
  "solana-transaction-status",
+ "thiserror 2.0.18",
  "tonic-prost-build",
  "wincode",
 ]
 
 [[package]]
 name = "solana-streamer"
-version = "4.1.2"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=bdf2e1d844b6453819ce6d4a24bc15df830908a4#bdf2e1d844b6453819ce6d4a24bc15df830908a4"
+version = "4.2.0-rc.1"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
 dependencies = [
  "agave-xdp",
  "bytes",
@@ -12114,12 +12153,12 @@ dependencies = [
  "nix",
  "num_cpus",
  "pem 1.1.1",
- "percentage",
  "quinn",
  "rand 0.9.5",
  "rustls 0.23.42",
  "smallvec",
  "solana-keypair 3.1.2",
+ "solana-measure",
  "solana-metrics",
  "solana-net-utils",
  "solana-packet 4.2.0",
@@ -12136,8 +12175,8 @@ dependencies = [
 
 [[package]]
 name = "solana-svm"
-version = "4.1.2"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=bdf2e1d844b6453819ce6d4a24bc15df830908a4#bdf2e1d844b6453819ce6d4a24bc15df830908a4"
+version = "4.2.0-rc.1"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
 dependencies = [
  "ahash 0.8.12",
  "log",
@@ -12145,16 +12184,21 @@ dependencies = [
  "qualifier_attr",
  "serde",
  "solana-account 4.3.1",
+ "solana-bpf-loader-program",
  "solana-clock 3.1.1",
+ "solana-compute-budget",
+ "solana-compute-budget-program",
  "solana-fee-structure 3.0.0",
  "solana-hash 4.5.0",
  "solana-instruction 3.4.0",
- "solana-instructions-sysvar 3.0.1",
+ "solana-instruction-error",
+ "solana-instructions-sysvar 4.0.0",
  "solana-loader-v3-interface 7.0.0",
  "solana-loader-v4-interface 3.1.0",
  "solana-message 4.3.0",
  "solana-nonce 3.2.0",
  "solana-nonce-account 4.1.1",
+ "solana-precompile-error 3.0.0",
  "solana-program-entrypoint 3.1.1",
  "solana-program-pack 3.1.0",
  "solana-program-runtime",
@@ -12168,9 +12212,11 @@ dependencies = [
  "solana-svm-timings",
  "solana-svm-transaction",
  "solana-svm-type-overrides",
+ "solana-syscalls",
  "solana-system-interface 3.2.0",
+ "solana-system-program",
  "solana-sysvar-id 3.1.0",
- "solana-transaction-context 4.1.2",
+ "solana-transaction-context 4.2.0-rc.1",
  "solana-transaction-error 3.3.1",
  "spl-generic-token",
  "thiserror 2.0.18",
@@ -12178,8 +12224,8 @@ dependencies = [
 
 [[package]]
 name = "solana-svm-callback"
-version = "4.1.2"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=bdf2e1d844b6453819ce6d4a24bc15df830908a4#bdf2e1d844b6453819ce6d4a24bc15df830908a4"
+version = "4.2.0-rc.1"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
 dependencies = [
  "solana-account 4.3.1",
  "solana-clock 3.1.1",
@@ -12189,26 +12235,26 @@ dependencies = [
 
 [[package]]
 name = "solana-svm-feature-set"
-version = "4.1.2"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=bdf2e1d844b6453819ce6d4a24bc15df830908a4#bdf2e1d844b6453819ce6d4a24bc15df830908a4"
+version = "4.2.0-rc.1"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
 
 [[package]]
 name = "solana-svm-log-collector"
-version = "4.1.2"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=bdf2e1d844b6453819ce6d4a24bc15df830908a4#bdf2e1d844b6453819ce6d4a24bc15df830908a4"
+version = "4.2.0-rc.1"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
 dependencies = [
  "log",
 ]
 
 [[package]]
 name = "solana-svm-measure"
-version = "4.1.2"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=bdf2e1d844b6453819ce6d4a24bc15df830908a4#bdf2e1d844b6453819ce6d4a24bc15df830908a4"
+version = "4.2.0-rc.1"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
 
 [[package]]
 name = "solana-svm-timings"
-version = "4.1.2"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=bdf2e1d844b6453819ce6d4a24bc15df830908a4#bdf2e1d844b6453819ce6d4a24bc15df830908a4"
+version = "4.2.0-rc.1"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
 dependencies = [
  "eager",
  "enum-iterator",
@@ -12217,8 +12263,9 @@ dependencies = [
 
 [[package]]
 name = "solana-svm-transaction"
-version = "4.1.2"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=bdf2e1d844b6453819ce6d4a24bc15df830908a4#bdf2e1d844b6453819ce6d4a24bc15df830908a4"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "736d2cec944c6f8f298a7bd8ada5eb318cca9ab859281b1300842fa0e9a25afa"
 dependencies = [
  "solana-hash 4.5.0",
  "solana-message 4.3.0",
@@ -12230,23 +12277,22 @@ dependencies = [
 
 [[package]]
 name = "solana-svm-type-overrides"
-version = "4.1.2"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=bdf2e1d844b6453819ce6d4a24bc15df830908a4#bdf2e1d844b6453819ce6d4a24bc15df830908a4"
+version = "4.2.0-rc.1"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
 dependencies = [
  "rand 0.9.5",
 ]
 
 [[package]]
 name = "solana-syscalls"
-version = "4.1.2"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=bdf2e1d844b6453819ce6d4a24bc15df830908a4#bdf2e1d844b6453819ce6d4a24bc15df830908a4"
+version = "4.2.0-rc.1"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
 dependencies = [
  "bincode",
  "libsecp256k1 0.7.2",
  "num-traits",
  "solana-account 4.3.1",
  "solana-account-info 3.1.1",
- "solana-big-mod-exp 3.0.0",
  "solana-blake3-hasher 3.1.0",
  "solana-bls12-381-syscall",
  "solana-bn254 3.2.1",
@@ -12267,14 +12313,15 @@ dependencies = [
  "solana-sha256-hasher 3.1.0",
  "solana-sha512-hasher",
  "solana-stable-layout 3.0.1",
- "solana-stake-interface 3.1.0",
+ "solana-stake-interface 4.3.0",
  "solana-svm-feature-set",
  "solana-svm-log-collector",
  "solana-svm-type-overrides",
  "solana-sysvar 4.1.0",
  "solana-sysvar-id 3.1.0",
- "solana-transaction-context 4.1.2",
+ "solana-transaction-context 4.2.0-rc.1",
  "thiserror 2.0.18",
+ "wincode",
 ]
 
 [[package]]
@@ -12326,8 +12373,8 @@ dependencies = [
 
 [[package]]
 name = "solana-system-program"
-version = "4.1.2"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=bdf2e1d844b6453819ce6d4a24bc15df830908a4#bdf2e1d844b6453819ce6d4a24bc15df830908a4"
+version = "4.2.0-rc.1"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
 dependencies = [
  "bincode",
  "log",
@@ -12344,7 +12391,7 @@ dependencies = [
  "solana-svm-log-collector",
  "solana-system-interface 3.2.0",
  "solana-sysvar 4.1.0",
- "solana-transaction-context 4.1.2",
+ "solana-transaction-context 4.2.0-rc.1",
 ]
 
 [[package]]
@@ -12518,9 +12565,10 @@ checksum = "0ced92c60aa76ec4780a9d93f3bd64dfa916e1b998eacc6f1c110f3f444f02c9"
 
 [[package]]
 name = "solana-tls-utils"
-version = "4.1.2"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=bdf2e1d844b6453819ce6d4a24bc15df830908a4#bdf2e1d844b6453819ce6d4a24bc15df830908a4"
+version = "4.2.0-rc.1"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
 dependencies = [
+ "quinn",
  "rustls 0.23.42",
  "solana-keypair 3.1.2",
  "solana-pubkey 4.2.0",
@@ -12530,8 +12578,8 @@ dependencies = [
 
 [[package]]
 name = "solana-tpu-client"
-version = "4.1.2"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=bdf2e1d844b6453819ce6d4a24bc15df830908a4#bdf2e1d844b6453819ce6d4a24bc15df830908a4"
+version = "4.2.0-rc.1"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
 dependencies = [
  "futures-util",
  "indicatif",
@@ -12542,6 +12590,7 @@ dependencies = [
  "solana-commitment-config 3.1.1",
  "solana-connection-cache",
  "solana-epoch-schedule 3.2.0",
+ "solana-leader-schedule",
  "solana-message 4.3.0",
  "solana-pubkey 4.2.0",
  "solana-pubsub-client",
@@ -12558,8 +12607,8 @@ dependencies = [
 
 [[package]]
 name = "solana-tpu-client-next"
-version = "4.1.2"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=bdf2e1d844b6453819ce6d4a24bc15df830908a4#bdf2e1d844b6453819ce6d4a24bc15df830908a4"
+version = "4.2.0-rc.1"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
 dependencies = [
  "async-trait",
  "futures 0.3.32",
@@ -12571,6 +12620,7 @@ dependencies = [
  "solana-clock 3.1.1",
  "solana-commitment-config 3.1.1",
  "solana-keypair 3.1.2",
+ "solana-leader-schedule",
  "solana-measure",
  "solana-metrics",
  "solana-packet 4.2.0",
@@ -12653,14 +12703,14 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-context"
-version = "4.1.2"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=bdf2e1d844b6453819ce6d4a24bc15df830908a4#bdf2e1d844b6453819ce6d4a24bc15df830908a4"
+version = "4.2.0-rc.1"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
 dependencies = [
  "bincode",
  "serde",
  "solana-account 4.3.1",
  "solana-instruction 3.4.0",
- "solana-instructions-sysvar 3.0.1",
+ "solana-instructions-sysvar 4.0.0",
  "solana-pubkey 4.2.0",
  "solana-rent 4.3.0",
  "solana-sbpf",
@@ -12695,8 +12745,8 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-status"
-version = "4.1.2"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=bdf2e1d844b6453819ce6d4a24bc15df830908a4#bdf2e1d844b6453819ce6d4a24bc15df830908a4"
+version = "4.2.0-rc.1"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
 dependencies = [
  "Inflector",
  "agave-reserved-account-keys",
@@ -12719,7 +12769,7 @@ dependencies = [
  "solana-reward-info 6.2.0",
  "solana-sdk-ids 3.1.0",
  "solana-signature 3.4.1",
- "solana-stake-interface 3.1.0",
+ "solana-stake-interface 4.3.0",
  "solana-system-interface 3.2.0",
  "solana-transaction 4.1.5",
  "solana-transaction-error 3.3.1",
@@ -12729,7 +12779,7 @@ dependencies = [
  "spl-memo-interface",
  "spl-token-2022-interface",
  "spl-token-group-interface",
- "spl-token-interface",
+ "spl-token-interface 3.0.0",
  "spl-token-metadata-interface",
  "thiserror 2.0.18",
  "wincode",
@@ -12737,8 +12787,8 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-status-client-types"
-version = "4.1.2"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=bdf2e1d844b6453819ce6d4a24bc15df830908a4#bdf2e1d844b6453819ce6d4a24bc15df830908a4"
+version = "4.2.0-rc.1"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -12752,7 +12802,7 @@ dependencies = [
  "solana-reward-info 6.2.0",
  "solana-signature 3.4.1",
  "solana-transaction 4.1.5",
- "solana-transaction-context 4.1.2",
+ "solana-transaction-context 4.2.0-rc.1",
  "solana-transaction-error 3.3.1",
  "thiserror 2.0.18",
  "wincode",
@@ -12760,8 +12810,8 @@ dependencies = [
 
 [[package]]
 name = "solana-turbine"
-version = "4.1.2"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=bdf2e1d844b6453819ce6d4a24bc15df830908a4#bdf2e1d844b6453819ce6d4a24bc15df830908a4"
+version = "4.2.0-rc.1"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
 dependencies = [
  "agave-feature-set",
  "agave-votor",
@@ -12780,10 +12830,12 @@ dependencies = [
  "smallvec",
  "solana-clock 3.1.1",
  "solana-cluster-type 3.1.0",
+ "solana-cost-model",
  "solana-entry",
  "solana-gossip",
  "solana-hash 4.5.0",
  "solana-keypair 3.1.2",
+ "solana-leader-schedule",
  "solana-ledger",
  "solana-measure",
  "solana-metrics",
@@ -12808,8 +12860,8 @@ dependencies = [
 
 [[package]]
 name = "solana-udp-client"
-version = "4.1.2"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=bdf2e1d844b6453819ce6d4a24bc15df830908a4#bdf2e1d844b6453819ce6d4a24bc15df830908a4"
+version = "4.2.0-rc.1"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
 dependencies = [
  "async-trait",
  "solana-connection-cache",
@@ -12821,8 +12873,8 @@ dependencies = [
 
 [[package]]
 name = "solana-unified-scheduler-logic"
-version = "4.1.2"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=bdf2e1d844b6453819ce6d4a24bc15df830908a4#bdf2e1d844b6453819ce6d4a24bc15df830908a4"
+version = "4.2.0-rc.1"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
 dependencies = [
  "assert_matches",
  "solana-clock 3.1.1",
@@ -12836,8 +12888,8 @@ dependencies = [
 
 [[package]]
 name = "solana-unified-scheduler-pool"
-version = "4.1.2"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=bdf2e1d844b6453819ce6d4a24bc15df830908a4#bdf2e1d844b6453819ce6d4a24bc15df830908a4"
+version = "4.2.0-rc.1"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
 dependencies = [
  "agave-banking-stage-ingress-types",
  "aquamarine",
@@ -12879,8 +12931,8 @@ checksum = "c5d2face763df5afeaa9509b9019968860e69cc1531ec8b4a2e6c7b702204d5a"
 
 [[package]]
 name = "solana-version"
-version = "4.1.2"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=bdf2e1d844b6453819ce6d4a24bc15df830908a4#bdf2e1d844b6453819ce6d4a24bc15df830908a4"
+version = "4.2.0-rc.1"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
 dependencies = [
  "agave-feature-set",
  "rand 0.9.5",
@@ -12888,12 +12940,14 @@ dependencies = [
  "serde",
  "solana-sanitize 3.0.1",
  "solana-serde-varint 3.0.1",
+ "solana-wincode-varint",
+ "wincode",
 ]
 
 [[package]]
 name = "solana-vote"
-version = "4.1.2"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=bdf2e1d844b6453819ce6d4a24bc15df830908a4#bdf2e1d844b6453819ce6d4a24bc15df830908a4"
+version = "4.2.0-rc.1"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
 dependencies = [
  "bincode",
  "log",
@@ -12971,8 +13025,8 @@ dependencies = [
 
 [[package]]
 name = "solana-vote-program"
-version = "4.1.2"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=bdf2e1d844b6453819ce6d4a24bc15df830908a4#bdf2e1d844b6453819ce6d4a24bc15df830908a4"
+version = "4.2.0-rc.1"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
 dependencies = [
  "agave-feature-set",
  "bincode",
@@ -12991,8 +13045,17 @@ dependencies = [
  "solana-sdk-ids 3.1.0",
  "solana-slot-hashes 3.1.0",
  "solana-system-interface 3.2.0",
- "solana-transaction-context 4.1.2",
+ "solana-transaction-context 4.2.0-rc.1",
  "solana-vote-interface 6.0.3",
+]
+
+[[package]]
+name = "solana-wincode-varint"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6679e72a01dcfe7ff180f0e9d3a0d165e4e9664426930014f2702e7571c259c7"
+dependencies = [
+ "wincode",
 ]
 
 [[package]]
@@ -13008,8 +13071,8 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-elgamal-proof-program"
-version = "4.1.2"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=bdf2e1d844b6453819ce6d4a24bc15df830908a4#bdf2e1d844b6453819ce6d4a24bc15df830908a4"
+version = "4.2.0-rc.1"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
 dependencies = [
  "bytemuck",
  "solana-instruction 3.4.0",
@@ -13092,8 +13155,8 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-token-proof-program"
-version = "4.1.2"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=bdf2e1d844b6453819ce6d4a24bc15df830908a4#bdf2e1d844b6453819ce6d4a24bc15df830908a4"
+version = "4.2.0-rc.1"
+source = "git+https://github.com/jito-foundation/jito-solana.git?rev=2bc2cc03a4e581172fbb47d4f4d88fec9493911e#2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
 dependencies = [
  "solana-program-runtime",
 ]
@@ -13304,6 +13367,26 @@ name = "spl-token-interface"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c564ac05a7c8d8b12e988a37d82695b5ba4db376d07ea98bc4882c81f96c7f3"
+dependencies = [
+ "arrayref",
+ "bytemuck",
+ "num-derive",
+ "num-traits",
+ "num_enum",
+ "solana-instruction 3.4.0",
+ "solana-program-error 3.0.1",
+ "solana-program-option 3.1.0",
+ "solana-program-pack 3.1.0",
+ "solana-pubkey 3.0.0",
+ "solana-sdk-ids 3.1.0",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "spl-token-interface"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7143c4e676984047a400e2fbd7ac29a1659f2b1b52b897cfde19316b562e4589"
 dependencies = [
  "arrayref",
  "bytemuck",
@@ -13750,6 +13833,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "tikv-jemalloc-ctl"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "661f1f6a57b3a36dc9174a2c10f19513b4866816e13425d3e418b11cc37bc24c"
+dependencies = [
+ "libc",
+ "paste",
+ "tikv-jemalloc-sys",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.6.1+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd8aa5b2ab86a2cefa406d889139c162cbb230092f7d1d7cbc1716405d852a3b"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "time"
 version = "0.3.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13777,23 +13881,6 @@ checksum = "c431b87111666e491a90baa837f914fb45cd5dc3c268591b0220ff5057f2085f"
 dependencies = [
  "num-conv",
  "time-core",
-]
-
-[[package]]
-name = "tiny-bip39"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a30fd743a02bf35236f6faf99adb03089bb77e91c998dac2c2ad76bb424f668c"
-dependencies = [
- "once_cell",
- "pbkdf2 0.12.2",
- "rand 0.8.7",
- "rustc-hash 1.1.0",
- "sha2 0.10.9",
- "thiserror 1.0.69",
- "unicode-normalization",
- "wasm-bindgen",
- "zeroize",
 ]
 
 [[package]]
@@ -13828,6 +13915,7 @@ dependencies = [
  "agave-snapshots",
  "anyhow",
  "base64 0.22.1",
+ "bincode",
  "borsh 1.8.0",
  "clap 2.34.0",
  "clap 4.6.2",
@@ -13870,7 +13958,8 @@ dependencies = [
  "solana-rpc-client-api",
  "solana-runtime",
  "solana-sdk 4.0.1",
- "solana-stake-interface 3.1.0",
+ "solana-shred-version 3.0.1",
+ "solana-stake-interface 4.3.0",
  "solana-streamer",
  "solana-system-interface 3.2.0",
  "solana-transaction-status",
@@ -14782,6 +14871,7 @@ version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66d967db7705dc29120bb6e8ce5b5a2e27734ed5976d1c904e95bd238d1c3c5a"
 dependencies = [
+ "bv",
  "bytes",
  "pastey",
  "proc-macro2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13905,7 +13905,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tip-router-operator-cli"
-version = "4.0.5"
+version = "4.2.0"
 dependencies = [
  "agave-snapshots",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ edition = "2021"
 readme = "README.md"
 
 [workspace.dependencies]
-agave-snapshots = { package = "agave-snapshots", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
+agave-snapshots = { package = "agave-snapshots", git = "https://github.com/jito-foundation/jito-solana.git", tag = "v4.2.0-jito" }
 anyhow = "1.0.86"
 assert_matches = "1.5.0"
 base64 = "0.22.1"
@@ -80,48 +80,48 @@ serde_json = "1.0.102"
 serde_with = "3.9.0"
 shank = "0.4.2"
 shank_idl = "0.4.2"
-solana-account-decoder = { package = "solana-account-decoder", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
+solana-account-decoder = { package = "solana-account-decoder", git = "https://github.com/jito-foundation/jito-solana.git", tag = "v4.2.0-jito" }
 solana-account-info = "3.1.1"
-solana-accounts-db = { package = "solana-accounts-db", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
+solana-accounts-db = { package = "solana-accounts-db", git = "https://github.com/jito-foundation/jito-solana.git", tag = "v4.2.0-jito" }
 solana-address-lookup-table-interface = { version = "3.1.0" }
-solana-clap-utils = { package = "solana-clap-utils", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
-solana-cli-config = { package = "solana-cli-config", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
-solana-client = { package = "solana-client", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
+solana-clap-utils = { package = "solana-clap-utils", git = "https://github.com/jito-foundation/jito-solana.git", tag = "v4.2.0-jito" }
+solana-cli-config = { package = "solana-cli-config", git = "https://github.com/jito-foundation/jito-solana.git", tag = "v4.2.0-jito" }
+solana-client = { package = "solana-client", git = "https://github.com/jito-foundation/jito-solana.git", tag = "v4.2.0-jito" }
 solana-clock = "3.0.1"
 solana-commitment-config = "=3.1.1"
 solana-compute-budget-interface = { version = "=3.0.0" }
-solana-core = { package = "solana-core", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
+solana-core = { package = "solana-core", git = "https://github.com/jito-foundation/jito-solana.git", tag = "v4.2.0-jito" }
 solana-decode-error = "=2.3.0"
 solana-genesis-config = "=4.0.0"
-solana-genesis-utils = { package = "solana-genesis-utils", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
-solana-geyser-plugin-manager = { package = "solana-geyser-plugin-manager", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
-solana-gossip = { package = "solana-gossip", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
+solana-genesis-utils = { package = "solana-genesis-utils", git = "https://github.com/jito-foundation/jito-solana.git", tag = "v4.2.0-jito" }
+solana-geyser-plugin-manager = { package = "solana-geyser-plugin-manager", git = "https://github.com/jito-foundation/jito-solana.git", tag = "v4.2.0-jito" }
+solana-gossip = { package = "solana-gossip", git = "https://github.com/jito-foundation/jito-solana.git", tag = "v4.2.0-jito" }
 solana-instruction = "3.4.0"
-solana-ledger = { package = "solana-ledger", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
-solana-measure = { git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
-solana-metrics = { package = "solana-metrics", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
+solana-ledger = { package = "solana-ledger", git = "https://github.com/jito-foundation/jito-solana.git", tag = "v4.2.0-jito" }
+solana-measure = { git = "https://github.com/jito-foundation/jito-solana.git", tag = "v4.2.0-jito" }
+solana-metrics = { package = "solana-metrics", git = "https://github.com/jito-foundation/jito-solana.git", tag = "v4.2.0-jito" }
 solana-program = { version = "4.0.0", default-features = false, features = [] }
 solana-program-entrypoint = "3.0.0"
 solana-program-error = "=3.0.1"
-solana-program-test = { package = "solana-program-test", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
+solana-program-test = { package = "solana-program-test", git = "https://github.com/jito-foundation/jito-solana.git", tag = "v4.2.0-jito" }
 solana-pubkey = "4.2.0"
-solana-rpc = { git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
-solana-rpc-client = { package = "solana-rpc-client", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
-solana-rpc-client-api = { git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
-solana-runtime = { package = "solana-runtime", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
+solana-rpc = { git = "https://github.com/jito-foundation/jito-solana.git", tag = "v4.2.0-jito" }
+solana-rpc-client = { package = "solana-rpc-client", git = "https://github.com/jito-foundation/jito-solana.git", tag = "v4.2.0-jito" }
+solana-rpc-client-api = { git = "https://github.com/jito-foundation/jito-solana.git", tag = "v4.2.0-jito" }
+solana-runtime = { package = "solana-runtime", git = "https://github.com/jito-foundation/jito-solana.git", tag = "v4.2.0-jito" }
 solana-sdk = "=4.0.1"
 solana-security-txt = "1.1.1"
 solana-shred-version = "3.0.1"
 solana-stake-interface = { version = "4.3.0", features = ["bincode", "serde", "sysvar"] }
-#solana-stake-program = { package = "solana-stake-program", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
-solana-streamer = { git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
+#solana-stake-program = { package = "solana-stake-program", git = "https://github.com/jito-foundation/jito-solana.git", tag = "v4.2.0-jito" }
+solana-streamer = { git = "https://github.com/jito-foundation/jito-solana.git", tag = "v4.2.0-jito" }
 solana-system-interface = { version = "3.1.0", features = ["bincode"] }
-solana-transaction-status = { package = "solana-transaction-status", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
-solana-unified-scheduler-pool = { package = "solana-unified-scheduler-pool", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
-solana-vote = { package = "solana-vote", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
+solana-transaction-status = { package = "solana-transaction-status", git = "https://github.com/jito-foundation/jito-solana.git", tag = "v4.2.0-jito" }
+solana-unified-scheduler-pool = { package = "solana-unified-scheduler-pool", git = "https://github.com/jito-foundation/jito-solana.git", tag = "v4.2.0-jito" }
+solana-vote = { package = "solana-vote", git = "https://github.com/jito-foundation/jito-solana.git", tag = "v4.2.0-jito" }
 solana-vote-interface = { version = "6.0.0", features = ["bincode"] }
-#solana-zk-sdk = { package = "solana-zk-sdk", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
-#solana-zk-token-sdk = { package = "solana-zk-token-sdk", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
+#solana-zk-sdk = { package = "solana-zk-sdk", git = "https://github.com/jito-foundation/jito-solana.git", tag = "v4.2.0-jito" }
+#solana-zk-token-sdk = { package = "solana-zk-token-sdk", git = "https://github.com/jito-foundation/jito-solana.git", tag = "v4.2.0-jito" }
 spl-associated-token-account-interface = { version = "2.0.0" }
 spl-math = { version = "0.3.0", features = ["no-entrypoint"] }
 spl-memo-interface = "2.0.0"
@@ -144,76 +144,76 @@ codegen-units = 1
 
 [patch.crates-io]
 switchboard-on-demand = { path = "vendor/switchboard-on-demand" }
-solana-account-decoder = { package = "solana-account-decoder", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
-solana-account-decoder-client-types = { package = "solana-account-decoder-client-types", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
-solana-accounts-db = { package = "solana-accounts-db", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
-solana-banks-client = { package = "solana-banks-client", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
-solana-banks-interface = { package = "solana-banks-interface", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
-solana-banks-server = { package = "solana-banks-server", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
-#solana-bloom = { package = "solana-bloom", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
-#solana-bpf-loader-program = { package = "solana-bpf-loader-program", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
-solana-bucket-map = { package = "solana-bucket-map", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
-solana-builtins-default-costs = { package = "solana-builtins-default-costs", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
-solana-clap-utils = { package = "solana-clap-utils", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
-solana-cli-config = { package = "solana-cli-config", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
-solana-client = { package = "solana-client", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
-solana-compute-budget = { package = "solana-compute-budget", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
-solana-connection-cache = { package = "solana-connection-cache", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
-solana-core = { package = "solana-core", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
-solana-cost-model = { package = "solana-cost-model", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
-#solana-curve25519 = { package = "solana-curve25519", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
-solana-entry = { package = "solana-entry", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
-solana-faucet = { package = "solana-faucet", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
-#solana-fee = { package = "solana-fee", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
-solana-geyser-plugin-manager = { package = "solana-geyser-plugin-manager", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
-#solana-gossip = { package = "solana-gossip", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
-solana-lattice-hash = { package = "solana-lattice-hash", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
-solana-ledger = { package = "solana-ledger", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
-#solana-loader-v4-program = { package = "solana-loader-v4-program", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
-solana-measure = { package = "solana-measure", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
-solana-merkle-tree = { package = "solana-merkle-tree", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
-solana-metrics = { package = "solana-metrics", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
-#solana-net-utils = { package = "solana-net-utils", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
-solana-perf = { package = "solana-perf", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
-solana-poh = { package = "solana-poh", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
-#solana-poseidon = { package = "solana-poseidon", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
-#solana-program-runtime = { package = "solana-program-runtime", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
-solana-program-test = { package = "solana-program-test", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
-solana-pubsub-client = { package = "solana-pubsub-client", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
-solana-quic-client = { package = "solana-quic-client", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
-solana-rayon-threadlimit = { package = "solana-rayon-threadlimit", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
-solana-remote-wallet = { package = "solana-remote-wallet", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
-#solana-timings = { package = "solana-timings", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
-solana-unified-scheduler-logic = { package = "solana-unified-scheduler-logic", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
-solana-unified-scheduler-pool = { package = "solana-unified-scheduler-pool", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
-solana-rpc = { package = "solana-rpc", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
-solana-rpc-client = { package = "solana-rpc-client", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
-solana-rpc-client-api = { package = "solana-rpc-client-api", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
-solana-rpc-client-nonce-utils = { package = "solana-rpc-client-nonce-utils", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
-solana-runtime = { package = "solana-runtime", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
-#solana-runtime-transaction = { package = "solana-runtime-transaction", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
-solana-send-transaction-service = { package = "solana-send-transaction-service", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
-#solana-stake-program = { package = "solana-stake-program", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
-solana-storage-bigtable = { package = "solana-storage-bigtable", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
-solana-storage-proto = { package = "solana-storage-proto", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
-solana-streamer = { package = "solana-streamer", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
-#solana-svm = { package = "solana-svm", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
-#solana-svm-rent-collector = { package = "solana-svm-rent-collector", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
-#solana-svm-transaction = { package = "solana-svm-transaction", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
-solana-system-program = { package = "solana-system-program", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
-#solana-thin-client = { package = "solana-thin-client", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
-solana-tpu-client = { package = "solana-tpu-client", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
-solana-transaction-status = { package = "solana-transaction-status", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
-solana-transaction-status-client-types = { package = "solana-transaction-status-client-types", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
-#solana-transaction-metrics-tracker = { package = "solana-transaction-metrics-tracker", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
-#solana-turbine = { package = "solana-turbine", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
-#solana-type-overrides = { package = "solana-type-overrides", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
-solana-udp-client = { package = "solana-udp-client", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
-solana-version = { package = "solana-version", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
-solana-vote = { package = "solana-vote", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
-solana-vote-program = { package = "solana-vote-program", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
-#solana-wen-restart = { package = "solana-wen-restart", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
-solana-zk-elgamal-proof-program = { package = "solana-zk-elgamal-proof-program", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
-#solana-zk-sdk = { package = "solana-zk-sdk", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
-#solana-zk-token-proof-program = { package = "solana-zk-token-proof-program", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
-#solana-zk-token-sdk = { package = "solana-zk-token-sdk", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
+solana-account-decoder = { package = "solana-account-decoder", git = "https://github.com/jito-foundation/jito-solana.git", tag = "v4.2.0-jito" }
+solana-account-decoder-client-types = { package = "solana-account-decoder-client-types", git = "https://github.com/jito-foundation/jito-solana.git", tag = "v4.2.0-jito" }
+solana-accounts-db = { package = "solana-accounts-db", git = "https://github.com/jito-foundation/jito-solana.git", tag = "v4.2.0-jito" }
+solana-banks-client = { package = "solana-banks-client", git = "https://github.com/jito-foundation/jito-solana.git", tag = "v4.2.0-jito" }
+solana-banks-interface = { package = "solana-banks-interface", git = "https://github.com/jito-foundation/jito-solana.git", tag = "v4.2.0-jito" }
+solana-banks-server = { package = "solana-banks-server", git = "https://github.com/jito-foundation/jito-solana.git", tag = "v4.2.0-jito" }
+#solana-bloom = { package = "solana-bloom", git = "https://github.com/jito-foundation/jito-solana.git", tag = "v4.2.0-jito" }
+#solana-bpf-loader-program = { package = "solana-bpf-loader-program", git = "https://github.com/jito-foundation/jito-solana.git", tag = "v4.2.0-jito" }
+solana-bucket-map = { package = "solana-bucket-map", git = "https://github.com/jito-foundation/jito-solana.git", tag = "v4.2.0-jito" }
+solana-builtins-default-costs = { package = "solana-builtins-default-costs", git = "https://github.com/jito-foundation/jito-solana.git", tag = "v4.2.0-jito" }
+solana-clap-utils = { package = "solana-clap-utils", git = "https://github.com/jito-foundation/jito-solana.git", tag = "v4.2.0-jito" }
+solana-cli-config = { package = "solana-cli-config", git = "https://github.com/jito-foundation/jito-solana.git", tag = "v4.2.0-jito" }
+solana-client = { package = "solana-client", git = "https://github.com/jito-foundation/jito-solana.git", tag = "v4.2.0-jito" }
+solana-compute-budget = { package = "solana-compute-budget", git = "https://github.com/jito-foundation/jito-solana.git", tag = "v4.2.0-jito" }
+solana-connection-cache = { package = "solana-connection-cache", git = "https://github.com/jito-foundation/jito-solana.git", tag = "v4.2.0-jito" }
+solana-core = { package = "solana-core", git = "https://github.com/jito-foundation/jito-solana.git", tag = "v4.2.0-jito" }
+solana-cost-model = { package = "solana-cost-model", git = "https://github.com/jito-foundation/jito-solana.git", tag = "v4.2.0-jito" }
+#solana-curve25519 = { package = "solana-curve25519", git = "https://github.com/jito-foundation/jito-solana.git", tag = "v4.2.0-jito" }
+solana-entry = { package = "solana-entry", git = "https://github.com/jito-foundation/jito-solana.git", tag = "v4.2.0-jito" }
+solana-faucet = { package = "solana-faucet", git = "https://github.com/jito-foundation/jito-solana.git", tag = "v4.2.0-jito" }
+#solana-fee = { package = "solana-fee", git = "https://github.com/jito-foundation/jito-solana.git", tag = "v4.2.0-jito" }
+solana-geyser-plugin-manager = { package = "solana-geyser-plugin-manager", git = "https://github.com/jito-foundation/jito-solana.git", tag = "v4.2.0-jito" }
+#solana-gossip = { package = "solana-gossip", git = "https://github.com/jito-foundation/jito-solana.git", tag = "v4.2.0-jito" }
+solana-lattice-hash = { package = "solana-lattice-hash", git = "https://github.com/jito-foundation/jito-solana.git", tag = "v4.2.0-jito" }
+solana-ledger = { package = "solana-ledger", git = "https://github.com/jito-foundation/jito-solana.git", tag = "v4.2.0-jito" }
+#solana-loader-v4-program = { package = "solana-loader-v4-program", git = "https://github.com/jito-foundation/jito-solana.git", tag = "v4.2.0-jito" }
+solana-measure = { package = "solana-measure", git = "https://github.com/jito-foundation/jito-solana.git", tag = "v4.2.0-jito" }
+solana-merkle-tree = { package = "solana-merkle-tree", git = "https://github.com/jito-foundation/jito-solana.git", tag = "v4.2.0-jito" }
+solana-metrics = { package = "solana-metrics", git = "https://github.com/jito-foundation/jito-solana.git", tag = "v4.2.0-jito" }
+#solana-net-utils = { package = "solana-net-utils", git = "https://github.com/jito-foundation/jito-solana.git", tag = "v4.2.0-jito" }
+solana-perf = { package = "solana-perf", git = "https://github.com/jito-foundation/jito-solana.git", tag = "v4.2.0-jito" }
+solana-poh = { package = "solana-poh", git = "https://github.com/jito-foundation/jito-solana.git", tag = "v4.2.0-jito" }
+#solana-poseidon = { package = "solana-poseidon", git = "https://github.com/jito-foundation/jito-solana.git", tag = "v4.2.0-jito" }
+#solana-program-runtime = { package = "solana-program-runtime", git = "https://github.com/jito-foundation/jito-solana.git", tag = "v4.2.0-jito" }
+solana-program-test = { package = "solana-program-test", git = "https://github.com/jito-foundation/jito-solana.git", tag = "v4.2.0-jito" }
+solana-pubsub-client = { package = "solana-pubsub-client", git = "https://github.com/jito-foundation/jito-solana.git", tag = "v4.2.0-jito" }
+solana-quic-client = { package = "solana-quic-client", git = "https://github.com/jito-foundation/jito-solana.git", tag = "v4.2.0-jito" }
+solana-rayon-threadlimit = { package = "solana-rayon-threadlimit", git = "https://github.com/jito-foundation/jito-solana.git", tag = "v4.2.0-jito" }
+solana-remote-wallet = { package = "solana-remote-wallet", git = "https://github.com/jito-foundation/jito-solana.git", tag = "v4.2.0-jito" }
+#solana-timings = { package = "solana-timings", git = "https://github.com/jito-foundation/jito-solana.git", tag = "v4.2.0-jito" }
+solana-unified-scheduler-logic = { package = "solana-unified-scheduler-logic", git = "https://github.com/jito-foundation/jito-solana.git", tag = "v4.2.0-jito" }
+solana-unified-scheduler-pool = { package = "solana-unified-scheduler-pool", git = "https://github.com/jito-foundation/jito-solana.git", tag = "v4.2.0-jito" }
+solana-rpc = { package = "solana-rpc", git = "https://github.com/jito-foundation/jito-solana.git", tag = "v4.2.0-jito" }
+solana-rpc-client = { package = "solana-rpc-client", git = "https://github.com/jito-foundation/jito-solana.git", tag = "v4.2.0-jito" }
+solana-rpc-client-api = { package = "solana-rpc-client-api", git = "https://github.com/jito-foundation/jito-solana.git", tag = "v4.2.0-jito" }
+solana-rpc-client-nonce-utils = { package = "solana-rpc-client-nonce-utils", git = "https://github.com/jito-foundation/jito-solana.git", tag = "v4.2.0-jito" }
+solana-runtime = { package = "solana-runtime", git = "https://github.com/jito-foundation/jito-solana.git", tag = "v4.2.0-jito" }
+#solana-runtime-transaction = { package = "solana-runtime-transaction", git = "https://github.com/jito-foundation/jito-solana.git", tag = "v4.2.0-jito" }
+solana-send-transaction-service = { package = "solana-send-transaction-service", git = "https://github.com/jito-foundation/jito-solana.git", tag = "v4.2.0-jito" }
+#solana-stake-program = { package = "solana-stake-program", git = "https://github.com/jito-foundation/jito-solana.git", tag = "v4.2.0-jito" }
+solana-storage-bigtable = { package = "solana-storage-bigtable", git = "https://github.com/jito-foundation/jito-solana.git", tag = "v4.2.0-jito" }
+solana-storage-proto = { package = "solana-storage-proto", git = "https://github.com/jito-foundation/jito-solana.git", tag = "v4.2.0-jito" }
+solana-streamer = { package = "solana-streamer", git = "https://github.com/jito-foundation/jito-solana.git", tag = "v4.2.0-jito" }
+#solana-svm = { package = "solana-svm", git = "https://github.com/jito-foundation/jito-solana.git", tag = "v4.2.0-jito" }
+#solana-svm-rent-collector = { package = "solana-svm-rent-collector", git = "https://github.com/jito-foundation/jito-solana.git", tag = "v4.2.0-jito" }
+#solana-svm-transaction = { package = "solana-svm-transaction", git = "https://github.com/jito-foundation/jito-solana.git", tag = "v4.2.0-jito" }
+solana-system-program = { package = "solana-system-program", git = "https://github.com/jito-foundation/jito-solana.git", tag = "v4.2.0-jito" }
+#solana-thin-client = { package = "solana-thin-client", git = "https://github.com/jito-foundation/jito-solana.git", tag = "v4.2.0-jito" }
+solana-tpu-client = { package = "solana-tpu-client", git = "https://github.com/jito-foundation/jito-solana.git", tag = "v4.2.0-jito" }
+solana-transaction-status = { package = "solana-transaction-status", git = "https://github.com/jito-foundation/jito-solana.git", tag = "v4.2.0-jito" }
+solana-transaction-status-client-types = { package = "solana-transaction-status-client-types", git = "https://github.com/jito-foundation/jito-solana.git", tag = "v4.2.0-jito" }
+#solana-transaction-metrics-tracker = { package = "solana-transaction-metrics-tracker", git = "https://github.com/jito-foundation/jito-solana.git", tag = "v4.2.0-jito" }
+#solana-turbine = { package = "solana-turbine", git = "https://github.com/jito-foundation/jito-solana.git", tag = "v4.2.0-jito" }
+#solana-type-overrides = { package = "solana-type-overrides", git = "https://github.com/jito-foundation/jito-solana.git", tag = "v4.2.0-jito" }
+solana-udp-client = { package = "solana-udp-client", git = "https://github.com/jito-foundation/jito-solana.git", tag = "v4.2.0-jito" }
+solana-version = { package = "solana-version", git = "https://github.com/jito-foundation/jito-solana.git", tag = "v4.2.0-jito" }
+solana-vote = { package = "solana-vote", git = "https://github.com/jito-foundation/jito-solana.git", tag = "v4.2.0-jito" }
+solana-vote-program = { package = "solana-vote-program", git = "https://github.com/jito-foundation/jito-solana.git", tag = "v4.2.0-jito" }
+#solana-wen-restart = { package = "solana-wen-restart", git = "https://github.com/jito-foundation/jito-solana.git", tag = "v4.2.0-jito" }
+solana-zk-elgamal-proof-program = { package = "solana-zk-elgamal-proof-program", git = "https://github.com/jito-foundation/jito-solana.git", tag = "v4.2.0-jito" }
+#solana-zk-sdk = { package = "solana-zk-sdk", git = "https://github.com/jito-foundation/jito-solana.git", tag = "v4.2.0-jito" }
+#solana-zk-token-proof-program = { package = "solana-zk-token-proof-program", git = "https://github.com/jito-foundation/jito-solana.git", tag = "v4.2.0-jito" }
+#solana-zk-token-sdk = { package = "solana-zk-token-sdk", git = "https://github.com/jito-foundation/jito-solana.git", tag = "v4.2.0-jito" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,10 +26,11 @@ edition = "2021"
 readme = "README.md"
 
 [workspace.dependencies]
-agave-snapshots = { package = "agave-snapshots", git = "https://github.com/jito-foundation/jito-solana.git", rev = "bdf2e1d844b6453819ce6d4a24bc15df830908a4" }
+agave-snapshots = { package = "agave-snapshots", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
 anyhow = "1.0.86"
 assert_matches = "1.5.0"
 base64 = "0.22.1"
+bincode = "1.3.3"
 borsh = { version = "1.5.7", features = ["derive"] }
 bytemuck = { version = "1.16.3", features = ["min_const_generics"] }
 cfg-if = "1.0.0"
@@ -79,47 +80,48 @@ serde_json = "1.0.102"
 serde_with = "3.9.0"
 shank = "0.4.2"
 shank_idl = "0.4.2"
-solana-account-decoder = { package = "solana-account-decoder", git = "https://github.com/jito-foundation/jito-solana.git", rev = "bdf2e1d844b6453819ce6d4a24bc15df830908a4" }
+solana-account-decoder = { package = "solana-account-decoder", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
 solana-account-info = "3.1.1"
-solana-accounts-db = { package = "solana-accounts-db", git = "https://github.com/jito-foundation/jito-solana.git", rev = "bdf2e1d844b6453819ce6d4a24bc15df830908a4" }
+solana-accounts-db = { package = "solana-accounts-db", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
 solana-address-lookup-table-interface = { version = "3.1.0" }
-solana-clap-utils = { package = "solana-clap-utils", git = "https://github.com/jito-foundation/jito-solana.git", rev = "bdf2e1d844b6453819ce6d4a24bc15df830908a4" }
-solana-cli-config = { package = "solana-cli-config", git = "https://github.com/jito-foundation/jito-solana.git", rev = "bdf2e1d844b6453819ce6d4a24bc15df830908a4" }
-solana-client = { package = "solana-client", git = "https://github.com/jito-foundation/jito-solana.git", rev = "bdf2e1d844b6453819ce6d4a24bc15df830908a4" }
+solana-clap-utils = { package = "solana-clap-utils", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
+solana-cli-config = { package = "solana-cli-config", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
+solana-client = { package = "solana-client", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
 solana-clock = "3.0.1"
 solana-commitment-config = "=3.1.1"
 solana-compute-budget-interface = { version = "=3.0.0" }
-solana-core = { package = "solana-core", git = "https://github.com/jito-foundation/jito-solana.git", rev = "bdf2e1d844b6453819ce6d4a24bc15df830908a4" }
+solana-core = { package = "solana-core", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
 solana-decode-error = "=2.3.0"
 solana-genesis-config = "=4.0.0"
-solana-genesis-utils = { package = "solana-genesis-utils", git = "https://github.com/jito-foundation/jito-solana.git", rev = "bdf2e1d844b6453819ce6d4a24bc15df830908a4" }
-solana-geyser-plugin-manager = { package = "solana-geyser-plugin-manager", git = "https://github.com/jito-foundation/jito-solana.git", rev = "bdf2e1d844b6453819ce6d4a24bc15df830908a4" }
-solana-gossip = { package = "solana-gossip", git = "https://github.com/jito-foundation/jito-solana.git", rev = "bdf2e1d844b6453819ce6d4a24bc15df830908a4" }
+solana-genesis-utils = { package = "solana-genesis-utils", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
+solana-geyser-plugin-manager = { package = "solana-geyser-plugin-manager", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
+solana-gossip = { package = "solana-gossip", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
 solana-instruction = "3.4.0"
-solana-ledger = { package = "solana-ledger", git = "https://github.com/jito-foundation/jito-solana.git", rev = "bdf2e1d844b6453819ce6d4a24bc15df830908a4" }
-solana-measure = { git = "https://github.com/jito-foundation/jito-solana.git", rev = "bdf2e1d844b6453819ce6d4a24bc15df830908a4" }
-solana-metrics = { package = "solana-metrics", git = "https://github.com/jito-foundation/jito-solana.git", rev = "bdf2e1d844b6453819ce6d4a24bc15df830908a4" }
+solana-ledger = { package = "solana-ledger", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
+solana-measure = { git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
+solana-metrics = { package = "solana-metrics", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
 solana-program = { version = "4.0.0", default-features = false, features = [] }
 solana-program-entrypoint = "3.0.0"
 solana-program-error = "=3.0.1"
-solana-program-test = { package = "solana-program-test", git = "https://github.com/jito-foundation/jito-solana.git", rev = "bdf2e1d844b6453819ce6d4a24bc15df830908a4" }
+solana-program-test = { package = "solana-program-test", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
 solana-pubkey = "4.2.0"
-solana-rpc = { git = "https://github.com/jito-foundation/jito-solana.git", rev = "bdf2e1d844b6453819ce6d4a24bc15df830908a4" }
-solana-rpc-client = { package = "solana-rpc-client", git = "https://github.com/jito-foundation/jito-solana.git", rev = "bdf2e1d844b6453819ce6d4a24bc15df830908a4" }
-solana-rpc-client-api = { git = "https://github.com/jito-foundation/jito-solana.git", rev = "bdf2e1d844b6453819ce6d4a24bc15df830908a4" }
-solana-runtime = { package = "solana-runtime", git = "https://github.com/jito-foundation/jito-solana.git", rev = "bdf2e1d844b6453819ce6d4a24bc15df830908a4" }
+solana-rpc = { git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
+solana-rpc-client = { package = "solana-rpc-client", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
+solana-rpc-client-api = { git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
+solana-runtime = { package = "solana-runtime", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
 solana-sdk = "=4.0.1"
 solana-security-txt = "1.1.1"
-solana-stake-interface = { version = "3.1.0", features = ["sysvar"] }
-#solana-stake-program = { package = "solana-stake-program", git = "https://github.com/jito-foundation/jito-solana.git", rev = "bdf2e1d844b6453819ce6d4a24bc15df830908a4" }
-solana-streamer = { git = "https://github.com/jito-foundation/jito-solana.git", rev = "bdf2e1d844b6453819ce6d4a24bc15df830908a4" }
+solana-shred-version = "3.0.1"
+solana-stake-interface = { version = "4.3.0", features = ["bincode", "serde", "sysvar"] }
+#solana-stake-program = { package = "solana-stake-program", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
+solana-streamer = { git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
 solana-system-interface = { version = "3.1.0", features = ["bincode"] }
-solana-transaction-status = { package = "solana-transaction-status", git = "https://github.com/jito-foundation/jito-solana.git", rev = "bdf2e1d844b6453819ce6d4a24bc15df830908a4" }
-solana-unified-scheduler-pool = { package = "solana-unified-scheduler-pool", git = "https://github.com/jito-foundation/jito-solana.git", rev = "bdf2e1d844b6453819ce6d4a24bc15df830908a4" }
-solana-vote = { package = "solana-vote", git = "https://github.com/jito-foundation/jito-solana.git", rev = "bdf2e1d844b6453819ce6d4a24bc15df830908a4" }
+solana-transaction-status = { package = "solana-transaction-status", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
+solana-unified-scheduler-pool = { package = "solana-unified-scheduler-pool", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
+solana-vote = { package = "solana-vote", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
 solana-vote-interface = { version = "6.0.0", features = ["bincode"] }
-#solana-zk-sdk = { package = "solana-zk-sdk", git = "https://github.com/jito-foundation/jito-solana.git", rev = "bdf2e1d844b6453819ce6d4a24bc15df830908a4" }
-#solana-zk-token-sdk = { package = "solana-zk-token-sdk", git = "https://github.com/jito-foundation/jito-solana.git", rev = "bdf2e1d844b6453819ce6d4a24bc15df830908a4" }
+#solana-zk-sdk = { package = "solana-zk-sdk", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
+#solana-zk-token-sdk = { package = "solana-zk-token-sdk", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
 spl-associated-token-account-interface = { version = "2.0.0" }
 spl-math = { version = "0.3.0", features = ["no-entrypoint"] }
 spl-memo-interface = "2.0.0"
@@ -142,76 +144,76 @@ codegen-units = 1
 
 [patch.crates-io]
 switchboard-on-demand = { path = "vendor/switchboard-on-demand" }
-solana-account-decoder = { package = "solana-account-decoder", git = "https://github.com/jito-foundation/jito-solana.git", rev = "bdf2e1d844b6453819ce6d4a24bc15df830908a4" }
-solana-account-decoder-client-types = { package = "solana-account-decoder-client-types", git = "https://github.com/jito-foundation/jito-solana.git", rev = "bdf2e1d844b6453819ce6d4a24bc15df830908a4" }
-solana-accounts-db = { package = "solana-accounts-db", git = "https://github.com/jito-foundation/jito-solana.git", rev = "bdf2e1d844b6453819ce6d4a24bc15df830908a4" }
-solana-banks-client = { package = "solana-banks-client", git = "https://github.com/jito-foundation/jito-solana.git", rev = "bdf2e1d844b6453819ce6d4a24bc15df830908a4" }
-solana-banks-interface = { package = "solana-banks-interface", git = "https://github.com/jito-foundation/jito-solana.git", rev = "bdf2e1d844b6453819ce6d4a24bc15df830908a4" }
-solana-banks-server = { package = "solana-banks-server", git = "https://github.com/jito-foundation/jito-solana.git", rev = "bdf2e1d844b6453819ce6d4a24bc15df830908a4" }
-#solana-bloom = { package = "solana-bloom", git = "https://github.com/jito-foundation/jito-solana.git", rev = "bdf2e1d844b6453819ce6d4a24bc15df830908a4" }
-#solana-bpf-loader-program = { package = "solana-bpf-loader-program", git = "https://github.com/jito-foundation/jito-solana.git", rev = "bdf2e1d844b6453819ce6d4a24bc15df830908a4" }
-solana-bucket-map = { package = "solana-bucket-map", git = "https://github.com/jito-foundation/jito-solana.git", rev = "bdf2e1d844b6453819ce6d4a24bc15df830908a4" }
-solana-builtins-default-costs = { package = "solana-builtins-default-costs", git = "https://github.com/jito-foundation/jito-solana.git", rev = "bdf2e1d844b6453819ce6d4a24bc15df830908a4" }
-solana-clap-utils = { package = "solana-clap-utils", git = "https://github.com/jito-foundation/jito-solana.git", rev = "bdf2e1d844b6453819ce6d4a24bc15df830908a4" }
-solana-cli-config = { package = "solana-cli-config", git = "https://github.com/jito-foundation/jito-solana.git", rev = "bdf2e1d844b6453819ce6d4a24bc15df830908a4" }
-solana-client = { package = "solana-client", git = "https://github.com/jito-foundation/jito-solana.git", rev = "bdf2e1d844b6453819ce6d4a24bc15df830908a4" }
-solana-compute-budget = { package = "solana-compute-budget", git = "https://github.com/jito-foundation/jito-solana.git", rev = "bdf2e1d844b6453819ce6d4a24bc15df830908a4" }
-solana-connection-cache = { package = "solana-connection-cache", git = "https://github.com/jito-foundation/jito-solana.git", rev = "bdf2e1d844b6453819ce6d4a24bc15df830908a4" }
-solana-core = { package = "solana-core", git = "https://github.com/jito-foundation/jito-solana.git", rev = "bdf2e1d844b6453819ce6d4a24bc15df830908a4" }
-solana-cost-model = { package = "solana-cost-model", git = "https://github.com/jito-foundation/jito-solana.git", rev = "bdf2e1d844b6453819ce6d4a24bc15df830908a4" }
-#solana-curve25519 = { package = "solana-curve25519", git = "https://github.com/jito-foundation/jito-solana.git", rev = "bdf2e1d844b6453819ce6d4a24bc15df830908a4" }
-solana-entry = { package = "solana-entry", git = "https://github.com/jito-foundation/jito-solana.git", rev = "bdf2e1d844b6453819ce6d4a24bc15df830908a4" }
-solana-faucet = { package = "solana-faucet", git = "https://github.com/jito-foundation/jito-solana.git", rev = "bdf2e1d844b6453819ce6d4a24bc15df830908a4" }
-#solana-fee = { package = "solana-fee", git = "https://github.com/jito-foundation/jito-solana.git", rev = "bdf2e1d844b6453819ce6d4a24bc15df830908a4" }
-solana-geyser-plugin-manager = { package = "solana-geyser-plugin-manager", git = "https://github.com/jito-foundation/jito-solana.git", rev = "bdf2e1d844b6453819ce6d4a24bc15df830908a4" }
-#solana-gossip = { package = "solana-gossip", git = "https://github.com/jito-foundation/jito-solana.git", rev = "bdf2e1d844b6453819ce6d4a24bc15df830908a4" }
-solana-lattice-hash = { package = "solana-lattice-hash", git = "https://github.com/jito-foundation/jito-solana.git", rev = "bdf2e1d844b6453819ce6d4a24bc15df830908a4" }
-solana-ledger = { package = "solana-ledger", git = "https://github.com/jito-foundation/jito-solana.git", rev = "bdf2e1d844b6453819ce6d4a24bc15df830908a4" }
-#solana-loader-v4-program = { package = "solana-loader-v4-program", git = "https://github.com/jito-foundation/jito-solana.git", rev = "bdf2e1d844b6453819ce6d4a24bc15df830908a4" }
-solana-measure = { package = "solana-measure", git = "https://github.com/jito-foundation/jito-solana.git", rev = "bdf2e1d844b6453819ce6d4a24bc15df830908a4" }
-solana-merkle-tree = { package = "solana-merkle-tree", git = "https://github.com/jito-foundation/jito-solana.git", rev = "bdf2e1d844b6453819ce6d4a24bc15df830908a4" }
-solana-metrics = { package = "solana-metrics", git = "https://github.com/jito-foundation/jito-solana.git", rev = "bdf2e1d844b6453819ce6d4a24bc15df830908a4" }
-#solana-net-utils = { package = "solana-net-utils", git = "https://github.com/jito-foundation/jito-solana.git", rev = "bdf2e1d844b6453819ce6d4a24bc15df830908a4" }
-solana-perf = { package = "solana-perf", git = "https://github.com/jito-foundation/jito-solana.git", rev = "bdf2e1d844b6453819ce6d4a24bc15df830908a4" }
-solana-poh = { package = "solana-poh", git = "https://github.com/jito-foundation/jito-solana.git", rev = "bdf2e1d844b6453819ce6d4a24bc15df830908a4" }
-#solana-poseidon = { package = "solana-poseidon", git = "https://github.com/jito-foundation/jito-solana.git", rev = "bdf2e1d844b6453819ce6d4a24bc15df830908a4" }
-#solana-program-runtime = { package = "solana-program-runtime", git = "https://github.com/jito-foundation/jito-solana.git", rev = "bdf2e1d844b6453819ce6d4a24bc15df830908a4" }
-solana-program-test = { package = "solana-program-test", git = "https://github.com/jito-foundation/jito-solana.git", rev = "bdf2e1d844b6453819ce6d4a24bc15df830908a4" }
-solana-pubsub-client = { package = "solana-pubsub-client", git = "https://github.com/jito-foundation/jito-solana.git", rev = "bdf2e1d844b6453819ce6d4a24bc15df830908a4" }
-solana-quic-client = { package = "solana-quic-client", git = "https://github.com/jito-foundation/jito-solana.git", rev = "bdf2e1d844b6453819ce6d4a24bc15df830908a4" }
-solana-rayon-threadlimit = { package = "solana-rayon-threadlimit", git = "https://github.com/jito-foundation/jito-solana.git", rev = "bdf2e1d844b6453819ce6d4a24bc15df830908a4" }
-solana-remote-wallet = { package = "solana-remote-wallet", git = "https://github.com/jito-foundation/jito-solana.git", rev = "bdf2e1d844b6453819ce6d4a24bc15df830908a4" }
-#solana-timings = { package = "solana-timings", git = "https://github.com/jito-foundation/jito-solana.git", rev = "bdf2e1d844b6453819ce6d4a24bc15df830908a4" }
-solana-unified-scheduler-logic = { package = "solana-unified-scheduler-logic", git = "https://github.com/jito-foundation/jito-solana.git", rev = "bdf2e1d844b6453819ce6d4a24bc15df830908a4" }
-solana-unified-scheduler-pool = { package = "solana-unified-scheduler-pool", git = "https://github.com/jito-foundation/jito-solana.git", rev = "bdf2e1d844b6453819ce6d4a24bc15df830908a4" }
-solana-rpc = { package = "solana-rpc", git = "https://github.com/jito-foundation/jito-solana.git", rev = "bdf2e1d844b6453819ce6d4a24bc15df830908a4" }
-solana-rpc-client = { package = "solana-rpc-client", git = "https://github.com/jito-foundation/jito-solana.git", rev = "bdf2e1d844b6453819ce6d4a24bc15df830908a4" }
-solana-rpc-client-api = { package = "solana-rpc-client-api", git = "https://github.com/jito-foundation/jito-solana.git", rev = "bdf2e1d844b6453819ce6d4a24bc15df830908a4" }
-solana-rpc-client-nonce-utils = { package = "solana-rpc-client-nonce-utils", git = "https://github.com/jito-foundation/jito-solana.git", rev = "bdf2e1d844b6453819ce6d4a24bc15df830908a4" }
-solana-runtime = { package = "solana-runtime", git = "https://github.com/jito-foundation/jito-solana.git", rev = "bdf2e1d844b6453819ce6d4a24bc15df830908a4" }
-#solana-runtime-transaction = { package = "solana-runtime-transaction", git = "https://github.com/jito-foundation/jito-solana.git", rev = "bdf2e1d844b6453819ce6d4a24bc15df830908a4" }
-solana-send-transaction-service = { package = "solana-send-transaction-service", git = "https://github.com/jito-foundation/jito-solana.git", rev = "bdf2e1d844b6453819ce6d4a24bc15df830908a4" }
-#solana-stake-program = { package = "solana-stake-program", git = "https://github.com/jito-foundation/jito-solana.git", rev = "bdf2e1d844b6453819ce6d4a24bc15df830908a4" }
-solana-storage-bigtable = { package = "solana-storage-bigtable", git = "https://github.com/jito-foundation/jito-solana.git", rev = "bdf2e1d844b6453819ce6d4a24bc15df830908a4" }
-solana-storage-proto = { package = "solana-storage-proto", git = "https://github.com/jito-foundation/jito-solana.git", rev = "bdf2e1d844b6453819ce6d4a24bc15df830908a4" }
-solana-streamer = { package = "solana-streamer", git = "https://github.com/jito-foundation/jito-solana.git", rev = "bdf2e1d844b6453819ce6d4a24bc15df830908a4" }
-#solana-svm = { package = "solana-svm", git = "https://github.com/jito-foundation/jito-solana.git", rev = "bdf2e1d844b6453819ce6d4a24bc15df830908a4" }
-#solana-svm-rent-collector = { package = "solana-svm-rent-collector", git = "https://github.com/jito-foundation/jito-solana.git", rev = "bdf2e1d844b6453819ce6d4a24bc15df830908a4" }
-#solana-svm-transaction = { package = "solana-svm-transaction", git = "https://github.com/jito-foundation/jito-solana.git", rev = "bdf2e1d844b6453819ce6d4a24bc15df830908a4" }
-solana-system-program = { package = "solana-system-program", git = "https://github.com/jito-foundation/jito-solana.git", rev = "bdf2e1d844b6453819ce6d4a24bc15df830908a4" }
-#solana-thin-client = { package = "solana-thin-client", git = "https://github.com/jito-foundation/jito-solana.git", rev = "bdf2e1d844b6453819ce6d4a24bc15df830908a4" }
-solana-tpu-client = { package = "solana-tpu-client", git = "https://github.com/jito-foundation/jito-solana.git", rev = "bdf2e1d844b6453819ce6d4a24bc15df830908a4" }
-solana-transaction-status = { package = "solana-transaction-status", git = "https://github.com/jito-foundation/jito-solana.git", rev = "bdf2e1d844b6453819ce6d4a24bc15df830908a4" }
-solana-transaction-status-client-types = { package = "solana-transaction-status-client-types", git = "https://github.com/jito-foundation/jito-solana.git", rev = "bdf2e1d844b6453819ce6d4a24bc15df830908a4" }
-#solana-transaction-metrics-tracker = { package = "solana-transaction-metrics-tracker", git = "https://github.com/jito-foundation/jito-solana.git", rev = "bdf2e1d844b6453819ce6d4a24bc15df830908a4" }
-#solana-turbine = { package = "solana-turbine", git = "https://github.com/jito-foundation/jito-solana.git", rev = "bdf2e1d844b6453819ce6d4a24bc15df830908a4" }
-#solana-type-overrides = { package = "solana-type-overrides", git = "https://github.com/jito-foundation/jito-solana.git", rev = "bdf2e1d844b6453819ce6d4a24bc15df830908a4" }
-solana-udp-client = { package = "solana-udp-client", git = "https://github.com/jito-foundation/jito-solana.git", rev = "bdf2e1d844b6453819ce6d4a24bc15df830908a4" }
-solana-version = { package = "solana-version", git = "https://github.com/jito-foundation/jito-solana.git", rev = "bdf2e1d844b6453819ce6d4a24bc15df830908a4" }
-solana-vote = { package = "solana-vote", git = "https://github.com/jito-foundation/jito-solana.git", rev = "bdf2e1d844b6453819ce6d4a24bc15df830908a4" }
-solana-vote-program = { package = "solana-vote-program", git = "https://github.com/jito-foundation/jito-solana.git", rev = "bdf2e1d844b6453819ce6d4a24bc15df830908a4" }
-#solana-wen-restart = { package = "solana-wen-restart", git = "https://github.com/jito-foundation/jito-solana.git", rev = "bdf2e1d844b6453819ce6d4a24bc15df830908a4" }
-solana-zk-elgamal-proof-program = { package = "solana-zk-elgamal-proof-program", git = "https://github.com/jito-foundation/jito-solana.git", rev = "bdf2e1d844b6453819ce6d4a24bc15df830908a4" }
-#solana-zk-sdk = { package = "solana-zk-sdk", git = "https://github.com/jito-foundation/jito-solana.git", rev = "bdf2e1d844b6453819ce6d4a24bc15df830908a4" }
-#solana-zk-token-proof-program = { package = "solana-zk-token-proof-program", git = "https://github.com/jito-foundation/jito-solana.git", rev = "bdf2e1d844b6453819ce6d4a24bc15df830908a4" }
-#solana-zk-token-sdk = { package = "solana-zk-token-sdk", git = "https://github.com/jito-foundation/jito-solana.git", rev = "bdf2e1d844b6453819ce6d4a24bc15df830908a4" }
+solana-account-decoder = { package = "solana-account-decoder", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
+solana-account-decoder-client-types = { package = "solana-account-decoder-client-types", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
+solana-accounts-db = { package = "solana-accounts-db", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
+solana-banks-client = { package = "solana-banks-client", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
+solana-banks-interface = { package = "solana-banks-interface", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
+solana-banks-server = { package = "solana-banks-server", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
+#solana-bloom = { package = "solana-bloom", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
+#solana-bpf-loader-program = { package = "solana-bpf-loader-program", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
+solana-bucket-map = { package = "solana-bucket-map", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
+solana-builtins-default-costs = { package = "solana-builtins-default-costs", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
+solana-clap-utils = { package = "solana-clap-utils", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
+solana-cli-config = { package = "solana-cli-config", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
+solana-client = { package = "solana-client", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
+solana-compute-budget = { package = "solana-compute-budget", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
+solana-connection-cache = { package = "solana-connection-cache", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
+solana-core = { package = "solana-core", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
+solana-cost-model = { package = "solana-cost-model", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
+#solana-curve25519 = { package = "solana-curve25519", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
+solana-entry = { package = "solana-entry", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
+solana-faucet = { package = "solana-faucet", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
+#solana-fee = { package = "solana-fee", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
+solana-geyser-plugin-manager = { package = "solana-geyser-plugin-manager", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
+#solana-gossip = { package = "solana-gossip", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
+solana-lattice-hash = { package = "solana-lattice-hash", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
+solana-ledger = { package = "solana-ledger", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
+#solana-loader-v4-program = { package = "solana-loader-v4-program", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
+solana-measure = { package = "solana-measure", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
+solana-merkle-tree = { package = "solana-merkle-tree", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
+solana-metrics = { package = "solana-metrics", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
+#solana-net-utils = { package = "solana-net-utils", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
+solana-perf = { package = "solana-perf", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
+solana-poh = { package = "solana-poh", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
+#solana-poseidon = { package = "solana-poseidon", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
+#solana-program-runtime = { package = "solana-program-runtime", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
+solana-program-test = { package = "solana-program-test", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
+solana-pubsub-client = { package = "solana-pubsub-client", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
+solana-quic-client = { package = "solana-quic-client", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
+solana-rayon-threadlimit = { package = "solana-rayon-threadlimit", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
+solana-remote-wallet = { package = "solana-remote-wallet", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
+#solana-timings = { package = "solana-timings", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
+solana-unified-scheduler-logic = { package = "solana-unified-scheduler-logic", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
+solana-unified-scheduler-pool = { package = "solana-unified-scheduler-pool", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
+solana-rpc = { package = "solana-rpc", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
+solana-rpc-client = { package = "solana-rpc-client", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
+solana-rpc-client-api = { package = "solana-rpc-client-api", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
+solana-rpc-client-nonce-utils = { package = "solana-rpc-client-nonce-utils", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
+solana-runtime = { package = "solana-runtime", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
+#solana-runtime-transaction = { package = "solana-runtime-transaction", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
+solana-send-transaction-service = { package = "solana-send-transaction-service", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
+#solana-stake-program = { package = "solana-stake-program", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
+solana-storage-bigtable = { package = "solana-storage-bigtable", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
+solana-storage-proto = { package = "solana-storage-proto", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
+solana-streamer = { package = "solana-streamer", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
+#solana-svm = { package = "solana-svm", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
+#solana-svm-rent-collector = { package = "solana-svm-rent-collector", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
+#solana-svm-transaction = { package = "solana-svm-transaction", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
+solana-system-program = { package = "solana-system-program", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
+#solana-thin-client = { package = "solana-thin-client", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
+solana-tpu-client = { package = "solana-tpu-client", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
+solana-transaction-status = { package = "solana-transaction-status", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
+solana-transaction-status-client-types = { package = "solana-transaction-status-client-types", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
+#solana-transaction-metrics-tracker = { package = "solana-transaction-metrics-tracker", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
+#solana-turbine = { package = "solana-turbine", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
+#solana-type-overrides = { package = "solana-type-overrides", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
+solana-udp-client = { package = "solana-udp-client", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
+solana-version = { package = "solana-version", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
+solana-vote = { package = "solana-vote", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
+solana-vote-program = { package = "solana-vote-program", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
+#solana-wen-restart = { package = "solana-wen-restart", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
+solana-zk-elgamal-proof-program = { package = "solana-zk-elgamal-proof-program", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
+#solana-zk-sdk = { package = "solana-zk-sdk", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
+#solana-zk-token-proof-program = { package = "solana-zk-token-proof-program", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }
+#solana-zk-token-sdk = { package = "solana-zk-token-sdk", git = "https://github.com/jito-foundation/jito-solana.git", rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e" }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -30,7 +30,6 @@ jito-priority-fee-distribution-sdk = { workspace = true }
 jito-restaking-client = { workspace = true }
 jito-restaking-core = { workspace = true }
 jito-restaking-program = { workspace = true }
-jito-restaking-sdk = { workspace = true }
 jito-tip-distribution-sdk = { workspace = true }
 jito-tip-router-client = { workspace = true }
 jito-tip-router-core = { workspace = true }
@@ -38,23 +37,19 @@ jito-tip-router-program = { workspace = true }
 jito-vault-client = { workspace = true }
 jito-vault-core = { workspace = true }
 jito-vault-program = { workspace = true }
-jito-vault-sdk = { workspace = true }
 log = { workspace = true }
 num-derive = { workspace = true }
 num-traits = { workspace = true }
 solana-account-decoder = { workspace = true }
 solana-account-info = "3.0.0"
-solana-address-lookup-table-interface = { workspace = true }
 solana-cli-config = { workspace = true }
 solana-client = { workspace = true }
 solana-commitment-config = { workspace = true }
 solana-compute-budget-interface = { workspace = true }
-solana-genesis-config = { workspace = true }
 solana-metrics = { workspace = true }
 solana-program = { workspace = true }
 solana-rpc-client = { workspace = true }
 solana-sdk = { workspace = true }
-solana-stake-interface = { workspace = true }
 solana-system-interface = { workspace = true }
 solana-transaction-status = { workspace = true }
 spl-associated-token-account-interface = { workspace = true }

--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -1,5 +1,5 @@
 ##### Builder image
-FROM rust:1.80.0-slim-bullseye as builder
+FROM rust:1.96.1-slim-bullseye as builder
 
 RUN apt-get update && apt-get install -y \
     libudev-dev \

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -85,8 +85,8 @@ services:
 
   tip-router-operator-cli:
     build:
-      context: ./tip-router-operator-cli
-      dockerfile: Dockerfile
+      context: .
+      dockerfile: tip-router-operator-cli/Dockerfile
     container_name: tip-router-operator-cli
     environment:
       - RUST_LOG=${RUST_LOG:-info}

--- a/gcp_uploader/Cargo.toml
+++ b/gcp_uploader/Cargo.toml
@@ -8,13 +8,10 @@ description = "A tool to continuously monitor and upload epoch-related files to 
 [dependencies]
 anyhow = { workspace = true }
 clap = { workspace = true, features = ["derive", "env"] }
-cloud-storage.workspace = true
 env_logger = { workspace = true }
-futures-util = "0.3.31"
 hostname = "0.3"
 log = { workspace = true }
 regex = "1.10"
-serde_json = { workspace = true }
 solana-client = { workspace = true }
 solana-metrics = { workspace = true }
 tokio = { workspace = true, features = ["full"] }

--- a/integration_tests/Cargo.toml
+++ b/integration_tests/Cargo.toml
@@ -14,7 +14,6 @@ jito-tip-router-client = { workspace = true }
 log = "0.4.21"
 num-derive = { workspace = true }
 num-traits = { workspace = true }
-spl-pod = "0.7.1"
 
 [dev-dependencies]
 anyhow = { workspace = true }

--- a/meta_merkle_tree/Cargo.toml
+++ b/meta_merkle_tree/Cargo.toml
@@ -10,25 +10,13 @@ edition = { workspace = true }
 readme = { workspace = true }
 
 [dependencies]
-borsh = { workspace = true }
-bytemuck = { workspace = true }
 fast-math = { workspace = true }
 hex = { workspace = true }
-jito-bytemuck = { workspace = true }
-jito-jsm-core = { workspace = true }
-jito-restaking-core = { workspace = true }
-jito-restaking-sdk = { workspace = true }
 jito-vault-core = { workspace = true }
-jito-vault-sdk = { workspace = true }
 log = { workspace = true }
-rand = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-shank = { workspace = true }
 solana-program = { workspace = true }
-spl-associated-token-account-interface = { workspace = true }
-spl-math = { workspace = true }
-spl-token-interface = { workspace = true }
 thiserror = { workspace = true }
 wincode = { workspace = true }
 

--- a/priority_fee_distribution_sdk/Cargo.toml
+++ b/priority_fee_distribution_sdk/Cargo.toml
@@ -13,4 +13,3 @@ readme = { workspace = true }
 anyhow = { workspace = true }
 borsh = { workspace = true }
 solana-program = { workspace = true }
-solana-pubkey = { workspace = true }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 # note: this file doesn't play nicely with solana-verify build
 [toolchain]
 components = ["rustfmt", "rustc-dev", "clippy", "cargo"]
-channel = "1.95.0"
+channel = "1.96.1"

--- a/shank_cli/Cargo.toml
+++ b/shank_cli/Cargo.toml
@@ -11,9 +11,7 @@ readme = { workspace = true }
 
 [dependencies]
 anyhow = { workspace = true }
-clap = { workspace = true }
 env_logger = { workspace = true }
 envfile = { workspace = true }
 log = { workspace = true }
-shank = { workspace = true }
 shank_idl = { workspace = true }

--- a/tip-router-operator-cli/Cargo.toml
+++ b/tip-router-operator-cli/Cargo.toml
@@ -14,8 +14,6 @@ clap = { workspace = true }
 clap_old = { workspace = true }
 crossbeam-channel = "0.5.15"
 env_logger = { workspace = true }
-hex = "0.4"
-imbl = "7.0.0"
 itertools = "0.11"
 jito-bytemuck = { workspace = true }
 jito-priority-fee-distribution-sdk = { workspace = true }
@@ -30,7 +28,6 @@ jito-tip-router-core = { workspace = true }
 log = { workspace = true }
 meta-merkle-tree = { workspace = true }
 rand = { workspace = true }
-serde = { workspace = true }
 serde_json = { workspace = true }
 solana-account-decoder = { workspace = true }
 solana-accounts-db = { workspace = true }
@@ -53,12 +50,9 @@ solana-runtime = { workspace = true }
 solana-sdk = { workspace = true }
 solana-shred-version = { workspace = true }
 solana-stake-interface = { workspace = true }
-#solana-stake-program = { workspace = true }
-solana-streamer = { workspace = true }
 solana-system-interface = { workspace = true }
 solana-transaction-status = { workspace = true }
 solana-unified-scheduler-pool = { workspace = true }
-solana-vote = { workspace = true }
 spl-memo-interface = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }

--- a/tip-router-operator-cli/Cargo.toml
+++ b/tip-router-operator-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tip-router-operator-cli"
-version = "4.0.5"
+version = "4.2.0"
 edition = "2021"
 description = "CLI for Jito Tip Router"
 

--- a/tip-router-operator-cli/Cargo.toml
+++ b/tip-router-operator-cli/Cargo.toml
@@ -8,6 +8,7 @@ description = "CLI for Jito Tip Router"
 agave-snapshots = { workspace = true }
 anyhow = { workspace = true }
 base64 = { workspace = true }
+bincode = { workspace = true }
 borsh = { workspace = true }
 clap = { workspace = true }
 clap_old = { workspace = true }
@@ -50,6 +51,7 @@ solana-rpc-client = { workspace = true }
 solana-rpc-client-api = { workspace = true }
 solana-runtime = { workspace = true }
 solana-sdk = { workspace = true }
+solana-shred-version = { workspace = true }
 solana-stake-interface = { workspace = true }
 #solana-stake-program = { workspace = true }
 solana-streamer = { workspace = true }

--- a/tip-router-operator-cli/Dockerfile
+++ b/tip-router-operator-cli/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile
-FROM rust:1.85.0-slim-bookworm as builder
+FROM rust:1.96.1-slim-bookworm as builder
 
 # Install dependencies
 RUN apt-get update && apt-get install -y \

--- a/tip-router-operator-cli/src/ledger_utils.rs
+++ b/tip-router-operator-cli/src/ledger_utils.rs
@@ -493,7 +493,7 @@ pub fn get_bank_from_ledger(
 /// an error.
 pub fn get_bank_from_snapshot_at_slot(
     snapshot_slot: u64,
-    full_snapshots_path: &PathBuf,
+    full_snapshots_path: &Path,
     bank_snapshots_dir: &Path,
     account_paths: Vec<PathBuf>,
     ledger_path: &Path,
@@ -513,8 +513,8 @@ pub fn get_bank_from_snapshot_at_slot(
     // Enable the stake-program ProgramId index so stake-meta generation avoids a full scan.
     process_options.accounts_db_config.account_indexes = Some(stake_program_account_indexes());
     let snapshot_config = SnapshotConfig {
-        full_snapshot_archives_dir: full_snapshots_path.clone(),
-        incremental_snapshot_archives_dir: full_snapshots_path.clone(),
+        full_snapshot_archives_dir: full_snapshots_path.to_path_buf(),
+        incremental_snapshot_archives_dir: full_snapshots_path.to_path_buf(),
         bank_snapshots_dir: bank_snapshots_dir.to_path_buf(),
         use_registered_io_uring_buffers: resource_limits::check_memlock_limit_for_disk_io(
             TOTAL_IO_URING_BUFFERS_SIZE_LIMIT,

--- a/tip-router-operator-cli/src/load_and_process_ledger.rs
+++ b/tip-router-operator-cli/src/load_and_process_ledger.rs
@@ -41,9 +41,10 @@ use {
         },
         bank_forks::BankForks,
         snapshot_controller::SnapshotController,
-        snapshot_utils::{self, clean_orphaned_account_snapshot_dirs},
+        snapshot_utils,
     },
     solana_sdk::{clock::Slot, pubkey::Pubkey, transaction::VersionedTransaction},
+    solana_shred_version::compute_shred_version,
     solana_unified_scheduler_pool::DefaultSchedulerPool,
     std::{
         path::{Path, PathBuf},
@@ -66,9 +67,6 @@ const _PROCESS_SLOTS_HELP_STRING: &str =
 
 #[derive(Error, Debug)]
 pub enum LoadAndProcessLedgerError {
-    #[error("failed to clean orphaned account snapshot directories: {0}")]
-    CleanOrphanedAccountSnapshotDirectories(#[source] std::io::Error),
-
     #[error("failed to create all run and snapshot directories: {0}")]
     CreateAllAccountsRunAndSnapshotDirectories(#[source] std::io::Error),
 
@@ -352,8 +350,7 @@ pub fn load_and_process_ledger(
     snapshot_utils::purge_incomplete_bank_snapshots(&bank_snapshots_dir);
 
     info!("Cleaning contents of account snapshot paths: {account_snapshot_paths:?}");
-    clean_orphaned_account_snapshot_dirs(&bank_snapshots_dir, &account_snapshot_paths)
-        .map_err(LoadAndProcessLedgerError::CleanOrphanedAccountSnapshotDirectories)?;
+    snapshot_utils::wipe_account_snapshot_dirs(&account_paths);
 
     let geyser_plugin_active = arg_matches.is_present("geyser_plugin_config");
     let (accounts_update_notifier, transaction_notifier) = if geyser_plugin_active {
@@ -523,14 +520,19 @@ pub fn load_and_process_ledger(
         "cluster" => cluster,
     );
 
+    let shred_version = {
+        let root_bank = bank_forks.read().unwrap().root_bank();
+        compute_shred_version(&genesis_config.hash(), Some(&root_bank.hard_forks()))
+    };
     let result = blockstore_processor::process_blockstore_from_root(
         blockstore.as_ref(),
         &bank_forks,
+        shred_version,
         &leader_schedule_cache,
         &process_options,
         transaction_status_sender.as_ref(),
         None,
-        Some(&*snapshot_controller), // Maybe support this later, though
+        Some(&*snapshot_controller),
     )
     .map(|_| (bank_forks, starting_snapshot_hashes))
     .map_err(LoadAndProcessLedgerError::ProcessBlockstoreFromRoot);

--- a/tip-router-operator-cli/src/stake_meta_generator.rs
+++ b/tip-router-operator-cli/src/stake_meta_generator.rs
@@ -12,10 +12,7 @@ use solana_ledger::{
     blockstore_processor::BlockstoreProcessorError,
 };
 use solana_runtime::{bank::Bank, stakes::StakeAccount};
-use solana_sdk::{
-    account::{from_account, ReadableAccount},
-    pubkey::Pubkey,
-};
+use solana_sdk::{account::ReadableAccount, pubkey::Pubkey};
 use solana_stake_interface::stake_history::StakeHistory;
 use solana_stake_interface::sysvar::stake_history;
 use std::{
@@ -241,10 +238,10 @@ fn group_delegations_by_voter_pubkey(
         .filter(|(_stake_pubkey, stake_account)| {
             stake_account.delegation().stake(
                 bank.epoch(),
-                &from_account::<StakeHistory, _>(
-                    &bank.get_account(&stake_history::id()).expect(
-                        "stake history sysvar account should be present in the loaded bank",
-                    ),
+                &bincode::deserialize::<StakeHistory>(
+                    bank.get_account(&stake_history::id())
+                        .expect("stake history sysvar account should be present in the loaded bank")
+                        .data(),
                 )
                 .expect("stake history sysvar account should deserialize"),
                 bank.new_warmup_cooldown_rate_epoch(),
@@ -302,7 +299,7 @@ mod tests {
     #[allow(deprecated)]
     use solana_sdk::{
         self,
-        account::{from_account, AccountSharedData},
+        account::AccountSharedData,
         account_utils::StateMut,
         signature::{Keypair, Signer},
     };
@@ -484,8 +481,8 @@ mod tests {
                 if stake.delegation.stake
                     != stake.stake(
                         bank.epoch(),
-                        &from_account::<StakeHistory, _>(
-                            &bank.get_account(&stake_history::id()).unwrap(),
+                        &bincode::deserialize::<StakeHistory>(
+                            bank.get_account(&stake_history::id()).unwrap().data(),
                         )
                         .unwrap(),
                         bank.new_warmup_cooldown_rate_epoch(),

--- a/tip_payment_sdk/Cargo.toml
+++ b/tip_payment_sdk/Cargo.toml
@@ -13,4 +13,3 @@ readme = { workspace = true }
 anyhow = { workspace = true }
 borsh = { workspace = true }
 solana-program = { workspace = true }
-solana-pubkey = { workspace = true }

--- a/vendor/switchboard-on-demand/Cargo.toml
+++ b/vendor/switchboard-on-demand/Cargo.toml
@@ -215,7 +215,7 @@ package = "solana-account-decoder"
 git = "https://github.com/jito-foundation/jito-solana.git"
 optional = true
 package = "solana-account-decoder"
-rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
+tag = "v4.2.0-jito"
 
 [dependencies.solana-client-v2]
 version = ">=2,<3"
@@ -226,7 +226,7 @@ package = "solana-client"
 git = "https://github.com/jito-foundation/jito-solana.git"
 optional = true
 package = "solana-client"
-rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
+tag = "v4.2.0-jito"
 
 [dependencies.solana-program-v2]
 version = ">=2,<3"

--- a/vendor/switchboard-on-demand/Cargo.toml
+++ b/vendor/switchboard-on-demand/Cargo.toml
@@ -215,7 +215,7 @@ package = "solana-account-decoder"
 git = "https://github.com/jito-foundation/jito-solana.git"
 optional = true
 package = "solana-account-decoder"
-rev = "bdf2e1d844b6453819ce6d4a24bc15df830908a4"
+rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
 
 [dependencies.solana-client-v2]
 version = ">=2,<3"
@@ -226,7 +226,7 @@ package = "solana-client"
 git = "https://github.com/jito-foundation/jito-solana.git"
 optional = true
 package = "solana-client"
-rev = "bdf2e1d844b6453819ce6d4a24bc15df830908a4"
+rev = "2bc2cc03a4e581172fbb47d4f4d88fec9493911e"
 
 [dependencies.solana-program-v2]
 version = ">=2,<3"


### PR DESCRIPTION
Bumps to jito-solana-4.2.0 . Also ran `cargo machete` and got rid of a bunch of unused deps