### PR TITLE
Operator: Skip building ix if the node does not exist in merkle tree

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -30,4 +30,5 @@ ignore = [
     "RUSTSEC-2025-0134", # rustls-pemfile - unmaintained
     "RUSTSEC-2025-0141", # bincode - unmaintained
     "RUSTSEC-2026-0012", # keccak - unsound ARMv8 backend
+    "RUSTSEC-2026-0258"
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2881,7 +2881,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3362,9 +3362,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "839c0e8a181239723652be9062bb56ca5bf5f64011f73b623f6f4fc59086a228"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -3655,7 +3655,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2 0.4.15",
+ "h2 0.4.18",
  "http 1.4.2",
  "http-body 1.1.0",
  "httparse",
@@ -3756,7 +3756,7 @@ dependencies = [
  "libc",
  "percent-encoding 2.3.2",
  "pin-project-lite",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -4037,7 +4037,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi 0.5.2",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6191,7 +6191,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls 0.23.42",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -6231,9 +6231,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6835,7 +6835,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6914,7 +6914,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -13742,7 +13742,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -14213,7 +14213,7 @@ dependencies = [
  "axum",
  "base64 0.22.1",
  "bytes",
- "h2 0.4.15",
+ "h2 0.4.18",
  "http 1.4.2",
  "http-body 1.1.0",
  "http-body-util",
@@ -14827,7 +14827,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13905,7 +13905,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tip-router-operator-cli"
-version = "4.2.0"
+version = "4.2.1"
 dependencies = [
  "agave-snapshots",
  "anyhow",

--- a/tip-router-operator-cli/Cargo.toml
+++ b/tip-router-operator-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tip-router-operator-cli"
-version = "4.2.0"
+version = "4.2.1"
 edition = "2021"
 description = "CLI for Jito Tip Router"
 

--- a/tip-router-operator-cli/src/tip_router.rs
+++ b/tip-router-operator-cli/src/tip_router.rs
@@ -232,14 +232,17 @@ pub fn set_priority_fee_merkle_root_instructions(
     let instructions = tip_distribution_accounts
         .iter()
         .filter_map(|(key, tip_distribution_account)| {
-            let meta_merkle_node = meta_merkle_tree
-                .get_node(key)
-                .expect("Node exists in meta merkle");
+            let meta_merkle_node = if let Some(node) = meta_merkle_tree.get_node(key) {
+                node
+            } else {
+                error!("No node found for priority fee distribution account, maybe the account has zero tips? {:?}", key);
+                return None;
+            };
 
             let proof = if let Some(proof) = meta_merkle_node.proof {
                 proof
             } else {
-                error!("No proof found for tip distribution account {:?}", key);
+                error!("No proof found for priority fee distribution account {:?}", key);
                 return None;
             };
 


### PR DESCRIPTION
#### Problem

- Confirmed a panic in prod

```bash
2026-08-22 02:55:43.693 unk note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace 
2026-08-22 02:55:43.693 unk Node exists in meta merkle 
2026-08-22 02:55:43.693 unk thread 'tokio-rt-worker' (2608319) panicked at tip-router-operator-cli/src/tip_router.rs:237:18: 
```

#### Solution

- Skip building ix if the node does not exist in merkle tree like TDA

https://github.com/jito-foundation/jito-tip-router/blob/4caf4ddf4deaacd4648b05110a316abea0114a0c/tip-router-operator-cli/src/tip_router.rs#L130-L135
